### PR TITLE
Guard STB_IMAGE_IMPLEMENTATION

### DIFF
--- a/Source/astc_stb_tga.cpp
+++ b/Source/astc_stb_tga.cpp
@@ -16,10 +16,12 @@
 #include "softfloat.h"
 #include <stdio.h>
 
-#define STB_IMAGE_IMPLEMENTATION
 #define STBI_NO_PSD
 #define STBI_NO_PIC
 #define STBI_NO_PNM
+#ifndef NO_STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_IMPLEMENTATION
+#endif
 #include "stb_image.h"
 
 astc_codec_image * load_image_with_stb(const char *filename, int padding, int *result)


### PR DESCRIPTION
This is to avoid re-defining stb_image.h implementation when using astc as a library in a project that also includes stb_image.h

The reason why we opted to include a new define is that this way we keep compatibility with projects that use both astc and stb_image.h and rely on astc defining the implementation.