### PR TITLE
Update documentation

### DIFF
--- a/Docs/Building.md
+++ b/Docs/Building.md
@@ -1,0 +1,35 @@
+# Building ASTC Encoder
+
+This page provides instructions for building `astcenc` from the sources in
+this repository.
+
+## Windows
+
+Builds for Windows use Visual Studio 2017, using the solution file located in
+the `Source/win32-2017/astcenc/` directory. To compile a release build from
+the command line, it is possible to use the `msbuild` utility:
+
+```
+msbuild .\Source\win32-2017\astcenc\astcenc.sln /p:Configuration=Release /p:Platform=x64
+```
+
+## macOS
+
+Builds for macOS use GCC and Make, and are tested with GCC 4.6 and GNU Make
+3.82.
+
+```
+cd Source
+make
+```
+
+## Linux
+
+Builds for Linux use GCC and Make, and are tested with GCC 4.6 and GNU Make
+3.82.
+
+```
+cd Source
+make
+```
+

--- a/Docs/Encoding.md
+++ b/Docs/Encoding.md
@@ -151,7 +151,7 @@ Z component of the normal can be reconstructed in shader code based on the
 knowledge that the vector is unit length.
 
 To encode this we therefore want to store two input channels and should
-therefore using `rrrg` coding swizzle, and the `.ga` sampling swizzle. The
+therefore use the `rrrg` coding swizzle, and the `.ga` sampling swizzle. The
 OpenGL ES shader code for reconstruction of the Z value is:
 
     vec3 normal;

