### PR TITLE
Cleanup handling of ASTC_CODEC_INTERNAL_ERROR

### DIFF
--- a/Source/astc_averages_and_directions.cpp
+++ b/Source/astc_averages_and_directions.cpp
@@ -223,10 +223,8 @@ void compute_averages_and_directions_3_components(const partition_info * pt,
 		texel_weights = ewb->texel_weight_rgb;
 	else
 	{
-		texel_weights = ewb->texel_weight_gba;
-		ASTC_CODEC_INTERNAL_ERROR;
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
-
 
 	for (partition = 0; partition < partition_count; partition++)
 	{
@@ -316,10 +314,7 @@ void compute_averages_and_directions_2_components(const partition_info * pt,
 		texel_weights = ewb->texel_weight_gb;
 	else
 	{
-		texel_weights = ewb->texel_weight_rg;
-		// unsupported set of color components.
-		ASTC_CODEC_INTERNAL_ERROR;
-		exit(1);
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	for (partition = 0; partition < partition_count; partition++)

--- a/Source/astc_codec_internals.h
+++ b/Source/astc_codec_internals.h
@@ -42,9 +42,8 @@
 #define MAX_WEIGHT_MODES 2048
 
 // error reporting for codec internal errors.
-#define ASTC_CODEC_INTERNAL_ERROR astc_codec_internal_error(__FILE__, __LINE__)
-
-void astc_codec_internal_error(const char *filename, int linenumber);
+#define ASTC_CODEC_INTERNAL_ERROR() astc_codec_internal_error(__FILE__, __LINE__)
+[[noreturn]] void astc_codec_internal_error(const char *filename, int linenumber);
 
 // uncomment this macro to enable checking for inappropriate NaNs;
 // works on Linux only, and slows down encoding significantly.

--- a/Source/astc_color_quantize.cpp
+++ b/Source/astc_color_quantize.cpp
@@ -695,12 +695,6 @@ void quantize_luminance_alpha(float4 color0, float4 color1, int output[4], int q
 	output[3] = color_quantization_tables[quantization_level][(int)floor(a1 + 0.5f)];
 }
 
-void quantize0(int output[8])
-{
-	for (int i = 0; i < 8; i++)
-		output[i] = 0;
-}
-
 // quantize and unquantize a number, wile making sure to retain the top two bits.
 static inline void quantize_and_unquantize_retain_top_two_bits(int quantization_level, int value_to_quantize,	// 0 to 255.
 															   int *quantized_value, int *unquantized_value)
@@ -1962,10 +1956,7 @@ int pack_color_endpoints(astc_decode_mode decode_mode, float4 color0, float4 col
 		break;
 
 	default:
-		ASTC_CODEC_INTERNAL_ERROR;
-		quantize0(output);
-		retval = FMT_LUMINANCE;
-		break;
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	#ifdef DEBUG_PRINT_DIAGNOSTICS

--- a/Source/astc_color_unquantize.cpp
+++ b/Source/astc_color_unquantize.cpp
@@ -825,7 +825,7 @@ void unpack_color_endpoints(astc_decode_mode decode_mode, int format, int quanti
 		break;
 
 	default:
-		ASTC_CODEC_INTERNAL_ERROR;
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	if (*alpha_hdr == -1)

--- a/Source/astc_compress_symbolic.cpp
+++ b/Source/astc_compress_symbolic.cpp
@@ -337,7 +337,7 @@ static void compress_symbolic_block_fixed_partition_1_plane(astc_decode_mode dec
 
 		int decimation_mode = bsd->block_modes[i].decimation_mode;
 		if (bsd->decimation_mode_percentile[decimation_mode] > mode_cutoff)
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 
 		// compute weight bitcount for the mode
 		int bits_used_by_weights = compute_ise_bitcount(ixtab2[decimation_mode]->num_weights,
@@ -1023,7 +1023,7 @@ static void compute_covariance_matrix(int xdim, int ydim, int zdim, const imageb
 	{
 		float weight = ewb->texel_weight[i];
 		if (weight < 0.0f)
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 		weight_sum += weight;
 		float r = blk->work_data[4 * i];
 		float g = blk->work_data[4 * i + 1];

--- a/Source/astc_ideal_endpoints_and_weights.cpp
+++ b/Source/astc_ideal_endpoints_and_weights.cpp
@@ -60,8 +60,7 @@ static void compute_endpoints_and_ideal_weights_1_component(int xdim, int ydim, 
 		error_weights = ewb->texel_weight_a;
 		break;
 	default:
-		error_weights = ewb->texel_weight_r;
-		ASTC_CODEC_INTERNAL_ERROR;
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	for (i = 0; i < partition_count; i++)
@@ -112,7 +111,7 @@ static void compute_endpoints_and_ideal_weights_1_component(int xdim, int ydim, 
 		ei->weight_error_scale[i] = partition_error_scale[partition] * error_weights[i];
 		if (astc_isnan(ei->weight_error_scale[i]))
 		{
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 		}
 	}
 
@@ -187,7 +186,7 @@ static void compute_endpoints_and_ideal_weights_2_components(int xdim, int ydim,
 	else
 	{
 		error_weights = ewb->texel_weight_rg;
-		ASTC_CODEC_INTERNAL_ERROR;
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	int texels_per_block = xdim * ydim * zdim;
@@ -377,7 +376,7 @@ static void compute_endpoints_and_ideal_weights_2_components(int xdim, int ydim,
 		ei->weight_error_scale[i] = length_squared[partition] * error_weights[i];
 		if (astc_isnan(ei->weight_error_scale[i]))
 		{
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 		}
 	}
 
@@ -430,8 +429,7 @@ static void compute_endpoints_and_ideal_weights_3_components(int xdim, int ydim,
 		error_weights = ewb->texel_weight_rgb;
 	else
 	{
-		error_weights = ewb->texel_weight_gba;
-		ASTC_CODEC_INTERNAL_ERROR;
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	compute_partition_error_color_weightings(xdim, ydim, zdim, ewb, pt, error_weightings, color_scalefactors);
@@ -657,7 +655,7 @@ static void compute_endpoints_and_ideal_weights_3_components(int xdim, int ydim,
 		ei->weight_error_scale[i] = length_squared[partition] * error_weights[i];
 		if (astc_isnan(ei->weight_error_scale[i]))
 		{
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 		}
 	}
 
@@ -817,7 +815,7 @@ static void compute_endpoints_and_ideal_weights_rgba(int xdim, int ydim, int zdi
 		ei->weight_error_scale[i] = error_weights[i] * length_squared[partition];
 		if (astc_isnan(ei->weight_error_scale[i]))
 		{
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 		}
 	}
 
@@ -908,7 +906,7 @@ void compute_endpoints_and_ideal_weights_2_planes(int xdim, int ydim, int zdim, 
 	case 3:					// separate weights for alpha
 		if (uses_alpha == 0)
 		{
-			ASTC_CODEC_INTERNAL_ERROR;
+			ASTC_CODEC_INTERNAL_ERROR();
 		}
 		compute_endpoints_and_ideal_weights_3_components(xdim, ydim, zdim, pt, blk, ewb, ei1, 0, 1, 2);
 

--- a/Source/astc_image_load_store.cpp
+++ b/Source/astc_image_load_store.cpp
@@ -88,8 +88,7 @@ astc_codec_image *allocate_image(int bitness, int xsize, int ysize, int zsize, i
 	}
 	else
 	{
-		ASTC_CODEC_INTERNAL_ERROR;
-		exit(1);
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	return img;
@@ -129,8 +128,7 @@ void initialize_image(astc_codec_image * img)
 	}
 	else
 	{
-		ASTC_CODEC_INTERNAL_ERROR;
-		exit(1);
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 }
 
@@ -1287,8 +1285,7 @@ astc_codec_image *astc_codec_load_image(const char *input_filename, int padding,
 		input_image = load_image_with_stb(input_filename, padding, load_result);
 		break;
 	default:
-		ASTC_CODEC_INTERNAL_ERROR;
-		exit(1);
+		ASTC_CODEC_INTERNAL_ERROR();
 	}
 
 	if (load_exr)
@@ -1399,9 +1396,7 @@ int astc_codec_store_image(const astc_codec_image * output_image, const char *ou
 			store_result = -99;
 		break;
 	default:
-		ASTC_CODEC_INTERNAL_ERROR;
-		exit(1);
-		break;
+		ASTC_CODEC_INTERNAL_ERROR();
 	};
 
 	return store_result;

--- a/Source/astc_toplevel.cpp
+++ b/Source/astc_toplevel.cpp
@@ -150,7 +150,7 @@ unsigned get_number_of_cpus(void)
 	return n_cpus;
 }
 
-void astc_codec_internal_error(const char *filename, int linenum)
+[[noreturn]] void astc_codec_internal_error(const char *filename, int linenum)
 {
 	printf("Internal error: File=%s Line=%d\n", filename, linenum);
 	exit(1);

--- a/Source/win32-2017/astcenc/astcenc.vcxproj
+++ b/Source/win32-2017/astcenc/astcenc.vcxproj
@@ -94,6 +94,8 @@
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -112,6 +114,8 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -134,6 +138,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies />
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -148,12 +154,16 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
- Error function calls exit(), so mark as [[noreturn]].
- Remove duplicate calls to exit().
- Remove functional logic which is redundant due to erro.