### PR TITLE
Fix possible out-of-bounds array access

### DIFF
--- a/Source/astc_pick_best_endpoint_format.cpp
+++ b/Source/astc_pick_best_endpoint_format.cpp
@@ -695,7 +695,7 @@ static void four_partitions_find_best_combination_for_bitcount(float combined_be
 															   int bits_available, int *best_quantization_level, int *best_quantization_level_mod, int *best_formats, float *error_of_best_combination)
 {
 	int i;
-	int best_integer_count = -4;
+	int best_integer_count = 0;
 	float best_integer_count_error = 1e20f;
 	int integer_count;
 


### PR DESCRIPTION
Changed implementation of four_partitions_find_best_combination_for_bitcount to match two_partitions_find_best_combination_for_bitcount and three_partitions_find_best_combination_for_bitcount.
We hit that case in Unity.