--- a/Docs/Encoding.md
+++ b/Docs/Encoding.md
@@ -1,0 +1,193 @@
+# Effective ASTC Encoding
+
+Most traditional texture compression schemes encode a single color format at
+single bitrate, so there are relatively few configuration options available to
+content creators beyond selecting which compressed format to use.
+
+ASTC on the other hand is an extremely flexible container format which can
+compress multiple color formats at multiple bit rates. Inevitably this
+flexibility gives rise to questions about how to best use ASTC to encode a
+specific color format, or what the equivalent settings are to get a close
+match to an existing legacy compression format.
+
+This page aims to give some guidelines, but note that they are only guidelines
+and are not exhaustive so please deviate from them as needed.
+
+## Traditional format reference
+
+The most commonly used traditional compressed formats, their color format, and
+their compressed bitrate are shown in the table below.
+
+| Name     | Color Format | Bits/Pixel | Notes            |
+| -------- | ------------ | ---------- | ---------------- |
+| BC1      | RGB+A        | 4          | RGB565 + 1-bit A |
+| BC3      | RGB+A        | 8          | BC1 RGB + BC4 A  |
+| BC3nm    | G+R          | 8          | BC1 G   + BC4 R  |
+| BC4      | R            | 4          | L8               |
+| BC5      | R+G          | 8          | BC1 R + BC1 G    |
+| BC6      | RGB (HDR)    | 8          |                  |
+| BC7      | RGB / RGBA   | 8          |                  |
+| EAC_R11  | R            | 4          | R11              |
+| EAC_RG11 | RG           | 8          | RG11             |
+| ETC1     | RGB          | 4          | RGB565           |
+| ETC2     | RGB+A        | 4          | RGB565 + 1-bit A |
+| ETC2+EAC | RGB+A        | 8          | RGB565 + EAC A   |
+| PVRTC    | RGBA         | 2 or 4     |                  |
+
+**Note:** BC2 (RGB+A) is not included in the table because it's rarely used in
+practice due to poor quality alpha encoding; BC3 is nearly always used instead.
+
+**Note** Color representations shown with a `+` symbol indicate non-correlated
+compression groups; e.g. an `RGB + A` format compresses `RGB` and `A`
+independently and does not assume the two signals are correlated. This can be
+a strength (it improves quality when compressing non-correlated signals), but
+also a weakness (it reduces quality when compressing correlated signals).
+
+# ASTC Format Mapping
+
+The main question which arises with the mapping of another format into ASTC is
+how to handle cases where the input isn't a 4 channel RGBA input. ASTC is a
+container format which always decompresses in to a 4 channel `RGBA` result, so
+it is notionally always an RGBA format. However, the internal compressed
+representation is very flexible and can store 1-4 channels as needed on a
+per-block basis.
+
+To get the best quality for a given bitrate, or the lowest bitrate for a given
+quality, it is important that as few channels as possible are stored in the
+internal representation to avoid wasting coding space on channels which are
+not actually present.
+
+Specific optimizations in the coding scheme exist for:
+
+* Encoding the RGB channels as a single luminance channel, so only a single
+  value needs to be stored in the coding instead of three.
+* Encoding the A channel as a constant 1.0 value, so the coding doesn't
+  actually need to store a per-pixel alpha value at all.
+
+... so mapping your inputs in to the compressor to hit these paths is really
+important if you want to get the best output quality for your chosen bitrate.
+
+## Encoding 1-4 channel data
+
+The table below shows the recommended channel usage for data with different
+numbers of color channels present in the data.
+
+The coding swizzle should be applied when compressing an image. This can be
+handled by the compressor when reading an uncompressed input image by
+specifying the swizzle using the `-esw` command line option.
+
+The sampling swizzle is what your should use in your shader programs to read
+the data from the compressed texture, assuming no additional API-level channel
+swizzling is specified by the application.
+
+| Input Channels |  ASTC Endpoint | Coding Swizzle | Sampling Swizzle   |
+| -------------- |  ------------- | -------------- | ------------------ |
+| 1              |  L + 1         | `rrr1`         | `.g` <sup>1</sup>  |
+| 2              |  L + A         | `rrrg`         | `.ga` <sup>1</sup> |
+| 3              |  RGB + 1       | `rgb1`         | `.rgb`             |
+| 4              |  RGB + A       | `rgba`         | `.rgba`            |
+
+**1:** Sampling from `g` is preferred to sampling from `r` because it
+allows a single shader to be compatible with ASTC, BC1, or ETC formats. BC1 and
+ETC1 store endpoints as RGB 565, so the `g` channel will have higher precision.
+For ASTC it doesn't actually make any difference; the same single channel
+luminance will be returned for all three of the `.rgb` channels.
+
+## Equivalence with other formats
+
+Based on these channel encoding requirements we can now derive the the ASTC
+coding equivalents for most of the other texture compression formats in common
+use today.
+
+| Formant  | ASTC Coding Swizzle  | ASTC Sampling Swizzle | Notes            |
+| -------- | -------------------- | --------------------- | ---------------- |
+| BC1      | `rgba` <sup>1</sup>  | `.rgba`               |                  |
+| BC3      | `rgba`               | `.rgba`               |                  |
+| BC3nm    | `gggr`               | `.ag`                 |                  |
+| BC4      | `rrr1`               | `.r1`                 |                  |
+| BC5      | `rrrg`               | `.ra` <sup>2</sup>    |                  |
+| BC6      | `rgb1`               | `.rgb`                | HDR profile only |
+| BC7      | `rgba`               | `.rgba`               |                  |
+| EAC_R11  | `rrr1`               | `.r`                  |                  |
+| EAC_RG11 | `rrrg`               | `.ra` <sup>2</sup>    |                  |
+| ETC1     | `rgba`               | `.rgba`               |                  |
+| ETC2     | `rgba` <sup>1</sup>  | `.rgb`                |                  |
+| ETC2+EAC | `rgba`               | `.rgba`               |                  |
+| ETC2+EAC | `rgba`               | `.rgba`               |                  |
+
+**1:** ASTC has no direct equivalent of the 1-bit punch-through alpha encoding
+supported by BC1 or ETC2; if alpha is present it will be a full alpha channel.
+
+**2:** ASTC relies on using the L+A color endpoint type for coding efficiency
+for two channel data. It therefore has no direct equivalent of a two-plane
+format sampled though the `.rg` channels such as BC5 or EAC_RG11. This can
+be emulated by setting texture channel swizzles in the runtime API - e.g. via
+`glTexParameteri()` for OpenGL ES - although it has been noted that API
+controlled swizzles are not available in WebGL.
+
+# Other Considerations
+
+This section outlines some of the other things to consider when encoding
+textures using ASTC.
+
+## Encoding non-correlated channels
+
+ASTC can optionally assign any single color channel to a separate
+non-correlated partition to the other three channels, chosen on a
+block-by-block basis. In the general case there is no need for non-correlated
+data to be in a specific channel in the data set; the compressor will
+assign the non-correlated channel on demand if it is needed.
+
+The one exception to this is for encoding textures which have HDR RGB data,
+but an LDR alpha channel, which will be the usual format to use for data where
+the alpha is an actual transparency value. In this case the single LDR channel
+must be stored in the alpha channel location in the coding swizzle.
+
+## Encoding normal maps
+
+The best way to store normal maps using ASTC is similar to the scheme used by
+BC5; store the X and Y components of a unit-length tangent space normal. The
+Z component of the normal can be reconstructed in shader code based on the
+knowledge that the vector is unit length.
+
+To encode this we therefore want to store two input channels and should
+therefore using `rrrg` coding swizzle, and the `.ga` sampling swizzle. The
+OpenGL ES shader code for reconstruction of the Z value is:
+
+    vec3 normal;
+    normal.xy = texture(...).ga;
+    normal.z = sqrt(1 - dot(normal.xy, normal.xy));
+
+In addition to this it is useful to use the `-normal_psnr` command line
+option, which switches the compressor to optimize for angular error in the
+resulting vector rather than color error in the data.
+
+## Encoding sRGB data
+
+The ASTC LDR profile can encode sRGB encoded color, which is a more efficient
+use of bits than storing linear encoded color, as the gamma corrected value
+distribution more closely matches human perception of luminance.
+
+For color data it is nearly always a perceptual quality win to use sRGB input
+source textures that are then compressed using the ASTC sRGB compression mode
+(compress using the `-cs` command line option rather than the `-c` command
+line). Note that sRGB gamma correction is only applied to the RGB channels
+during decode; the alpha channel is always treated as linear encoded data.
+
+*Important:* The uncompressed input texture provided on the command line must
+be stored in the sRGB color space for `-cs` to function correctly.
+
+## Encoding HDR data
+
+HDR data can be encoded just like LDR data, but with some caveats around
+handling the alpha channel.
+
+For many use cases the alpha channel is an actual alpha opacity channel and is
+used for storing an LDR opacity value. For these cases use the `-hdr`
+compressor option which will treat the RGB channels as HDR, but the A channel
+as LDR.
+
+For other use cases the alpha channel is simply a fourth data channel which is
+also storing an HDR value. For these cases use the `-hdra` compressor option
+which will treat all channels as HDR data.
+

