### PR TITLE
Remove variable shadows to pass GCC analysis

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -43,7 +43,7 @@ HEADERS = \
 
 OBJECTS = $(SOURCES:.cpp=.o)
 
-CPPFLAGS = -std=c++11 -O3 -Wall -W -Wextra -msse2 -mfpmath=sse
+CPPFLAGS = -std=c++11 -O3 -Wall -W -Wextra -Werror=shadow -msse2 -mfpmath=sse
 
 astcenc: $(OBJECTS)
 	g++ -o $@ $^ $(CPPFLAGS) -lpthread

--- a/Source/astc_block_sizes2.cpp
+++ b/Source/astc_block_sizes2.cpp
@@ -581,22 +581,21 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 	int decimation_mode_index[256];	// for each of the 256 entries in the decim_table_array, its index
 	int decimation_mode_count = 0;
 
-	int i;
-	int x_weights;
-	int y_weights;
-
-	for (i = 0; i < 256; i++)
+	for (int i = 0; i < 256; i++)
 	{
 		decimation_mode_index[i] = -1;
 	}
 
 	// gather all the infill-modes that can be used with the current block size
-	for (x_weights = 2; x_weights <= 12; x_weights++)
+	for (int x_weights = 2; x_weights <= 12; x_weights++)
 	{
-		for (y_weights = 2; y_weights <= 12; y_weights++)
+		for (int y_weights = 2; y_weights <= 12; y_weights++)
 		{
 			if (x_weights * y_weights > MAX_WEIGHTS_PER_BLOCK)
+			{
 				continue;
+			}
+
 			decimation_table *dt = new decimation_table;
 			decimation_mode_index[y_weights * 16 + x_weights] = decimation_mode_count;
 			initialize_decimation_table_2d(xdim, ydim, x_weights, y_weights, dt);
@@ -605,7 +604,7 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 
 			int maxprec_1plane = -1;
 			int maxprec_2planes = -1;
-			for (i = 0; i < 12; i++)
+			for (int i = 0; i < 12; i++)
 			{
 				int bits_1plane = compute_ise_bitcount(weight_count, (quantization_method) i);
 				int bits_2planes = compute_ise_bitcount(2 * weight_count, (quantization_method) i);
@@ -616,7 +615,9 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 			}
 
 			if (2 * x_weights * y_weights > MAX_WEIGHTS_PER_BLOCK)
+			{
 				maxprec_2planes = -1;
+			}
 
 			bsd->permit_encode[decimation_mode_count] = (x_weights <= xdim && y_weights <= ydim);
 
@@ -629,12 +630,12 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 		}
 	}
 
-	for (i = 0; i < MAX_DECIMATION_MODES; i++)
+	for (int i = 0; i < MAX_DECIMATION_MODES; i++)
 	{
 		bsd->decimation_mode_percentile[i] = 1.0f;
 	}
 
