### PR TITLE
CI: Add AppVeyor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# About
+# About [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ARM-software/astc-encoder?branch=master&svg=true)](https://ci.appveyor.com/project/ARM-software/astc-encoder)
 
 This is the official repository for the Arm® Adaptive Scalable Texture
 Compression (ASTC) Encoder, `astcenc`, a command-line tool for compressing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+image: Visual Studio 2019
+configuration: Release
+
+build:
+  project: Source/VS2019/astcenc.sln
+
+artifacts:
+    - path: bin\Release\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ configuration: Release
 
 build:
   project: Source/VS2019/astcenc.sln
+  parallel: true
 
 artifacts:
-    - path: bin\Release\*.*
+    - path: Source\VS2019\**\astcenc*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,4 +6,4 @@ build:
   parallel: true
 
 artifacts:
-    - path: Source\VS2019\**\astcenc*.*
+    - path: Source\VS2019\**\astcenc*.exe


### PR DESCRIPTION
Adds an AppVeyor configuration that builds `astcenc` with Visual Studio using the `astcenc.sln`.

AppVeyor can be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.