--- a/Docs/Encoding.md
+++ b/Docs/Encoding.md
@@ -131,14 +131,19 @@ textures using ASTC.
 
 ## Encoding non-correlated channels
 
-ASTC can optionally assign any single color channel to a separate
-non-correlated partition to the other three channels, chosen on a
-block-by-block basis. In the general case there is no need for non-correlated
-data to be in a specific channel in the data set; the compressor will
-assign the non-correlated channel on demand if it is needed.
+Most other texture compression formats have a static channel assignment in
+terms of the expected data correlation. For example, ETC2+EAC assumes that RGB
+are always correlated and that alpha is non-correlated. ASTC can automatically
+encode data as either fully correlated across all 4 channels, or with any one
+channel assigned to a separate non correlated partition to the other three.
 
-It is worth noting that the alpha channel is treated differently to the RGB
-color channels in some circumstances:
+The non-correlated channel can be changed on a block-by-block basis, so the
+compressor can dynamically adjust the coding based on the data present in the
+image. This means that there is no need for non-correlated data to be stored
+in a specific channel in the input image.
+
+It is however worth noting that the alpha channel is treated differently to
+the RGB color channels in some circumstances:
 
 * When coding for sRGB the alpha channel will always be stored in linear space.
 * When coding for HDR the alpha channel can optionally be kept as LDR data.