-	for (i = decimation_mode_count; i < MAX_DECIMATION_MODES; i++)
+	for (int i = decimation_mode_count; i < MAX_DECIMATION_MODES; i++)
 	{
 		bsd->permit_encode[i] = 0;
 		bsd->decimation_mode_samples[i] = 0;
@@ -647,7 +648,7 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 	const float *percentiles = get_2d_percentile_table(xdim, ydim);
 
 	// then construct the list of block formats
-	for (i = 0; i < 2048; i++)
+	for (int i = 0; i < 2048; i++)
 	{
 		int x_weights, y_weights;
 		int is_dual_plane;
@@ -694,15 +695,19 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 	if (xdim * ydim <= 64)
 	{
 		bsd->texelcount_for_bitmap_partitioning = xdim * ydim;
-		for (i = 0; i < xdim * ydim; i++)
+		for (int i = 0; i < xdim * ydim; i++)
+		{
 			bsd->texels_for_bitmap_partitioning[i] = i;
+		}
 	}
 	else
 	{
 		// pick 64 random texels for use with bitmap partitioning.
 		int arr[MAX_TEXELS_PER_BLOCK];
-		for (i = 0; i < xdim * ydim; i++)
+		for (int i = 0; i < xdim * ydim; i++)
+		{
 			arr[i] = 0;
+		}
 
 		int arr_elements_set = 0;
 		while (arr_elements_set < 64)
@@ -720,7 +725,9 @@ void construct_block_size_descriptor_2d(int xdim, int ydim, block_size_descripto
 		while (texel_weights_written < 64)
 		{
 			if (arr[idx])
+			{
 				bsd->texels_for_bitmap_partitioning[texel_weights_written++] = idx;
+			}
 			idx++;
 		}
 
@@ -733,22 +740,17 @@ void construct_block_size_descriptor_3d(int xdim, int ydim, int zdim, block_size
 	int decimation_mode_index[512];	// for each of the 512 entries in the decim_table_array, its index
 	int decimation_mode_count = 0;
 
-	int i;
-	int x_weights;
-	int y_weights;
-	int z_weights;
-
-	for (i = 0; i < 512; i++)
+	for (int i = 0; i < 512; i++)
 	{
 		decimation_mode_index[i] = -1;
 	}
 
 	// gather all the infill-modes that can be used with the current block size
-	for (x_weights = 2; x_weights <= 6; x_weights++)
+	for (int x_weights = 2; x_weights <= 6; x_weights++)
 	{
-		for (y_weights = 2; y_weights <= 6; y_weights++)
+		for (int y_weights = 2; y_weights <= 6; y_weights++)
 		{
-			for (z_weights = 2; z_weights <= 6; z_weights++)
+			for (int z_weights = 2; z_weights <= 6; z_weights++)
 			{
 				if ((x_weights * y_weights * z_weights) > MAX_WEIGHTS_PER_BLOCK)
 					continue;
@@ -760,7 +762,7 @@ void construct_block_size_descriptor_3d(int xdim, int ydim, int zdim, block_size
 
 				int maxprec_1plane = -1;
 				int maxprec_2planes = -1;
-				for (i = 0; i < 12; i++)
+				for (int i = 0; i < 12; i++)
 				{
 					int bits_1plane = compute_ise_bitcount(weight_count, (quantization_method) i);
 					int bits_2planes = compute_ise_bitcount(2 * weight_count, (quantization_method) i);
@@ -785,12 +787,12 @@ void construct_block_size_descriptor_3d(int xdim, int ydim, int zdim, block_size
 		}
 	}
 
-	for (i = 0; i < MAX_DECIMATION_MODES; i++)
+	for (int i = 0; i < MAX_DECIMATION_MODES; i++)
 	{
 		bsd->decimation_mode_percentile[i] = 1.0f;
 	}
 
-	for (i = decimation_mode_count; i < MAX_DECIMATION_MODES; i++)
+	for (int i = decimation_mode_count; i < MAX_DECIMATION_MODES; i++)
 	{
 		bsd->permit_encode[i] = 0;
 		bsd->decimation_mode_samples[i] = 0;
@@ -803,7 +805,7 @@ void construct_block_size_descriptor_3d(int xdim, int ydim, int zdim, block_size
 	const float *percentiles = get_3d_percentile_table();
 
 	// then construct the list of block formats
-	for (i = 0; i < 2048; i++)
+	for (int i = 0; i < 2048; i++)
 	{
 		int x_weights, y_weights, z_weights;
 		int is_dual_plane;
@@ -848,15 +850,20 @@ void construct_block_size_descriptor_3d(int xdim, int ydim, int zdim, block_size
 	if (xdim * ydim * zdim <= 64)
 	{
 		bsd->texelcount_for_bitmap_partitioning = xdim * ydim * zdim;
-		for (i = 0; i < xdim * ydim * zdim; i++)
+		for (int i = 0; i < xdim * ydim * zdim; i++)
+		{
 			bsd->texels_for_bitmap_partitioning[i] = i;
+		}
 	}
 	else
 	{
 		// pick 64 random texels for use with bitmap partitioning.
 		int arr[MAX_TEXELS_PER_BLOCK];
-		for (i = 0; i < xdim * ydim * zdim; i++)
+		for (int i = 0; i < xdim * ydim * zdim; i++)
+		{
 			arr[i] = 0;
+		}
+
 		int arr_elements_set = 0;
 		while (arr_elements_set < 64)
 		{
@@ -867,6 +874,7 @@ void construct_block_size_descriptor_3d(int xdim, int ydim, int zdim, block_size
 				arr[idx] = 1;
 			}
 		}
+
 		int texel_weights_written = 0;
 		int idx = 0;
 		while (texel_weights_written < 64)

--- a/Source/astc_compress_symbolic.cpp
+++ b/Source/astc_compress_symbolic.cpp
@@ -810,7 +810,6 @@ void expand_block_artifact_suppression(int xdim, int ydim, int zdim, error_weigh
 float prepare_error_weight_block(const astc_codec_image * input_image,
 								 int xdim, int ydim, int zdim, const error_weighting_params * ewp, const imageblock * blk, error_weight_block * ewb, error_weight_block_orig * ewbo)
 {
-	int x, y, z;
 	int idx = 0;
 
 	int any_mean_stdev_weight =
@@ -823,11 +822,11 @@ float prepare_error_weight_block(const astc_codec_image * input_image,
 
 	ewb->contains_zeroweight_texels = 0;
 
-	for (z = 0; z < zdim; z++)
+	for (int z = 0; z < zdim; z++)
 	{
-		for (y = 0; y < ydim; y++)
+		for (int y = 0; y < ydim; y++)
 		{
-			for (x = 0; x < xdim; x++)
+			for (int x = 0; x < xdim; x++)
 			{
 				int xpos = x + blk->xpos;
 				int ypos = y + blk->ypos;
@@ -886,14 +885,16 @@ float prepare_error_weight_block(const astc_codec_image * input_image,
 
 					if (ewp->ra_normal_angular_scale)
 					{
-						float x = (blk->orig_data[4 * idx] - 0.5f) * 2.0f;
-						float y = (blk->orig_data[4 * idx + 3] - 0.5f) * 2.0f;
-						float denom = 1.0f - x * x - y * y;
+						// Convert from 0 to 1 to -1 to +1 range.
+						float xN = (blk->orig_data[4 * idx] - 0.5f) * 2.0f;
+						float yN = (blk->orig_data[4 * idx + 3] - 0.5f) * 2.0f;
+
+						float denom = 1.0f - xN * xN - yN * yN;
 						if (denom < 0.1f)
 							denom = 0.1f;
 						denom = 1.0f / denom;
-						error_weight.x *= 1.0f + x * x * denom;
-						error_weight.w *= 1.0f + y * y * denom;
+						error_weight.x *= 1.0f + xN * xN * denom;
+						error_weight.w *= 1.0f + yN * yN * denom;
 					}
 
 					if (ewp->enable_rgb_scale_with_alpha)
@@ -959,12 +960,9 @@ float prepare_error_weight_block(const astc_codec_image * input_image,
 		}
 	}
 
-	int i;
-
 	float4 error_weight_sum = float4(0, 0, 0, 0);
 	int texels_per_block = xdim * ydim * zdim;
-
-	for (i = 0; i < texels_per_block; i++)
+	for (int i = 0; i < texels_per_block; i++)
 	{
 		error_weight_sum = error_weight_sum + ewb->error_weights[i];
 

--- a/Source/astc_ideal_endpoints_and_weights.cpp
+++ b/Source/astc_ideal_endpoints_and_weights.cpp
@@ -1369,9 +1369,6 @@ void compute_ideal_quantized_weights_for_decimation_table(const endpoints_and_we
 				float flt_weight_val = qat->unquantized_value_flt[weight_val];
 				float flt_weight_next_up = qat->unquantized_value_flt[weight_next_up];
 				float flt_weight_next_down = qat->unquantized_value_flt[weight_next_down];
-
-				int do_quant_mod = 0;
-
 				float error_change_up, error_change_down;
 
 				// compute the error change from perturbing the weight either up or down.
@@ -1404,11 +1401,11 @@ void compute_ideal_quantized_weights_for_decimation_table(const endpoints_and_we
 					quantized_weight_set[weight_to_perturb] = new_weight_val;
 
 					// update the infilled-weights
-					int num_weights = it->weight_num_texels[weight_to_perturb];
+					int num_weights_infill = it->weight_num_texels[weight_to_perturb];
 					float perturbation = (flt_new_weight_val - flt_weight_val) * (1.0f / TEXEL_WEIGHT_SUM);
 					const uint8_t *weight_texel_ptr = it->weight_texel[weight_to_perturb];
 					const float *weights_ptr = it->weights_flt[weight_to_perturb];
-					for (i = num_weights - 1; i >= 0; i--)
+					for (i = num_weights_infill - 1; i >= 0; i--)
 					{
 						uint8_t weight_texel = weight_texel_ptr[i];
 						float weights = weights_ptr[i];

--- a/Source/astc_image_load_store.cpp
+++ b/Source/astc_image_load_store.cpp
@@ -869,13 +869,12 @@ void write_imageblock(astc_codec_image * img, const imageblock * pb,	// picture-
 							}
 							data[3] = fptr[3];
 
-							float x = (data[0] * 2.0f) - 1.0f;
-							float y = (data[3] * 2.0f) - 1.0f;
-							float z = 1.0f - x * x - y * y;
-							if (z < 0.0f)
-								z = 0.0f;
-							data[6] = (sqrt(z) * 0.5f) + 0.5f;
-
+							float xN = (data[0] * 2.0f) - 1.0f;
+							float yN = (data[3] * 2.0f) - 1.0f;
+							float zN = 1.0f - xN * xN - yN * yN;
+							if (zN < 0.0f)
+								zN = 0.0f;
+							data[6] = (sqrt(zN) * 0.5f) + 0.5f;
 
 							int r = float_to_sf16(data[swz.r], SF_NEARESTEVEN);
 							int g = float_to_sf16(data[swz.g], SF_NEARESTEVEN);

--- a/Source/astc_kmeans_partitioning.cpp
+++ b/Source/astc_kmeans_partitioning.cpp
@@ -110,11 +110,11 @@ void kpp_initialize(int xdim, int ydim, int zdim, int partition_count, const ima
 	// finally, gather up the results.
 	for (i = 0; i < partition_count; i++)
 	{
-		int sample = cluster_center_samples[i];
-		float4 color = float4(blk->work_data[4 * sample],
-							  blk->work_data[4 * sample + 1],
-							  blk->work_data[4 * sample + 2],
-							  blk->work_data[4 * sample + 3]);
+		int center_sample = cluster_center_samples[i];
+		float4 color = float4(blk->work_data[4 * center_sample],
+							  blk->work_data[4 * center_sample + 1],
+							  blk->work_data[4 * center_sample + 2],
+							  blk->work_data[4 * center_sample + 3]);
 		cluster_centers[i] = color;
 	}
 }
@@ -128,7 +128,6 @@ void basic_kmeans_assign_pass(int xdim, int ydim, int zdim, int partition_count,
 	int texels_per_block = xdim * ydim * zdim;
 
 	float distances[MAX_TEXELS_PER_BLOCK];
-	float4 center_color = cluster_centers[0];
 
 	int texels_per_partition[4];
 
@@ -142,7 +141,7 @@ void basic_kmeans_assign_pass(int xdim, int ydim, int zdim, int partition_count,
 							  blk->work_data[4 * i + 1],
 							  blk->work_data[4 * i + 2],
 							  blk->work_data[4 * i + 3]);
-		float4 diff = color - center_color;
+		float4 diff = color - cluster_centers[0];
 		float distance = dot(diff, diff);
 		distances[i] = distance;
 		partition_of_texel[i] = 0;

--- a/Source/astc_toplevel.cpp
+++ b/Source/astc_toplevel.cpp
@@ -719,8 +719,6 @@ void dump_image(astc_codec_image * img)
 
 int astc_main(int argc, char **argv)
 {
-	int i;
-
 	test_inappropriate_extended_precision();
 	// initialization routines
 	prepare_angular_tables();
@@ -1503,7 +1501,7 @@ int astc_main(int argc, char **argv)
 			}
 
 			int swizzle_components[4];
-			for (i = 0; i < 4; i++)
+			for (int i = 0; i < 4; i++)
 				switch (argv[argidx - 1][i])
 				{
 				case 'r':
@@ -1549,7 +1547,7 @@ int astc_main(int argc, char **argv)
 			}
 
 			int swizzle_components[4];
-			for (i = 0; i < 4; i++)
+			for (int i = 0; i < 4; i++)
 			{
 				switch (argv[argidx - 1][i])
 				{
@@ -2229,10 +2227,10 @@ int astc_main(int argc, char **argv)
 	// determine encoding bitness as follows:
 	// if enforced by the output format, follow the output format's result
 	// else use decode_mode to pick bitness.
-	int bitness = get_output_filename_enforced_bitness(output_filename);
-	if (bitness == -1)
+	int out_bitness = get_output_filename_enforced_bitness(output_filename);
+	if (out_bitness == -1)
 	{
-		bitness = (decode_mode == DECODE_HDR) ? 16 : 8;
+		out_bitness = (decode_mode == DECODE_HDR) ? 16 : 8;
 	}
 
 	int xdim = -1;
@@ -2315,7 +2313,7 @@ int astc_main(int argc, char **argv)
 		// Merge input image data.
 		else
 		{
-			int i, z, xsize, ysize, zsize, bitness, slice_size;
+			int z, xsize, ysize, zsize, bitness, slice_size;
 
 			xsize = input_images[0]->xsize;
 			ysize = input_images[0]->ysize;
@@ -2340,7 +2338,7 @@ int astc_main(int argc, char **argv)
 			}
 
 			// Clean up temporary images.
-			for (i = 0; i < array_size; i++)
+			for (int i = 0; i < array_size; i++)
 			{
 				destroy_image(input_images[i]);
 			}
@@ -2400,11 +2398,11 @@ int astc_main(int argc, char **argv)
 	start_coding_time = get_time();
 
 	if (opmode == 1)
-		output_image = load_astc_file(input_filename, bitness, decode_mode, swz_decode);
+		output_image = load_astc_file(input_filename, out_bitness, decode_mode, swz_decode);
 
 	// process image, if relevant
 	if (opmode == 2)
-		output_image = pack_and_unpack_astc_image(input_image, xdim, ydim, zdim, &ewp, decode_mode, swz_encode, swz_decode, bitness, thread_count);
+		output_image = pack_and_unpack_astc_image(input_image, xdim, ydim, zdim, &ewp, decode_mode, swz_encode, swz_decode, out_bitness, thread_count);
 
 	end_coding_time = get_time();
 
@@ -2423,7 +2421,7 @@ int astc_main(int argc, char **argv)
 		int store_result = -1;
 		const char *format_string = "";
 
-		store_result = astc_codec_store_image(output_image, output_filename, bitness, &format_string);
+		store_result = astc_codec_store_image(output_image, output_filename, out_bitness, &format_string);
 
 		if (store_result < 0)
 		{
@@ -2450,8 +2448,10 @@ int astc_main(int argc, char **argv)
 	{
 		printf("%s ", argv[2]);
 		printf("%d %d  ", xdim_2d, ydim_2d);
-		for (i = 0; i < 2048; i++)
+		for (int i = 0; i < 2048; i++)
+		{
 			printf(" %d", block_mode_histogram[i]);
+		}
 		printf("\n");
 	}
 

--- a/Source/astc_weight_align.cpp
+++ b/Source/astc_weight_align.cpp
@@ -376,44 +376,47 @@ void compute_angular_endpoints_for_quantization_levels(int samplecount, const fl
 
 	for (i = 0; i < max_angular_steps; i++)
 	{
-		int samplecount = highest_weight[i] - lowest_weight[i] + 1;
-		if (samplecount >= (max_quantization_steps + 4))
+		int samplecount_weight = highest_weight[i] - lowest_weight[i] + 1;
+		if (samplecount_weight >= (max_quantization_steps + 4))
 		{
 			continue;
 		}
-		if (samplecount < 2)
-			samplecount = 2;
 
-		if (best_errors[samplecount] > error[i])
+		if (samplecount_weight < 2)
 		{
-			best_errors[samplecount] = error[i];
-			best_scale[samplecount] = i;
-			cut_low_weight[samplecount] = 0;
+			samplecount_weight = 2;
+		}
+
+		if (best_errors[samplecount_weight] > error[i])
+		{
+			best_errors[samplecount_weight] = error[i];
+			best_scale[samplecount_weight] = i;
+			cut_low_weight[samplecount_weight] = 0;
 		}
 
 		float error_cut_low = error[i] + cut_low_weight_error[i];
 		float error_cut_high = error[i] + cut_high_weight_error[i];
 		float error_cut_low_high = error[i] + cut_low_weight_error[i] + cut_high_weight_error[i];
 
-		if (best_errors[samplecount - 1] > error_cut_low)
+		if (best_errors[samplecount_weight - 1] > error_cut_low)
 		{
-			best_errors[samplecount - 1] = error_cut_low;
-			best_scale[samplecount - 1] = i;
-			cut_low_weight[samplecount - 1] = 1;
+			best_errors[samplecount_weight - 1] = error_cut_low;
+			best_scale[samplecount_weight - 1] = i;
+			cut_low_weight[samplecount_weight - 1] = 1;
 		}
 
-		if (best_errors[samplecount - 1] > error_cut_high)
+		if (best_errors[samplecount_weight - 1] > error_cut_high)
 		{
-			best_errors[samplecount - 1] = error_cut_high;
-			best_scale[samplecount - 1] = i;
-			cut_low_weight[samplecount - 1] = 0;
+			best_errors[samplecount_weight - 1] = error_cut_high;
+			best_scale[samplecount_weight - 1] = i;
+			cut_low_weight[samplecount_weight - 1] = 0;
 		}
 
-		if (best_errors[samplecount - 2] > error_cut_low_high)
+		if (best_errors[samplecount_weight - 2] > error_cut_low_high)
 		{
-			best_errors[samplecount - 2] = error_cut_low_high;
-			best_scale[samplecount - 2] = i;
-			cut_low_weight[samplecount - 2] = 1;
+			best_errors[samplecount_weight - 2] = error_cut_low_high;
+			best_scale[samplecount_weight - 2] = i;
+			cut_low_weight[samplecount_weight - 2] = 1;
 		}
 
 	}


### PR DESCRIPTION
This fixes one bug in the code caused by shadowing where quant_mod
wasn't getting updated in the outer scope. Minor IQ differences
expected, on average it's better quality but really small differences
expected based on testing here (we will test more values for weight
perturbations).

Fixes #70