### PR TITLE
don't mask pixel channels for void-extent blocks in the sRGB mode

### DIFF
--- a/Source/astc_decompress_symbolic.cpp
+++ b/Source/astc_decompress_symbolic.cpp
@@ -132,13 +132,10 @@ void decompress_symbolic_block(astc_decode_mode decode_mode,
 
 		if (scb->block_mode == -2)
 		{
-			// For sRGB decoding, we should return only the top 8 bits.
-			int mask = (decode_mode == DECODE_LDR_SRGB) ? 0xFF00 : 0xFFFF;
-
-			red = sf16_to_float(unorm16_to_sf16(scb->constant_color[0] & mask));
-			green = sf16_to_float(unorm16_to_sf16(scb->constant_color[1] & mask));
-			blue = sf16_to_float(unorm16_to_sf16(scb->constant_color[2] & mask));
-			alpha = sf16_to_float(unorm16_to_sf16(scb->constant_color[3] & mask));
+			red = sf16_to_float(unorm16_to_sf16(scb->constant_color[0]));
+			green = sf16_to_float(unorm16_to_sf16(scb->constant_color[1]));
+			blue = sf16_to_float(unorm16_to_sf16(scb->constant_color[2]));
+			alpha = sf16_to_float(unorm16_to_sf16(scb->constant_color[3]));
 			use_lns = 0;
 			use_nan = 0;
 		}


### PR DESCRIPTION
According to section 3.1 (Decode Procedure) of the specification,
a color read from a void-extent block must be immediately returned.
Pixel channels are only masked when returning an interpolated color
from a non-void-extent block in the sRGB mode.