--- a/Docs/Encoding.md
+++ b/Docs/Encoding.md
@@ -185,7 +185,7 @@ HDR data can be encoded just like LDR data, but with some caveats around
 handling the alpha channel.
 
 For many use cases the alpha channel is an actual alpha opacity channel and is
-therefore used for storing an LDR value between 0 and 1 . For these cases use
+therefore used for storing an LDR value between 0 and 1. For these cases use
 the `-hdr` compressor option which will treat the RGB channels as HDR, but the
 A channel as LDR.
 

--- a/Docs/Encoding.md
+++ b/Docs/Encoding.md
@@ -1,21 +1,21 @@
 # Effective ASTC Encoding
 
-Most traditional texture compression schemes encode a single color format at
-single bitrate, so there are relatively few configuration options available to
+Most texture compression schemes encode a single color format at single
+bitrate, so there are relatively few configuration options available to
 content creators beyond selecting which compressed format to use.
 
 ASTC on the other hand is an extremely flexible container format which can
 compress multiple color formats at multiple bit rates. Inevitably this
 flexibility gives rise to questions about how to best use ASTC to encode a
 specific color format, or what the equivalent settings are to get a close
-match to an existing legacy compression format.
+match to another compression format.
 
 This page aims to give some guidelines, but note that they are only guidelines
 and are not exhaustive so please deviate from them as needed.
 
 ## Traditional format reference
 
-The most commonly used traditional compressed formats, their color format, and
+The most commonly used non-ASTC compressed formats, their color format, and
 their compressed bitrate are shown in the table below.
 
 | Name     | Color Format | Bits/Pixel | Notes            |
@@ -45,27 +45,26 @@ also a weakness (it reduces quality when compressing correlated signals).
 
 # ASTC Format Mapping
 
-The main question which arises with the mapping of another format into ASTC is
-how to handle cases where the input isn't a 4 channel RGBA input. ASTC is a
-container format which always decompresses in to a 4 channel `RGBA` result, so
-it is notionally always an RGBA format. However, the internal compressed
-representation is very flexible and can store 1-4 channels as needed on a
-per-block basis.
+The main question which arises with the mapping of another format on to ASTC
+is how to handle cases where the input isn't a 4 channel RGBA input. ASTC is a
+container format which always decompresses in to a 4 channel RGBA result.
+However, the internal compressed representation is very flexible and can store
+1-4 channels as needed on a per-block basis.
 
 To get the best quality for a given bitrate, or the lowest bitrate for a given
 quality, it is important that as few channels as possible are stored in the
-internal representation to avoid wasting coding space on channels which are
-not actually present.
+internal representation to avoid wasting coding space.
 
-Specific optimizations in the coding scheme exist for:
+Specific optimizations in the ASTC coding scheme exist for:
 
 * Encoding the RGB channels as a single luminance channel, so only a single
   value needs to be stored in the coding instead of three.
 * Encoding the A channel as a constant 1.0 value, so the coding doesn't
   actually need to store a per-pixel alpha value at all.
 
-... so mapping your inputs in to the compressor to hit these paths is really
-important if you want to get the best output quality for your chosen bitrate.
+... so mapping your inputs given to the compressor to hit these paths is
+really important if you want to get the best output quality for your chosen
+bitrate.
 
 ## Encoding 1-4 channel data
 
@@ -87,11 +86,11 @@ swizzling is specified by the application.
 | 3              |  RGB + 1       | `rgb1`         | `.rgb`             |
 | 4              |  RGB + A       | `rgba`         | `.rgba`            |
 
