### PR TITLE
Update Jenkins shared library to fix Artifactory build permissions

### DIFF
--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('hive-infra-library@changes/63/236263/2') _
+@Library('hive-infra-library@changes/64/237764/6') _
 
 pipeline {
   agent none


### PR DESCRIPTION
This is required to overcome issues in Artefactory permissioning.