### PR TITLE
Split the core codec usage into multiple passes

### DIFF
--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -143,7 +143,6 @@ enum astcenc_preset {
 // Image channel data type
 enum astcenc_type {
 	ASTCENC_TYP_U8 = 0,
-	ASTCENC_TYP_U16,
 	ASTCENC_TYP_F16
 };
 

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -229,10 +229,13 @@ struct astcenc_config {
 struct astcenc_image {
 	unsigned int dim_x;
 	unsigned int dim_y;
+	unsigned int dim_z;
 	unsigned int channels;
 	astcenc_type type;
 	astcenc_swizzle swizzle;
-	void* data;
+	uint8_t ***data8;
+	uint16_t ***data16;
+	size_t padding_texels;
 	size_t row_stride;
 	size_t data_size;
 };
@@ -288,19 +291,19 @@ astcenc_error astcenc_context_alloc(
  * Note: User must allocate all output memory before calling this function.
  *
  * @param context      The codec context.
- * @param image        Array of input images, each a 2D slice.
- * @param dim_z        The length of image array, the Z dimension of 3D image.
+ * @param image        The input image.
  * @param data_out     Pointer to byte array to store the output.
  * @param data_len     Length of the data array, in bytes.
  * @param thread_index The thread index [0..N-1] of the calling thread. All
- *                     N threads must call this function.
+ *                     N threads must call this function exactly once per
+ *                     decompression, and all threads must ext this function
+ *                     before a new image can be compressed or decompressed
  *
  * @return ASTCENC_SUCCESS on success, or an error if compression failed.
  */
 astcenc_error astcenc_compress_image(
 	astcenc_context& context,
-	astcenc_image const* image,
-	size_t dim_z,
+	astcenc_image& image,
 	uint8_t* data_out,
 	size_t data_len,
 	int thread_index);
@@ -313,10 +316,11 @@ astcenc_error astcenc_compress_image(
  * @param context      The codec context.
  * @param data         Pointer to compressed data.
  * @param data_len     Length of the compressed data, in bytes.
- * @param image_out    Array of output images, each a 2D slice.
- * @param dim_z        The length of image array, the Z dimension of 3D image.
+ * @param image_out    The output image.
  * @param thread_index The thread index [0..N-1] of the calling thread. All
- *                     N threads must call this function.
+ *                     N threads must call this function exactly once per
+ *                     decompression, and all threads must ext this function
+ *                     before a new image can be compressed or decompressed.
  *
  * @return ASTCENC_SUCCESS on success, or an error if decompression failed.
  */
@@ -324,8 +328,7 @@ astcenc_error astcenc_decompress_image(
 	astcenc_context& context,
 	uint8_t const* data,
 	size_t data_len,
-	astcenc_image* image_out,
-	size_t image_out_len,
+	astcenc_image& image_out,
 	int thread_index);
 
 /**

--- a/Source/astcenc_color_quantize.cpp
+++ b/Source/astcenc_color_quantize.cpp
@@ -1872,7 +1872,7 @@ int pack_color_endpoints(
 	color1.z = MAX(color1.z, 0.0f);
 	color1.w = MAX(color1.w, 0.0f);
 
-	int retval;
+	int retval = 0;
 
 	// TODO: Make format an endpoint_fmt enum type
 	switch (format)

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -704,24 +704,25 @@ void compute_averages_and_variances(
 	astcenc_swizzle swz,
 	int thread_count);
 
-/*
-	Functions to load image from file.
-	If successful, return an astc_codec_image object.
-	If unsuccessful, returns nullptr.
-
-	*result is used to return a result. In case of a successfully loaded image, bits[2:0]
-	of *result indicate how many components are present, and bit[7] indicate whether
-	the input image was LDR or HDR (0=LDR, 1=HDR).
-
-	In case of failure, *result is given a negative value.
-*/
-
+/**
+ * Functions to load image from file.
+ *
+ * @param filename            The file path on disk.
+ * @param padding             The texel padding needed around the image.
+ * @param y_flip              Should this image be Y flipped?
+ * @param linearize_srgb      Should this image be converted to linear from sRGB?
+ * @param[out] is_hdr         Is the loaded image HDR?
+ * @param[out] num_components The number of components in the loaded image.
+ *
+ * @return The astc image file, or nullptr on error.
+ */
 astc_codec_image* astc_codec_load_image(
 	const char* filename,
 	int padding,
-	int y_flip,
-	int linearize_srgb,
-	int* result);
+	bool y_flip,
+	bool linearize_srgb,
+	bool& is_hdr,
+	int& num_components);
 
 int astc_codec_store_image(
 	const astc_codec_image* output_image,

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1456,7 +1456,7 @@ astc_codec_image* load_dds_uncompressed_image(
 
 	delete[] buf;
 	fill_image_padding_area(astc_img);
-	is_hdr = bitness;
+	is_hdr = bitness == 16;
 	num_components = components;
 	return astc_img;
 }

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -52,8 +52,9 @@ Image load and store through the stb_iamge and tinyexr libraries
 static astc_codec_image* load_image_with_tinyexr(
 	const char* filename,
 	int padding,
-	int y_flip,
-	int* result
+	bool y_flip,
+	bool& is_hdr,
+	int& num_components
 ) {
 	int xsize;
 	int ysize;
@@ -64,7 +65,6 @@ static astc_codec_image* load_image_with_tinyexr(
 	{
 		printf("ERROR: Failed to load image %s (%s)\n", filename, err);
 		free((void*)err);
-		*result = -1;
 		return nullptr;
 	}
 
@@ -72,16 +72,17 @@ static astc_codec_image* load_image_with_tinyexr(
 		image, xsize, ysize, padding, y_flip);
 
 	free(image);
-
-	*result = 0x84; // 4 components of 16-bit data.
+	is_hdr = true;
+	num_components = 4;
 	return res_img;
 }
 
 static astc_codec_image* load_image_with_stb(
 	const char* filename,
 	int padding,
-	int y_flip,
-	int* result
+	bool y_flip,
+	bool& is_hdr,
+	int& num_components
 ) {
 	int xsize, ysize;
 	int components;
@@ -95,7 +96,8 @@ static astc_codec_image* load_image_with_stb(
 		{
 			astc_img = astc_img_from_floatx4_array(image, xsize, ysize, padding, y_flip);
 			stbi_image_free(image);
-			*result = components + 0x80;
+			is_hdr = true;
+			num_components = 4;
 			return astc_img;
 		}
 	}
@@ -107,13 +109,13 @@ static astc_codec_image* load_image_with_stb(
 		{
 			astc_img = astc_img_from_unorm8x4_array(imageptr, xsize, ysize, padding, y_flip);
 			stbi_image_free(image);
-			*result = components;
+			is_hdr = false;
+			num_components = 4;
 			return astc_img;
 		}
 	}
 
 	printf("ERROR: Failed to load image %s (%s)\n", filename, stbi_failure_reason());
-	*result = -1;
 	return nullptr;
 }
 
@@ -588,8 +590,9 @@ static void ktx_header_switch_endianness(ktx_header * kt)
 static astc_codec_image* load_ktx_uncompressed_image(
 	const char* filename,
 	int padding,
-	int y_flip,
-	int* result
+	bool y_flip,
+	bool& is_hdr,
+	int& num_components
 ) {
 	int y, z;
 
@@ -597,7 +600,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	if (!f)
 	{
 		printf("Failed to open file %s\n", filename);
-		*result = -1;
 		return nullptr;
 	}
 
@@ -608,7 +610,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	{
 		printf("Failed to read header of KTX file %s\n", filename);
 		fclose(f);
-		*result = -2;
 		return nullptr;
 	}
 
@@ -616,7 +617,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	{
 		printf("File %s does not have a valid KTX header\n", filename);
 		fclose(f);
-		*result = -3;
 		return nullptr;
 	}
 
@@ -631,7 +631,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	{
 		printf("File %s appears to be compressed, not supported as input\n", filename);
 		fclose(f);
-		*result = -4;
 		return nullptr;
 	}
 
@@ -669,7 +668,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	default:
 		printf("KTX file %s has unsupported GL type\n", filename);
 		fclose(f);
-		*result = -5;
 		return nullptr;
 	};
 
@@ -815,7 +813,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	default:
 		printf("KTX file %s has unsupported GL format\n", filename);
 		fclose(f);
-		*result = -5;
 		return nullptr;
 	}
 
@@ -847,7 +844,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	{
 		printf("Failed to read header of KTX file %s\n", filename);
 		fclose(f);
-		*result = -2;
 		return nullptr;
 	}
 
@@ -862,7 +858,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	{
 		fclose(f);
 		printf("%s: KTX file inconsistency: computed surface size is %d bytes, but specified size is %d bytes\n", filename, computed_bytes_of_surface, specified_bytes_of_surface);
-		*result = -5;
 		return nullptr;
 	}
 
@@ -873,7 +868,6 @@ static astc_codec_image* load_ktx_uncompressed_image(
 	{
 		delete[] buf;
 		printf("Failed to read file %s\n", filename);
-		*result = -6;
 		return nullptr;
 	}
 
@@ -909,7 +903,8 @@ static astc_codec_image* load_ktx_uncompressed_image(
 
 	delete[] buf;
 	fill_image_padding_area(astc_img);
-	*result = components + (bitness == 16 ? 0x80 : 0);
+	is_hdr = bitness == 16;
+	num_components = components;
 	return astc_img;
 }
 
@@ -1192,8 +1187,9 @@ struct dds_header_dx10
 astc_codec_image* load_dds_uncompressed_image(
 	const char* filename,
 	int padding,
-	int y_flip,
-	int* result
+	bool y_flip,
+	bool& is_hdr,
+	int& num_components
 ) {
 	int i;
 	int y, z;
@@ -1202,7 +1198,6 @@ astc_codec_image* load_dds_uncompressed_image(
 	if (!f)
 	{
 		printf("Failed to open file %s\n", filename);
-		*result = -1;
 		return nullptr;
 	}
 
@@ -1215,7 +1210,6 @@ astc_codec_image* load_dds_uncompressed_image(
 	{
 		printf("Failed to read header of DDS file %s\n", filename);
 		fclose(f);
-		*result = -2;
 		return nullptr;
 	}
 
@@ -1225,7 +1219,6 @@ astc_codec_image* load_dds_uncompressed_image(
 	{
 		printf("File %s does not have a valid DDS header\n", filename);
 		fclose(f);
-		*result = -3;
 		return nullptr;
 	}
 
@@ -1240,7 +1233,6 @@ astc_codec_image* load_dds_uncompressed_image(
 		{
 			printf("DDS file %s is compressed, not supported\n", filename);
 			fclose(f);
-			*result = -4;
 			return nullptr;
 		}
 	}
@@ -1253,7 +1245,6 @@ astc_codec_image* load_dds_uncompressed_image(
 		{
 			printf("Failed to read header of DDS file %s\n", filename);
 			fclose(f);
-			*result = -2;
 			return nullptr;
 		}
 	}
@@ -1333,7 +1324,6 @@ astc_codec_image* load_dds_uncompressed_image(
 		{
 			printf("DDS file %s: DXGI format not supported by codec\n", filename);
 			fclose(f);
-			*result = -4;
 			return nullptr;
 		}
 	}
@@ -1422,7 +1412,6 @@ astc_codec_image* load_dds_uncompressed_image(
 		{
 			printf("DDS file %s: Non-DXGI format not supported by codec\n", filename);
 			fclose(f);
-			*result = -4;
 			return nullptr;
 		}
 
@@ -1441,7 +1430,6 @@ astc_codec_image* load_dds_uncompressed_image(
 	{
 		delete[] buf;
 		printf("Failed to read file %s\n", filename);
-		*result = -6;
 		return nullptr;
 	}
 
@@ -1468,7 +1456,8 @@ astc_codec_image* load_dds_uncompressed_image(
 
 	delete[] buf;
 	fill_image_padding_area(astc_img);
-	*result = components + (bitness == 16 ? 0x80 : 0);
+	is_hdr = bitness;
+	num_components = components;
 	return astc_img;
 }
 
@@ -1738,7 +1727,7 @@ we use tinyexr; for TGA, BMP and PNG, we use stb_image_write.
 static const struct {
 	const char *ending1;
 	const char *ending2;
-	astc_codec_image *(*loader_func)(const char *filename, int padding, int y_flip, int *load_result);
+	astc_codec_image *(*loader_func)(const char *filename, int padding, bool y_flip, bool& is_hdr, int& num_components);
 } loader_descs[] = {
 	// HDR formats
 	{".exr",   ".EXR",  load_image_with_tinyexr },
@@ -1808,9 +1797,10 @@ int get_output_filename_enforced_bitness(
 astc_codec_image* astc_codec_load_image(
 	const char* input_filename,
 	int padding,
-	int y_flip,
-	int linearize_srgb,
-	int* load_result
+	bool y_flip,
+	bool linearize_srgb,
+	bool& is_hdr,
+	int& num_components
 ) {
 	// get hold of the filename ending
 	const char* eptr = strrchr(input_filename, '.');
@@ -1826,7 +1816,7 @@ astc_codec_image* astc_codec_load_image(
 			|| strcmp(eptr, loader_descs[i].ending1) == 0
 			|| strcmp(eptr, loader_descs[i].ending2) == 0)
 		{
-			astc_codec_image* img = loader_descs[i].loader_func(input_filename, padding, y_flip, load_result);
+			astc_codec_image* img = loader_descs[i].loader_func(input_filename, padding, y_flip, is_hdr, num_components);
 			if (img)
 			{
 				img->linearize_srgb = linearize_srgb;

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <vector>
 
 #ifdef DEBUG_CAPTURE_NAN
 	#ifndef _GNU_SOURCE
@@ -398,6 +399,165 @@ static void test_inappropriate_cpu_extensions()
 		}
 	#endif
 }
+
+/**
+ * @brief Utility to generate a slice file name from a pattern.
+ *
+ * Convert "foo/bar.png" in to "foo/bar_<slice>.png"
+ *
+ * @param basename The base pattern; must contain a file extension.
+ * @param index    The slice index.
+ * @param error    Set to true on success, false on error (no extension found).
+ *
+ * @return The slice file name.
+ */
+static std::string get_slice_filename(
+	const std::string& basename,
+	unsigned int index,
+	bool& error
+) {
+	error = false;
+
+	size_t sep = basename.find_last_of(".");
+	if (sep == std::string::npos)
+	{
+		error = true;
+		return "";
+	}
+
+	std::string base = basename.substr(0, sep);
+	std::string ext = basename.substr(sep);
+
+	std::string name = base + "_" + std::to_string(index) + ext;
+	return name;
+}
+
+/**
+ * @brief Load a non-astc image file from memory.
+ *
+ * @param filename           The file to load, or a pattern for array loads.
+ * @param dim_z              The number of slices to load.
+ * @param padding            The number of texels of padding.
+ * @param y_flip             Should this image be Y flipped?
+ * @param linearize_srgb     Should this image be Y flipped?
+ * @param img_is_hdr         Is the loaded image HDR?
+ * @param img_num_components How many components in the loaded image?
+ *
+ * @return The astc image file, or nullptr is the load failed.
+ */
+static astc_codec_image* load_decomp_file(
+	const char* filename,
+	unsigned int dim_z,
+	int padding,
+	bool y_flip,
+	bool linearize_srgb,
+	bool& img_is_hdr,
+	int& img_num_components
+) {
+	int load_result = 0;
+	astc_codec_image *image = nullptr;
+
+	// For a 2D image just load the image directly
+	if (dim_z == 1)
+	{
+		image = astc_codec_load_image(filename, padding, y_flip, linearize_srgb, &load_result);
+	}
+	else
+	{
+		int slice_result = 0;
+		astc_codec_image* slice = nullptr;
+		std::vector<astc_codec_image*> slices;
+
+		// For a 3D image load an array of slices
+		for (unsigned int image_index = 0; image_index < dim_z; image_index++)
+		{
+			bool error;
+			std::string slice_name = get_slice_filename(filename, image_index, error);
+			if (error)
+			{
+				printf("ERROR: Image pattern does not contain an extension: %s\n", filename);
+				break;
+			}
+
+			slice = astc_codec_load_image(slice_name.c_str(), padding, y_flip, linearize_srgb, &slice_result);
+			if (!slice)
+			{
+				break;
+			}
+
+			assert(slice_result != 0);
+			slices.push_back(slice);
+
+			// Check it is not a 3D image
+			if (slice->zsize != 1)
+			{
+				printf("ERROR: Image arrays do not support 3D sources: %s\n", slice_name.c_str());
+				break;
+			}
+
+			// Check slices are consistent with each other
+			if (image_index != 0)
+			{
+				if (load_result != slice_result)
+				{
+					printf("ERROR: Image array[0] and [%d] are different formats\n", image_index);
+					break;
+				}
+
+				if ((slices[0]->xsize != slice->xsize) ||
+				    (slices[0]->ysize != slice->ysize) ||
+				    (slices[0]->zsize != slice->zsize))
+				{
+					printf("ERROR: Image array[0] and [%d] are different dimensions\n", image_index);
+					break;
+				}
+			}
+			else
+			{
+				load_result = slice_result;
+			}
+		}
+
+		// If all slices loaded correctly then repack them into a single image
+		if (slices.size() == dim_z)
+		{
+			unsigned int dim_x = slices[0]->xsize;
+			unsigned int dim_y = slices[0]->ysize;
+			int bitness = (load_result & 0x80) ? 16 : 8;
+			int slice_size = (dim_x + (2 * padding)) * (dim_y + (2 * padding));
+
+			image = alloc_image(bitness, dim_x, dim_y, dim_y, padding);
+
+			// Combine 2D source images into one 3D image; skipping padding slices
+			for (unsigned int z = padding; z < dim_z + padding; z++)
+			{
+				if (bitness == 8)
+				{
+					size_t copy_size = slice_size * 4 * sizeof(uint8_t);
+					memcpy(*image->data8[z], *slices[z - padding]->data8[0], copy_size);
+				}
+				else
+				{
+					size_t copy_size = slice_size * 4 * sizeof(uint16_t);
+					memcpy(*image->data16[z], *slices[z - padding]->data16[0], copy_size);
+				}
+			}
+
+			// Fill in the padding slices with clamped data
+			fill_image_padding_area(image);
+		}
+
+		for (auto &i : slices)
+		{
+			free_image(i);
+		}
+	}
+
+	img_num_components = load_result & 7;
+	img_is_hdr = (bool)(load_result & 0x80);
+	return image;
+}
+
 
 int astc_main(
 	int argc,
@@ -1144,6 +1304,12 @@ int astc_main(
 		}
 	}
 
+	astc_codec_image* input_decomp_img = nullptr ;
+	int input_decomp_img_num_chan = 0;
+	bool input_decomp_img_is_hdr = false;
+
+	astc_codec_image* output_decomp_img = nullptr;
+
 	int padding = MAX(ewp.mean_stdev_radius, ewp.alpha_radius);
 
 	// determine encoding bitness as follows:
@@ -1156,133 +1322,18 @@ int astc_main(
 		out_bitness = is_hdr ? 16 : 8;
 	}
 
-	// Temporary image array (for merging multiple 2D images into one 3D image).
-	int load_result = 0;
-	astc_codec_image *input_decomp_img = nullptr;
-	//astc_compressed_image *input_comp_img = nullptr;
-	astc_codec_image *output_decomp_img = nullptr;
-	//astc_compressed_image *output_comp_img = nullptr;
-
-	int input_components = 0;
-	int input_image_is_hdr = 0;
-
-	// Load uncompressed inputs
 	if (op_mode == ASTC_ENCODE || op_mode == ASTC_ENCODE_AND_DECODE)
 	{
-		// Allocate temporary arrays for image data and load results
-		int* load_results = new int [array_size];
-		astc_codec_image** input_images = new astc_codec_image* [array_size];
-
-		// Iterate over all input images
-		for (int image_index = 0; image_index < array_size; image_index++)
-		{
-			// 2D input data
-			if (array_size == 1)
-			{
-				input_images[image_index] = astc_codec_load_image(
-					input_filename, padding, y_flip, linearize_srgb,
-					&load_results[image_index]);
-			}
-			// 3D input data - multiple 2D images
-			else
-			{
-				// TODO: These can overflow if the file name is longer than 256
-				char new_input_filename[256];
-
-				// Check for extension: <name>.<extension>
-				if (!strrchr(input_filename, '.'))
-				{
-					printf("ERROR: Unable to determine file extension: %s\n", input_filename);
-					return 1;
-				}
-
-				// Construct new file name and load: <name>_N.<extension>
-				strcpy(new_input_filename, input_filename);
-				sprintf(strrchr(new_input_filename, '.'), "_%d%s", image_index, strrchr(input_filename, '.'));
-				input_images[image_index] = astc_codec_load_image
-					(new_input_filename, padding, y_flip, linearize_srgb,
-					&load_results[image_index]);
-
-				// If image loaded correctly, check image is not 3D.
-				if ((load_results[image_index] >= 0) &&
-				    (input_images[image_index]->zsize != 1))
-				{
-					printf("3D source images not supported with -array option: %s\n", new_input_filename);
-					return 1;
-				}
-			}
-
-			// Check load result.
-			if (load_results[image_index] < 0)
-			{
-				return 1;
-			}
-
-			// Check format matches other slices.
-			if (load_results[image_index] != load_results[0])
-			{
-				printf("Mismatching image format - image 0 and %d are a different format\n", image_index);
-				return 1;
-			}
-		}
-
-		load_result = load_results[0];
-
-		// Assign input image.
-		if (array_size == 1)
-		{
-			input_decomp_img = input_images[0];
-		}
-		// Merge input image data.
-		else
-		{
-			int z, xsize, ysize, zsize, bitness, slice_size;
-
-			xsize = input_images[0]->xsize;
-			ysize = input_images[0]->ysize;
-			zsize = array_size;
-			bitness = (load_result & 0x80) ? 16 : 8;
-			slice_size = (xsize + (2 * padding)) * (ysize + (2 * padding));
-
-			// Allocate image memory.
-			input_decomp_img = alloc_image(bitness, xsize, ysize, zsize, padding);
-
-			// Combine 2D source images into one 3D image (skip padding slices as these don't exist in 2D textures).
-			for (z = padding; z < zsize + padding; z++)
-			{
-				if (bitness == 8)
-				{
-					memcpy(*input_decomp_img->data8[z], *input_images[z - padding]->data8[0], slice_size * 4 * sizeof(uint8_t));
-				}
-				else
-				{
-					memcpy(*input_decomp_img->data16[z], *input_images[z - padding]->data16[0], slice_size * 4 * sizeof(uint16_t));
-				}
-			}
-
-			// Clean up temporary images.
-			for (int i = 0; i < array_size; i++)
-			{
-				free_image(input_images[i]);
-			}
-
-			// Clamp texels outside the actual image area.
-			fill_image_padding_area(input_decomp_img);
-		}
-
-		delete[] input_images;
-		input_images = nullptr;
-
-		delete[] load_results;
-		load_results = nullptr;
-
-		input_components = load_result & 7;
-		input_image_is_hdr = (load_result & 0x80) ? 1 : 0;
-
-		if ((input_decomp_img->zsize > 1) && (block_z == 1))
+		if ((array_size > 1) && (block_z == 1))
 		{
 			printf("ERROR: 3D input data for a 2D ASTC block format\n");
-			exit(1);
+			return 1;
+		}
+
+		input_decomp_img = load_decomp_file(input_filename, array_size, padding, y_flip, linearize_srgb, input_decomp_img_is_hdr, input_decomp_img_num_chan);
+		if (!input_decomp_img)
+		{
+			return 1;
 		}
 
 		ewp.texel_avg_error_limit = texel_avg_error_limit;
@@ -1293,7 +1344,7 @@ int astc_main(
 			printf("Source image\n");
 			printf("============\n\n");
 			printf("    Source:                     %s\n", input_filename);
-			printf("    Color profile:              %s\n", input_image_is_hdr ? "HDR" : "LDR");
+			printf("    Color profile:              %s\n", input_decomp_img_is_hdr ? "HDR" : "LDR");
 			if (input_decomp_img->zsize > 1)
 			{
 				printf("    Dimensions:                 3D, %d x %d x %d\n",
@@ -1304,7 +1355,7 @@ int astc_main(
 				printf("    Dimensions:                 2D, %d x %d\n",
 				       input_decomp_img->xsize, input_decomp_img->ysize);
 			}
-			printf("    Channels:                   %d\n\n", load_result & 7);
+			printf("    Channels:                   %d\n\n", input_decomp_img_num_chan);
 		}
 
 		if (padding > 0 ||
@@ -1370,7 +1421,7 @@ int astc_main(
 	// print PSNR if encoding
 	if (op_mode == ASTC_ENCODE_AND_DECODE)
 	{
-		compute_error_metrics(input_image_is_hdr, input_components, input_decomp_img, output_decomp_img, low_fstop, high_fstop);
+		compute_error_metrics(input_decomp_img_is_hdr, input_decomp_img_num_chan, input_decomp_img, output_decomp_img, low_fstop, high_fstop);
 	}
 
 	// store image

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -445,7 +445,7 @@ static std::string get_slice_filename(
  *
  * @return The astc image file, or nullptr on error.
  */
-static astc_codec_image* load_decomp_file(
+static astc_codec_image* load_uncomp_file(
 	const char* filename,
 	unsigned int dim_z,
 	int padding,
@@ -1201,29 +1201,20 @@ int astc_main(
 		return 1;
 	}
 
-	float texel_avg_error_limit = 0.0f;
 	if (op_mode == ASTC_ENCODE || op_mode == ASTC_ENCODE_AND_DECODE)
 	{
-		int partitions_to_test = plimit_set;
-		float oplimit = oplimit_set;
-		float mincorrel = mincorrel_set;
-
-		int maxiters = maxiters_set;
-		ewp.max_refinement_iters = maxiters;
+		ewp.max_refinement_iters = maxiters_set;
 		ewp.block_mode_cutoff = bmc_set / 100.0f;
 
+		ewp.texel_avg_error_limit = 0.0f;
 		if ((decode_mode == ASTCENC_PRF_LDR) || (decode_mode == ASTCENC_PRF_LDR_SRGB))
 		{
-			texel_avg_error_limit = powf(0.1f, dblimit_set * 0.1f) * 65535.0f * 65535.0f;
-		}
-		else
-		{
-			texel_avg_error_limit = 0.0f;
+			ewp.texel_avg_error_limit = powf(0.1f, dblimit_set * 0.1f) * 65535.0f * 65535.0f;
 		}
 
-		ewp.partition_1_to_2_limit = oplimit;
-		ewp.lowest_correlation_cutoff = mincorrel;
-		ewp.partition_search_limit = astc::clampi(partitions_to_test, 1, PARTITION_COUNT);
+		ewp.partition_1_to_2_limit = oplimit_set;
+		ewp.lowest_correlation_cutoff = mincorrel_set;
+		ewp.partition_search_limit = astc::clampi(plimit_set, 1, PARTITION_COUNT);
 
 		if (thread_count < 1)
 		{
@@ -1233,11 +1224,13 @@ int astc_main(
 		// Specifying the error weight of a color component as 0 is not allowed.
 		// If weights are 0, then they are instead set to a small positive value.
 		float max_color_component_weight = MAX(MAX(ewp.rgba_weights[0], ewp.rgba_weights[1]),
-											   MAX(ewp.rgba_weights[2], ewp.rgba_weights[3]));
+		                                       MAX(ewp.rgba_weights[2], ewp.rgba_weights[3]));
 		ewp.rgba_weights[0] = MAX(ewp.rgba_weights[0], max_color_component_weight / 1000.0f);
 		ewp.rgba_weights[1] = MAX(ewp.rgba_weights[1], max_color_component_weight / 1000.0f);
 		ewp.rgba_weights[2] = MAX(ewp.rgba_weights[2], max_color_component_weight / 1000.0f);
 		ewp.rgba_weights[3] = MAX(ewp.rgba_weights[3], max_color_component_weight / 1000.0f);
+
+		expand_block_artifact_suppression(block_x, block_y, block_z, &ewp);
 
 		// print all encoding settings unless specifically told otherwise.
 		if (!silentmode)
@@ -1295,8 +1288,8 @@ int astc_main(
 			printf("    Deblock artifact setting:   %g\n", (double)ewp.block_artifact_suppression);
 			printf("    Block partition cutoff:     %d partitions\n", ewp.partition_search_limit);
 			printf("    PSNR cutoff:                %g dB\n", (double)dblimit_set);
-			printf("    1->2 partition cutoff:      %g\n", (double)oplimit);
-			printf("    2 plane correlation cutoff: %g\n", (double)mincorrel_set);
+			printf("    1->2 partition cutoff:      %g\n", (double)ewp.partition_1_to_2_limit);
+			printf("    2 plane correlation cutoff: %g\n", (double)ewp.lowest_correlation_cutoff);
 			printf("    Block mode centile cutoff:  %g%%\n", (double)(ewp.block_mode_cutoff * 100.0f));
 			printf("    Max refinement cutoff:      %d iterations\n", ewp.max_refinement_iters);
 			printf("    Compressor thread count:    %d\n", thread_count);
@@ -1304,133 +1297,148 @@ int astc_main(
 		}
 	}
 
-	astc_codec_image* input_decomp_img = nullptr ;
-	int input_decomp_img_num_chan = 0;
-	bool input_decomp_img_is_hdr = false;
-
-	astc_codec_image* output_decomp_img = nullptr;
-
 	int padding = MAX(ewp.mean_stdev_radius, ewp.alpha_radius);
 
-	// determine encoding bitness as follows:
-	// if enforced by the output format, follow the output format's result
-	// else use decode_mode to pick bitness.
-	int out_bitness = (op_mode == ASTC_DECODE || op_mode == ASTC_ENCODE_AND_DECODE) ? get_output_filename_enforced_bitness(output_filename) : -1;
-	if (out_bitness == -1)
-	{
-		bool is_hdr = (decode_mode == ASTCENC_PRF_HDR) || (decode_mode == ASTCENC_PRF_HDR_RGB_LDR_A);
-		out_bitness = is_hdr ? 16 : 8;
-	}
 
-	if (op_mode == ASTC_ENCODE || op_mode == ASTC_ENCODE_AND_DECODE)
+	// Flatten out the list of operations we need to perform
+	bool stage_compress = (op_mode == ASTC_ENCODE) || (op_mode == ASTC_ENCODE_AND_DECODE);
+	bool stage_decompress = (op_mode == ASTC_DECODE) || (op_mode == ASTC_ENCODE_AND_DECODE);
+	bool stage_load_uncomp = stage_compress;
+	bool stage_load_comp = op_mode == ASTC_DECODE;
+	bool stage_compare = op_mode == ASTC_ENCODE_AND_DECODE;
+	bool stage_store_comp = op_mode == ASTC_ENCODE;
+	bool stage_store_decomp = stage_decompress;
+
+	astc_codec_image* image_uncomp_in = nullptr ;
+	int image_uncomp_in_num_chan = 0;
+	bool image_uncomp_in_is_hdr = false;
+
+	astc_compressed_image image_comp;
+
+	astc_codec_image* image_decomp_out = nullptr;
+
+	// TODO: Handle RAII resources so they get freed when out of scope
+
+	// Load the uncompressed input file if needed
+	if (stage_load_uncomp)
 	{
+		// TODO: This can be moved to command line parsing
 		if ((array_size > 1) && (block_z == 1))
 		{
 			printf("ERROR: 3D input data for a 2D ASTC block format\n");
 			return 1;
 		}
 
-		input_decomp_img = load_decomp_file(input_filename, array_size, padding, y_flip, linearize_srgb, input_decomp_img_is_hdr, input_decomp_img_num_chan);
-		if (!input_decomp_img)
+		image_uncomp_in = load_uncomp_file(input_filename, array_size, padding, y_flip, linearize_srgb,
+		                                   image_uncomp_in_is_hdr, image_uncomp_in_num_chan);
+		if (!image_uncomp_in)
 		{
 			return 1;
 		}
-
-		ewp.texel_avg_error_limit = texel_avg_error_limit;
-		expand_block_artifact_suppression(block_x, block_y, block_z, &ewp);
 
 		if (!silentmode)
 		{
 			printf("Source image\n");
 			printf("============\n\n");
 			printf("    Source:                     %s\n", input_filename);
-			printf("    Color profile:              %s\n", input_decomp_img_is_hdr ? "HDR" : "LDR");
-			if (input_decomp_img->zsize > 1)
+			printf("    Color profile:              %s\n", image_uncomp_in_is_hdr ? "HDR" : "LDR");
+			if (image_uncomp_in->zsize > 1)
 			{
 				printf("    Dimensions:                 3D, %d x %d x %d\n",
-				       input_decomp_img->xsize, input_decomp_img->ysize, input_decomp_img->zsize);
+				       image_uncomp_in->xsize, image_uncomp_in->ysize, image_uncomp_in->zsize);
 			}
 			else
 			{
 				printf("    Dimensions:                 2D, %d x %d\n",
-				       input_decomp_img->xsize, input_decomp_img->ysize);
+				       image_uncomp_in->xsize, image_uncomp_in->ysize);
 			}
-			printf("    Channels:                   %d\n\n", input_decomp_img_num_chan);
+			printf("    Channels:                   %d\n\n", image_uncomp_in_num_chan);
 		}
+	}
 
-		if (padding > 0 ||
-		    ewp.rgb_mean_weight != 0.0f || ewp.rgb_stdev_weight != 0.0f ||
-		    ewp.alpha_mean_weight != 0.0f || ewp.alpha_stdev_weight != 0.0f)
+	// Load the compressed input file if needed
+	if (stage_load_comp)
+	{
+		int error = load_astc_file(input_filename, image_comp);
+		if (error)
 		{
-			compute_averages_and_variances(
-				input_decomp_img,
-				ewp.rgb_power,
-				ewp.alpha_power,
-				ewp.mean_stdev_radius,
-				ewp.alpha_radius,
-				linearize_srgb,
-				swz_encode,
-				thread_count);
+			return 1;
 		}
 	}
 
 	start_coding_time = get_time();
 
-	if (op_mode == ASTC_DECODE)
+	// Compress an image
+	if (stage_compress)
 	{
-		astc_compressed_image comp_img;
-		int error = load_astc_file(input_filename, comp_img);
-		if (error)
+		if (padding > 0 ||
+		    ewp.rgb_mean_weight != 0.0f || ewp.rgb_stdev_weight != 0.0f ||
+		    ewp.alpha_mean_weight != 0.0f || ewp.alpha_stdev_weight != 0.0f)
 		{
-			return 1;
+			compute_averages_and_variances(image_uncomp_in, ewp.rgb_power, ewp.alpha_power,
+			                               ewp.mean_stdev_radius, ewp.alpha_radius, linearize_srgb,
+			                               swz_encode, thread_count);
 		}
 
-		output_decomp_img = decompress_astc_image(
-		    comp_img, out_bitness, decode_mode, swz_decode,
-		    linearize_srgb);
-
-		delete[] comp_img.data;
-	}
-
-	// process image, if relevant
-	if (op_mode == ASTC_ENCODE_AND_DECODE)
-	{
-		int xsize = input_decomp_img->xsize;
-		int ysize = input_decomp_img->ysize;
-		int zsize = input_decomp_img->zsize;
+		int xsize = image_uncomp_in->xsize;
+		int ysize = image_uncomp_in->ysize;
+		int zsize = image_uncomp_in->zsize;
 		int xblocks = (xsize + block_x - 1) / block_x;
 		int yblocks = (ysize + block_y - 1) / block_y;
 		int zblocks = (zsize + block_z - 1) / block_z;
 		uint8_t* buffer = new uint8_t [xblocks * yblocks * zblocks * 16];
-		compress_astc_image(input_decomp_img, block_x, block_y, block_z, &ewp, decode_mode, swz_encode, buffer, thread_count);
+		compress_astc_image(image_uncomp_in, block_x, block_y, block_z, &ewp, decode_mode,
+		                    swz_encode, buffer, thread_count);
 
-		astc_compressed_image comp_img {
-			block_x, block_y, block_z,
-			xsize, ysize, zsize,
-			buffer
-		};
+		image_comp.block_x = block_x;
+		image_comp.block_y = block_y;
+		image_comp.block_z = block_z;
+		image_comp.dim_x = xsize;
+		image_comp.dim_y = ysize;
+		image_comp.dim_z = zsize;
+		image_comp.data = buffer;
+	}
 
-		output_decomp_img = decompress_astc_image(
-		    comp_img, out_bitness, decode_mode, swz_decode, 0);
+	// Decompress an image
+	if (stage_decompress)
+	{
+		int out_bitness = get_output_filename_enforced_bitness(output_filename);
+		if (out_bitness == -1)
+		{
+			bool is_hdr = (decode_mode == ASTCENC_PRF_HDR) || (decode_mode == ASTCENC_PRF_HDR_RGB_LDR_A);
+			out_bitness = is_hdr ? 16 : 8;
+		}
 
-		delete[] buffer;
+		image_decomp_out = decompress_astc_image(
+		    image_comp, out_bitness, decode_mode, swz_decode, linearize_srgb);
 	}
 
 	end_coding_time = get_time();
 
-	// print PSNR if encoding
-	if (op_mode == ASTC_ENCODE_AND_DECODE)
+	// Print metrics in comparison mode
+	if (stage_compare)
 	{
-		compute_error_metrics(input_decomp_img_is_hdr, input_decomp_img_num_chan, input_decomp_img, output_decomp_img, low_fstop, high_fstop);
+		compute_error_metrics(image_uncomp_in_is_hdr, image_uncomp_in_num_chan, image_uncomp_in,
+		                      image_decomp_out, low_fstop, high_fstop);
 	}
 
-	// store image
-	if (op_mode == ASTC_DECODE || op_mode == ASTC_ENCODE_AND_DECODE)
+	// Store compressed image
+	if (stage_store_comp)
+	{
+		int error = store_astc_file(image_comp, output_filename);
+		if (error)
+		{
+			return 1;
+		}
+	}
+
+	// Store decompressed image
+	if (stage_store_decomp)
 	{
 		int store_result = -1;
 		const char *format_string = "";
 
-		store_result = astc_codec_store_image(output_decomp_img, output_filename, &format_string, y_flip);
+		store_result = astc_codec_store_image(image_decomp_out, output_filename, &format_string, y_flip);
 		if (store_result < 0)
 		{
 			printf("ERROR: Failed to write output image %s\n", output_filename);
@@ -1438,36 +1446,13 @@ int astc_main(
 		}
 	}
 
-	if (op_mode == ASTC_ENCODE)
-	{
-		int xsize = input_decomp_img->xsize;
-		int ysize = input_decomp_img->ysize;
-		int zsize = input_decomp_img->zsize;
-		int xblocks = (xsize + block_x - 1) / block_x;
-		int yblocks = (ysize + block_y - 1) / block_y;
-		int zblocks = (zsize + block_z - 1) / block_z;
-		uint8_t* buffer = new uint8_t [xblocks * yblocks * zblocks * 16];
-		compress_astc_image(input_decomp_img, block_x, block_y, block_z, &ewp, decode_mode, swz_encode, buffer, thread_count);
+	free_image(image_uncomp_in);
+	free_image(image_decomp_out);
+	delete[] image_comp.data;
 
-		end_coding_time = get_time();
-
-		astc_compressed_image comp_img {
-			block_x, block_y, block_z,
-			xsize, ysize, zsize,
-			buffer
-		};
-
-		int error = store_astc_file(comp_img, output_filename);
-		if (error)
-		{
-			return 1;
-		}
-	}
-
-	free_image(input_decomp_img);
 	end_time = get_time();
 
-	if (op_mode == ASTC_ENCODE_AND_DECODE || !silentmode)
+	if (stage_compare || !silentmode)
 	{
 		printf("Coding time\n");
 		printf("===========\n\n");

--- a/Source/astcenccli_toplevel_help.cpp
+++ b/Source/astcenccli_toplevel_help.cpp
@@ -361,11 +361,14 @@ ADVANCED COMPRESSION
            Convert input images from sRGB to linear RGB before compression,
            and output images from linear RGB to sRGB after decompression.
            For compression, the transform is applied after any swizzle; for
-           decode, the transform is applied before any swizzle.
+           decode, the transform is applied before any swizzle. Note that
+           using this option in a test mode (-t*) will have no obvious
+           effect as the image will be converted twice, although some image
+           precision loss may occur.
 
            Note that this switch is only intended for diagnostic purposes;
            real use cases should directly compress/decompress sRGB data
-           using the ASTC LDR sRGB format, using the -cs, -ds, and -ts
+           using the LDR sRGB profile, using the -cs, -ds, and -ts
            operation modes. This preserves more perceptual image quality.
 
        -yflip

--- a/Test/astc_test_functional.py
+++ b/Test/astc_test_functional.py
@@ -488,7 +488,10 @@ class CLIPTest(CLITestBase):
 
         # Emit debug logging if needed
         if ASTCENC_CLI_ALWAYS or (error and ASTCENC_CLI_ON_ERROR):
-            print(" ".join(command))
+            # Format for shell replay
+            print("\n" + " ".join(command))
+            # Format for script command list replay
+            print("\n" + ", ".join(("\"%s\"" % x for x in command)))
 
         if ASTCENC_LOG_ALWAYS or (error and ASTCENC_LOG_ON_ERROR):
             print(result.stdout)
@@ -1342,7 +1345,7 @@ class CLIPTest(CLITestBase):
         # Test time should get slower with fewer threads
         self.assertGreater(testTime, refTime)
 
-    def test_linearize_srgb1(self):
+    def test_linearize_srgb_compress(self):
         """
         Test linearize srgb on compression.
 
@@ -1376,7 +1379,7 @@ class CLIPTest(CLITestBase):
         self.assertColorSame(refColors[:3], srgbColors[:3], threshold=0.05)
         self.assertColorSame(refColors[3:], srgbColors[3:], threshold=0.0)
 
-    def test_linearize_srgb2(self):
+    def test_linearize_srgb_decompress(self):
         """
         Test linearize srgb on decompression.
 
@@ -1410,13 +1413,13 @@ class CLIPTest(CLITestBase):
         self.assertColorSame(refColors[:3], linColors[:3], threshold=0.05)
         self.assertColorSame(refColors[3:], linColors[3:], threshold=0.0)
 
-    def test_linearize_srgb3(self):
+    def test_linearize_srgb_roundtrip(self):
         """
         Test linearize srgb on round-trip.
 
-        This should behave the same as linearizing with compression only; i.e.
-        we convert to linear before compression, but we do NOT sRGB encode the
-        output after decompression.
+        This linearizes on input, and converts back to sRGB on output, so
+        overall no conversion should occur. There may be some precision
+        losses however.
         """
         inputFile = "./Test/Data/Tiles/ldr.png"
         decompFile = self.get_tmp_image_path("LDR", "decomp")
@@ -1433,11 +1436,10 @@ class CLIPTest(CLITestBase):
 
         img = tli.Image(decompFile)
         testColors = img.get_colors((7, 7))
-        srgbColors = self.to_srgb_color(testColors)
 
         # Test we get a match within 5% on the RGB channels, exact on alpha
-        self.assertColorSame(refColors[:3], srgbColors[:3], threshold=0.05)
-        self.assertColorSame(refColors[3:], srgbColors[3:], threshold=0.0)
+        self.assertColorSame(refColors[:3], testColors[:3], threshold=0.0)
+        self.assertColorSame(refColors[3:], testColors[3:], threshold=0.0)
 
     def test_silent(self):
         """
@@ -1507,7 +1509,10 @@ class CLINTest(CLITestBase):
         badResult = (error == expectPass) or (rcode < 0)
 
         if ASTCENC_CLI_ALWAYS or (badResult and ASTCENC_CLI_ON_ERROR_NEG):
-            print(" ".join(command))
+            # Format for shell replay
+            print("\n" + " ".join(command))
+            # Format for script command list replay
+            print("\n" + ", ".join(("\"%s\"" % x for x in command)))
 
         if ASTCENC_LOG_ALWAYS or (badResult and ASTCENC_LOG_ON_ERROR_NEG):
             print(result.stdout)


### PR DESCRIPTION
This patch refactors the CLI use of the codec into a number of ordered passes, which are selected based on the operation being used. This removes duplicated code, and makes it easier to migrate to the new API. 

This change also forces a decision on what we do with #102, for which I've decided that the round-trip functionality for -linsrgb should match the -yflip (i.e. change twice and end up back where you started). This includes this change and fixes the tests. 