-**1:** Sampling from `g` is preferred to sampling from `r` because it
-allows a single shader to be compatible with ASTC, BC1, or ETC formats. BC1 and
-ETC1 store endpoints as RGB 565, so the `g` channel will have higher precision.
-For ASTC it doesn't actually make any difference; the same single channel
-luminance will be returned for all three of the `.rgb` channels.
+**1:** Sampling from `g` is preferred to sampling from `r` because it allows a
+single shader to be compatible with ASTC, BC1, or ETC formats. BC1 and ETC1
+store color endpoints as RGB565 data, so the `g` channel will have higher
+precision. For ASTC it doesn't actually make any difference; the same single
+channel luminance will be returned for all three of the `.rgb` channels.
 
 ## Equivalence with other formats
 
@@ -99,23 +98,23 @@ Based on these channel encoding requirements we can now derive the the ASTC
 coding equivalents for most of the other texture compression formats in common
 use today.
 
-| Formant  | ASTC Coding Swizzle  | ASTC Sampling Swizzle | Notes            |
-| -------- | -------------------- | --------------------- | ---------------- |
-| BC1      | `rgba` <sup>1</sup>  | `.rgba`               |                  |
-| BC3      | `rgba`               | `.rgba`               |                  |
-| BC3nm    | `gggr`               | `.ag`                 |                  |
-| BC4      | `rrr1`               | `.r1`                 |                  |
-| BC5      | `rrrg`               | `.ra` <sup>2</sup>    |                  |
-| BC6      | `rgb1`               | `.rgb`                | HDR profile only |
-| BC7      | `rgba`               | `.rgba`               |                  |
-| EAC_R11  | `rrr1`               | `.r`                  |                  |
-| EAC_RG11 | `rrrg`               | `.ra` <sup>2</sup>    |                  |
-| ETC1     | `rgba`               | `.rgba`               |                  |
-| ETC2     | `rgba` <sup>1</sup>  | `.rgb`                |                  |
-| ETC2+EAC | `rgba`               | `.rgba`               |                  |
-| ETC2+EAC | `rgba`               | `.rgba`               |                  |
+| Formant  | ASTC Coding Swizzle | ASTC Sampling Swizzle | Notes            |
+| -------- | ------------------- | --------------------- | ---------------- |
+| BC1      | `rgba` <sup>1</sup> | `.rgba`               |                  |
+| BC3      | `rgba`              | `.rgba`               |                  |
+| BC3nm    | `gggr`              | `.ag`                 |                  |
+| BC4      | `rrr1`              | `.r1`                 |                  |
+| BC5      | `rrrg`              | `.ra` <sup>2</sup>    |                  |
+| BC6      | `rgb1`              | `.rgb`                | HDR profile only |
+| BC7      | `rgba`              | `.rgba`               |                  |
+| EAC_R11  | `rrr1`              | `.r`                  |                  |
+| EAC_RG11 | `rrrg`              | `.ra` <sup>2</sup>    |                  |
+| ETC1     | `rgba`              | `.rgba`               |                  |
+| ETC2     | `rgba` <sup>1</sup> | `.rgb`                |                  |
+| ETC2+EAC | `rgba`              | `.rgba`               |                  |
+| ETC2+EAC | `rgba`              | `.rgba`               |                  |
 
-**1:** ASTC has no direct equivalent of the 1-bit punch-through alpha encoding
+**1:** ASTC has no equivalent of the 1-bit punch-through alpha encoding
 supported by BC1 or ETC2; if alpha is present it will be a full alpha channel.
 
 **2:** ASTC relies on using the L+A color endpoint type for coding efficiency
@@ -138,10 +137,11 @@ block-by-block basis. In the general case there is no need for non-correlated
 data to be in a specific channel in the data set; the compressor will
 assign the non-correlated channel on demand if it is needed.
 
-The one exception to this is for encoding textures which have HDR RGB data,
-but an LDR alpha channel, which will be the usual format to use for data where
-the alpha is an actual transparency value. In this case the single LDR channel
-must be stored in the alpha channel location in the coding swizzle.
+It is worth noting that the alpha channel is treated differently to the RGB
+color channels in some circumstances:
+
+* When coding for sRGB the alpha channel will always be stored in linear space.
+* When coding for HDR the alpha channel can optionally be kept as LDR data.
 
 ## Encoding normal maps
 
