### PR TITLE
use the top 8-bits more accurately for void-extent blocks in sRGB mode

### DIFF
--- a/Source/astc_decompress_symbolic.cpp
+++ b/Source/astc_decompress_symbolic.cpp
@@ -133,12 +133,18 @@ void decompress_symbolic_block(astc_decode_mode decode_mode,
 		if (scb->block_mode == -2)
 		{
 			// For sRGB decoding, we should return only the top 8 bits.
-			int mask = (decode_mode == DECODE_LDR_SRGB) ? 0xFF00 : 0xFFFF;
-
-			red = sf16_to_float(unorm16_to_sf16(scb->constant_color[0] & mask));
-			green = sf16_to_float(unorm16_to_sf16(scb->constant_color[1] & mask));
-			blue = sf16_to_float(unorm16_to_sf16(scb->constant_color[2] & mask));
-			alpha = sf16_to_float(unorm16_to_sf16(scb->constant_color[3] & mask));
+			if (decode_mode == DECODE_LDR_SRGB)
+			{
+				red   = (scb->constant_color[0] >> 8) / 255.0f;
+				green = (scb->constant_color[1] >> 8) / 255.0f;
+				blue  = (scb->constant_color[2] >> 8) / 255.0f;
+				alpha = (scb->constant_color[3] >> 8) / 255.0f;
+			} else {
+				red = sf16_to_float(unorm16_to_sf16(scb->constant_color[0]));
+				green = sf16_to_float(unorm16_to_sf16(scb->constant_color[1]));
+				blue = sf16_to_float(unorm16_to_sf16(scb->constant_color[2]));
+				alpha = sf16_to_float(unorm16_to_sf16(scb->constant_color[3]));
+			}
 			use_lns = 0;
 			use_nan = 0;
 		}


### PR DESCRIPTION
Section 2.5. Table 4, mentions that an 8-bit resolution is allowed for sRGB
mode. After masking the bottom 8 bits in the pixel channels of void-extent
blocks in sRGB mode, the resulting value is treated as a UNORM16. This causes
all input values above 128 (in the upper 8 bits) to return an output that
is 1 less than expected. For example, 129 in the top 8 bits returns 128.
This patch uses the top 8 bits to generate a float that will give the
expected output when writing out to disk.