### PR TITLE
Use <cmath> to get C++ overloaded math functions

### DIFF
--- a/Source/astc_averages_and_directions.cpp
+++ b/Source/astc_averages_and_directions.cpp
@@ -16,7 +16,7 @@
 
 #include "astc_codec_internals.h"
 
-#include <math.h>
+#include <cmath>
 #include "mathlib.h"
 
 #ifdef DEBUG_CAPTURE_NAN

--- a/Source/astc_color_quantize.cpp
+++ b/Source/astc_color_quantize.cpp
@@ -17,7 +17,7 @@
 
 #include "astc_codec_internals.h"
 #include "softfloat.h"
-#include <math.h>
+#include <cmath>
 
 #ifdef DEBUG_PRINT_DIAGNOSTICS
 	#include <stdio.h>

--- a/Source/astc_compress_symbolic.cpp
+++ b/Source/astc_compress_symbolic.cpp
@@ -16,7 +16,7 @@
 #include "astc_codec_internals.h"
 
 #include "softfloat.h"
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <stdio.h>
 

--- a/Source/astc_compute_variance.cpp
+++ b/Source/astc_compute_variance.cpp
@@ -19,7 +19,7 @@
 
 #include "astc_codec_internals.h"
 
-#include <math.h>
+#include <cmath>
 #include "mathlib.h"
 #include "softfloat.h"
 

--- a/Source/astc_decompress_symbolic.cpp
+++ b/Source/astc_decompress_symbolic.cpp
@@ -14,7 +14,7 @@
  */
 /*----------------------------------------------------------------------------*/
 
-#include <math.h>
+#include <cmath>
 
 #include "astc_codec_internals.h"
 

--- a/Source/astc_encoding_choice_error.cpp
+++ b/Source/astc_encoding_choice_error.cpp
@@ -41,7 +41,7 @@
 
 #include "astc_codec_internals.h"
 
-#include <math.h>
+#include <cmath>
 
 #ifdef DEBUG_PRINT_DIAGNOSTICS
 	#include <stdio.h>

--- a/Source/astc_find_best_partitioning.cpp
+++ b/Source/astc_find_best_partitioning.cpp
@@ -46,7 +46,7 @@
  * each element in the table is an uint8_t indicating partition index (0, 1, 2 or 3)
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "astc_codec_internals.h"
 

--- a/Source/astc_ideal_endpoints_and_weights.cpp
+++ b/Source/astc_ideal_endpoints_and_weights.cpp
@@ -13,7 +13,7 @@
  */
 /*----------------------------------------------------------------------------*/
 
-#include <math.h>
+#include <cmath>
 
 #include "astc_codec_internals.h"
 

--- a/Source/astc_image_load_store.cpp
+++ b/Source/astc_image_load_store.cpp
@@ -13,7 +13,7 @@
  */
 /*----------------------------------------------------------------------------*/
 
-#include <math.h>
+#include <cmath>
 
 #include "astc_codec_internals.h"
 
@@ -1272,7 +1272,7 @@ astc_codec_image *astc_codec_load_image(const char *input_filename, int padding,
 
 	// check the ending of the input filename
 	int load_fileformat = LOAD_STB_IMAGE;
-	int filename_len = strlen(input_filename);
+	size_t filename_len = strlen(input_filename);
 
 	const char *eptr = input_filename + filename_len - 5;
 	if (eptr > input_filename && (strcmp(eptr, ".htga") == 0 || strcmp(eptr, ".HTGA") == 0))
@@ -1346,7 +1346,7 @@ int get_output_filename_enforced_bitness(const char *output_filename)
 	if (output_filename == NULL)
 		return -1;
 
-	int filename_len = strlen(output_filename);
+	size_t filename_len = strlen(output_filename);
 	const char *eptr = output_filename + filename_len - 5;
 
 	if (eptr > output_filename && (strcmp(eptr, ".htga") == 0 || strcmp(eptr, ".HTGA") == 0))
@@ -1380,7 +1380,7 @@ int astc_codec_store_image(const astc_codec_image * output_image, const char *ou
 	#define STORE_DDS 3
 	#define STORE_EXR 4
 
-	int filename_len = strlen(output_filename);
+	size_t filename_len = strlen(output_filename);
 
 	int store_fileformat = STORE_TGA;
 	const char *eptr = output_filename + filename_len - 5;

--- a/Source/astc_pick_best_endpoint_format.cpp
+++ b/Source/astc_pick_best_endpoint_format.cpp
@@ -18,7 +18,7 @@
 	#include <stdio.h>
 #endif
 
-#include <math.h>
+#include <cmath>
 
 // clamp an input value to [0,1]; Nan is turned into 0.
 static inline float clamp01(float val)

--- a/Source/astc_toplevel.cpp
+++ b/Source/astc_toplevel.cpp
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 
 #ifndef WIN32
 	#include <sys/time.h>

--- a/Source/astc_weight_align.cpp
+++ b/Source/astc_weight_align.cpp
@@ -37,7 +37,7 @@
  */
 /*----------------------------------------------------------------------------*/
 
-#include <math.h>
+#include <cmath>
 #include "astc_codec_internals.h"
 
 #ifdef DEBUG_PRINT_DIAGNOSTICS

--- a/Source/mathlib.cpp
+++ b/Source/mathlib.cpp
@@ -16,7 +16,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include "mathlib.h"
 
 /**************************


### PR DESCRIPTION
This avoids many double to float cast precision warnings which we get using the C versions of e.g. min/max/sqrt from <math.h>.

With this set of changes x86 and x64 builds are warning free on VS2017.