@@ -160,19 +160,21 @@ OpenGL ES shader code for reconstruction of the Z value is:
 
 In addition to this it is useful to use the `-normal_psnr` command line
 option, which switches the compressor to optimize for angular error in the
-resulting vector rather than color error in the data.
+resulting vector rather than for absolute color error in the data.
 
 ## Encoding sRGB data
 
-The ASTC LDR profile can encode sRGB encoded color, which is a more efficient
-use of bits than storing linear encoded color, as the gamma corrected value
-distribution more closely matches human perception of luminance.
+The ASTC LDR profile can compress sRGB encoded color, which is a more
+efficient use of bits than storing linear encoded color because the gamma
+corrected value distribution more closely matches human perception of
+luminance.
 
 For color data it is nearly always a perceptual quality win to use sRGB input
 source textures that are then compressed using the ASTC sRGB compression mode
 (compress using the `-cs` command line option rather than the `-c` command
-line). Note that sRGB gamma correction is only applied to the RGB channels
-during decode; the alpha channel is always treated as linear encoded data.
+line option). Note that sRGB gamma correction is only applied to the RGB
+channels during decode; the alpha channel is always treated as linear encoded
+data.
 
 *Important:* The uncompressed input texture provided on the command line must
 be stored in the sRGB color space for `-cs` to function correctly.
@@ -183,11 +185,10 @@ HDR data can be encoded just like LDR data, but with some caveats around
 handling the alpha channel.
 
 For many use cases the alpha channel is an actual alpha opacity channel and is
-used for storing an LDR opacity value. For these cases use the `-hdr`
-compressor option which will treat the RGB channels as HDR, but the A channel
-as LDR.
+therefore used for storing an LDR value between 0 and 1 . For these cases use
+the `-hdr` compressor option which will treat the RGB channels as HDR, but the
+A channel as LDR.
 
 For other use cases the alpha channel is simply a fourth data channel which is
 also storing an HDR value. For these cases use the `-hdra` compressor option
 which will treat all channels as HDR data.
-

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-END USER LICENCE AGREEMENT FOR THE MALI ASTC SPECIFICATION AND SOFTWARE CODEC,
-VERSION: 1.3
+# END USER LICENCE AGREEMENT FOR THE MALI ASTC SPECIFICATION AND SOFTWARE CODEC
+
+**VERSION: 1.3**
 
 THIS END USER LICENCE AGREEMENT ("LICENCE") IS A LEGAL AGREEMENT BETWEEN YOU
 (EITHER A SINGLE INDIVIDUAL, OR SINGLE LEGAL ENTITY) AND ARM LIMITED ("ARM")
@@ -12,19 +13,20 @@ TERMS OF THIS LICENCE.
 IF YOU DO NOT AGREE TO THE TERMS OF THIS LICENCE, ARM IS UNWILLING TO LICENSE
 THE SOFTWARE TO YOU AND YOU MAY NOT INSTALL, USE OR COPY THE SOFTWARE.
 
-1.  DEFINITIONS.
+# 1. DEFINITIONS
 
 "Authorised Purpose" means the use of the Software solely to develop products
 and tools which implement the Khronos ASTC specification to;
-(i) compress texture images into ASTC format ("Compression Results"); 
-(ii) distribute such Compression Results to third parties; and 
-(iii) decompress texture images stored in ASTC format.
+
+* (i) compress texture images into ASTC format ("Compression Results");
+* (ii) distribute such Compression Results to third parties; and
+* (iii) decompress texture images stored in ASTC format.
 
 "Software" means the source code and Software binaries accompanying this
 Licence, and any printed, electronic or online documentation supplied with it,
 in all cases relating to the MALI ASTC SPECIFICATION AND SOFTWARE CODEC.
 
-2. LICENCE GRANT.
+# 2. LICENCE GRANT
 
 ARM hereby grants to you, subject to the terms and conditions of this Licence,
 a nonexclusive, nontransferable, free of charge, royalty free, worldwide
