### PR TITLE
Memory leak fix and some cleanups

### DIFF
--- a/Source/astc_block_sizes2.cpp
+++ b/Source/astc_block_sizes2.cpp
@@ -899,3 +899,12 @@ void init_block_size_descriptor(
 
 	init_partition_tables(bsd);
 }
+
+void deinit_block_size_descriptor(
+	block_size_descriptor* bsd)
+{
+	for(int i = 0; i < bsd->decimation_mode_count; i++)
+	{
+		delete bsd->decimation_tables[i];
+	}
+}

--- a/Source/astc_codec_internals.h
+++ b/Source/astc_codec_internals.h
@@ -156,7 +156,7 @@ struct block_size_descriptor
 	int decimation_mode_maxprec_2planes[MAX_DECIMATION_MODES];
 	float decimation_mode_percentile[MAX_DECIMATION_MODES];
 	int permit_encode[MAX_DECIMATION_MODES];
-	const decimation_table *decimation_tables[MAX_DECIMATION_MODES + 1];
+	const decimation_table *decimation_tables[MAX_DECIMATION_MODES];
 	block_mode block_modes[MAX_WEIGHT_MODES];
 
 	// for the k-means bed bitmap partitioning algorithm, we don't
@@ -423,6 +423,9 @@ void init_block_size_descriptor(
 	int xdim,
 	int ydim,
 	int zdim,
+	block_size_descriptor* bsd);
+
+void deinit_block_size_descriptor(
 	block_size_descriptor* bsd);
 
 /**

--- a/Source/astc_color_unquantize.cpp
+++ b/Source/astc_color_unquantize.cpp
@@ -779,7 +779,7 @@ static void hdr_alpha_unpack(
 	*a1 <<= 4;
 }
 
-void hdr_rgb_hdr_alpha_unpack3(
+static void hdr_rgb_hdr_alpha_unpack3(
 	const int input[8],
 	int quantization_level,
 	uint4* output0,

--- a/Source/astc_mathlib.h
+++ b/Source/astc_mathlib.h
@@ -442,9 +442,9 @@ template <typename T> class vtype2
 {
 public:
 	T x, y;
-	vtype2() {};
-	vtype2(T p, T q)         : x(p),   y(q)   {};
-	vtype2(const vtype2 & p) : x(p.x), y(p.y) {};
+	vtype2() {}
+	vtype2(T p, T q)         : x(p),   y(q)   {}
+	vtype2(const vtype2 & p) : x(p.x), y(p.y) {}
 	vtype2 &operator =(const vtype2 &s) {
 		this->x = s.x;
 		this->y = s.y;
@@ -456,9 +456,9 @@ template <typename T> class vtype3
 {
 public:
 	T x, y, z;
-	vtype3() {};
-	vtype3(T p, T q, T r)    : x(p),   y(q),   z(r)   {};
-	vtype3(const vtype3 & p) : x(p.x), y(p.y), z(p.z) {};
+	vtype3() {}
+	vtype3(T p, T q, T r)    : x(p),   y(q),   z(r)   {}
+	vtype3(const vtype3 & p) : x(p.x), y(p.y), z(p.z) {}
 	vtype3 &operator =(const vtype3 &s) {
 		this->x = s.x;
 		this->y = s.y;
@@ -471,9 +471,9 @@ template <typename T> class vtype4
 {
 public:
 	T x, y, z, w;
-	vtype4() {};
-	vtype4(T p, T q, T r, T s) : x(p),   y(q),   z(r),   w(s)   {};
-	vtype4(const vtype4 & p)   : x(p.x), y(p.y), z(p.z), w(p.w) {};
+	vtype4() {}
+	vtype4(T p, T q, T r, T s) : x(p),   y(q),   z(r),   w(s)   {}
+	vtype4(const vtype4 & p)   : x(p.x), y(p.y), z(p.z), w(p.w) {}
 	vtype4 &operator =(const vtype4 &s) {
 		this->x = s.x;
 		this->y = s.y;

--- a/Source/astc_toplevel.cpp
+++ b/Source/astc_toplevel.cpp
@@ -175,6 +175,7 @@ astc_codec_image *load_astc_file(
 				write_imageblock(img, &pb, &bsd, x * xdim, y * ydim, z * zdim, swz_decode);
 			}
 
+	deinit_block_size_descriptor(&bsd);
 	free(buffer);
 	return img;
 }
@@ -330,6 +331,7 @@ static void encode_astc_image(
 	ai.output_image = output_image;
 
 	launch_threads(threadcount, encode_astc_image_threadfunc, &ai);
+	deinit_block_size_descriptor(bsd);
 	delete bsd;
 }
 


### PR DESCRIPTION
- Fixed memory leak related to decimation_tables being
  allocated and never deallocated
- Reduced size of decimation_tables array to remove
  unused last element
- Made hdr_rgb_hdr_alpha_unpack3() static
- Removed spurious semicolons in vtypeX classes