@@ -39,7 +41,7 @@ programming interface specification issued by The Khronos Group Inc.
 ("Khronos"), provided that you have licences to develop such products
 under the relevant Khronos agreements.
 
- 3. RESTRICTIONS ON USE OF THE SOFTWARE.
+# 3. RESTRICTIONS ON USE OF THE SOFTWARE
 
 RESTRICTIONS ON TRANSFER OF LICENSED RIGHTS: The rights granted to you under
 this Licence may not be assigned by you to any third party without the prior
@@ -60,12 +62,12 @@ trademarks to market Compression Results. If you distribute the Software to a
 third party, you agree to include a copy of this Licence with such
 distribution.
 
-4. NO SUPPORT.
+# 4. NO SUPPORT
 
 ARM has no obligation to support or to continue providing or updating any of
 the Software.
 
-5. NO WARRANTIES.
+# 5. NO WARRANTIES
 
 YOU AGREE THAT THE SOFTWARE IS LICENSED "AS IS", AND THAT ARM EXPRESSLY
 DISCLAIMS ALL REPRESENTATIONS, WARRANTIES, CONDITIONS OR OTHER TERMS, EXPRESS,
@@ -74,7 +76,7 @@ ASSUME ALL LIABILITIES AND RISKS, FOR USE OR OPERATION OF ANY APPLICATION
 PROGRAMS YOU CREATE WITH THE SOFTWARE, AND YOU ASSUME THE ENTIRE COST OF ALL
 NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-6. LIMITATION OF LIABILITY.
+# 6. LIMITATION OF LIABILITY
 
 TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL ARM BE
 LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
@@ -94,14 +96,14 @@ IN CONTRACT TORT OR OTHERWISE UNDER OR IN CONNECTION WITH THE SUBJECT MATTER
 OF THIS LICENCE SHALL NOT EXCEED THE GREATER OF THE TOTAL OF SUMS PAID BY YOU
 TO ARM (IF ANY) FOR THIS LICENCE AND US$5.00.
 
-7. U.S. GOVERNMENT END USERS.
+# 7. U.S. GOVERNMENT END USERS
 
 US Government Restrictions: Use, duplication, reproduction, release,
 modification, disclosure or transfer of this commercial product and
 accompanying documentation is restricted in accordance with the terms
 of this Licence.
 
-8. TERM AND TERMINATION.
+# 8. TERM AND TERMINATION
 
 This Licence shall remain in force until terminated by you or by ARM. Without
 prejudice to any of its other rights if you are in breach of any of the terms
@@ -113,7 +115,7 @@ Software and destroy all copies of the Software in your possession together
 with all documentation and related materials. The provisions of Clauses 1, 3,
 4, 5, 6, 7, 8 and 9  shall survive termination of this Licence.
 
-9. GENERAL.
+# 9. GENERAL
 
 This Licence is governed by English Law. Except where ARM agrees otherwise in
 a written contract signed by you and ARM, this is the only agreement between
@@ -132,6 +134,6 @@ and other countries ("Export Laws") to assure that the Software is not;
 (1) exported, directly or indirectly, in violation of Export Laws, either to
 any countries that are subject to U.S.A. export restrictions or to any end
 user who has been prohibited from participating in the U.S.A. export
-transactions by any federal agency of the U.S.A. government; or 
+transactions by any federal agency of the U.S.A. government; or
 (2) intended to be used for any purpose prohibited by Export Laws, including,
 without limitation, nuclear, chemical, or biological weapons proliferation.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The [Effective ASTC Encoding](./Docs/Encoding.md) page looks at some of the
 guidelines that should be followed when compressing data using `astcenc`.
 It covers:
 
-* How to efficiently encoding data with fewer than 4 channels.
+* How to efficiently encode data with fewer than 4 channels.
 * How to efficiently encode normal maps, sRGB data, and HDR data
 * Coding equivalents to other compression formats.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The ASTC data format specification is available here:
 
 * [Khronos Data Format Specification v1.2 # ASTC](https://www.khronos.org/registry/DataFormat/specs/1.2/dataformat.1.2.html#ASTC)
 
+## License
+
+By downloading any component from this repository you acknowledge that you
+accept the End User Licence Agreement for the ASTC Encoder. See the
+[LICENSE.md](LICENSE.md) file for details.
+
 # Encoder feature support
 
 The encoder supports compression of PNG, TGA and KTX input images into ASTC
@@ -44,12 +50,6 @@ In addition it also supports all of the ASTC block sizes and compression
 modes, allowing content creators access the full spectrum of quality-to-bitrate
 options ranging from 0.89 bits/pixel up to 8 bits/pixel.
 
-# License
-
-By downloading any component from this repository you acknowledge that you
-accept the End User Licence Agreement for the ASTC Encoder. See the
-[license.txt](license.txt) file for details.
-
 # Prebuilt binaries
 
 Prebuilt release build binaries for Windows (x86 and x64), Linux (x86 and x64),
@@ -59,19 +59,6 @@ and macOS (x64) are available here:
 
  These binaries are built from the latest stable tag, and therefore do not
  necessarily represent the current state of the `master` branch source code.
-
-# Building from source
-
-Builds for Linux and macOS use GCC and Make, and are tested with GCC 4.6 and
-GNU Make 3.82.
-
-```
-cd Source
-make
-```
-
-Builds for Windows platforms use Visual Studio 2017, using the solution file
-located in the `Source/win32-2017/astcenc/` directory.
 
 # Getting started
 
@@ -94,8 +81,8 @@ Compress an image using the `-c` option:
     astcenc -c example.png example.astc 6x6 -medium
 
 This compresses `example.png` using the 6x6 block footprint (3.55 bits/pixel)
-and a `medium` compression speed, storing the compressed output to
-`example.astc`.
+and a `medium` compression speed, storing the compressed output in the linear
+color space to `example.astc`.
 
 ## Decompressing an image
 
@@ -119,12 +106,12 @@ console.
 
 ## Experimenting
 
-Efficient real-time graphics benefits from minimizing the bitrate needed to
-store a texture, as it reduces memory bandwidth, saves energy, and can improve
-texture cache efficiency. However, like any lossy compression format there will
-come a point where the compressed image quality is unacceptable because there
-are simply not enough bits to represent the output with the precision needed.
-We recommend experimenting with the block footprint to find the optimum balance
+Efficient real-time graphics benefits from minimizing compressed texture size,
+as it reduces memory bandwidth, saves energy, and can improve texture cache
+efficiency. However, like any lossy compression format there will come a point
+where the compressed image quality is unacceptable because there are simply
+not enough bits to represent the output with the precision needed. We
+recommend experimenting with the block footprint to find the optimum balance
 between size and quality, as the finely adjustable compression ratio is one of
 major strengths of the ASTC format.
 
@@ -136,6 +123,19 @@ does result in increasingly small improvements for the amount of time required.
 There are many other command line options for tuning the encoder parameters
 which can be used to fine tune the compression algorithm. See the command line
 help message for more details.
+
+# Documentation
+
+The [Effective ASTC Encoding](./Docs/Encoding.md) page looks at some of the
+guidelines that should be followed when compressing data using `astcenc`.
+It covers:
+
+* How to efficiently encoding data with fewer than 4 channels.
+* How to efficiently encode normal maps, sRGB data, and HDR data
+* Coding equivalents to other compression formats.
+
+The [Building ASTC Encoder](./Docs/Building.md) page provides the instructions
+on how to build `astcenc` from the sources in this repository.
 
 # Support
 


### PR DESCRIPTION
Added a new `Encoding.md` document to provide guidelines about how to actually drive the compressor command line options, in particular looking at format equivalency with other compression formats.

Moved build instructions to a new `Building.md` document, and added instructions for command line builds for Visual Studio.

Converted the license into `LICENSE.md` markdown, to make it a bit more readable in the browser (and no less readable in text format).