### PR TITLE
Optimize trials of using 2/3 partitions and two planes of weights

### DIFF
--- a/Docs/Analysis.md
+++ b/Docs/Analysis.md
@@ -1,10 +1,10 @@
 # astcenc 2.1 optimization log
 
-This page is a working document explaining the my current understanding of the
+This page is a working document explaining the current understanding of the
 performance and quality impact of some of the compression trials, refinement
 passes, and the heuristics which drive them. To make things easier to
 cross-reference, I've inserted some comments in the code to identify passes
-that I've analyzed.
+that have been analyzed.
 
 This information will hopefully allow as "tuned up" a future version of the
 codec. At the moment it's just research.

--- a/Docs/Analysis.md
+++ b/Docs/Analysis.md
@@ -1,0 +1,26 @@
+# astcenc 2.0 analysis
+
+This page is a working document explaining my current understanding of the
+performance and quality impact of some of the compression trials, refinement
+passes, and the heuristics which drive them. To make things easier to
+cross-reference, I've inserted some comments in the code to identify passes
+that I've analyzed.
+
+This information will hopefully allow as "tuned up" a future version of the
+codec. At the moment it's just research.
+
+## Configuration sensitivity
+
+The most important thing to know for this analysis is that the impact of each
+trial and refinement can vary dramatically depending on the codec
+configuration. Principally this means:
+
+* block size,
+* quality preset,
+* image color format.
+
+For example, removing the initial 1 partition 1 plane fast-early-out
+optimization actually improves the performance of 4x4 blocks in `-fast` and
+`-medium`. However, it makes 5x5 blocks marginally slower and the slow down
+increases as block size increases.
+

--- a/Docs/Analysis.md
+++ b/Docs/Analysis.md
@@ -1,6 +1,6 @@
-# astcenc 2.0 analysis
+# astcenc 2.1 optimization log
 
-This page is a working document explaining my current understanding of the
+This page is a working document explaining the my current understanding of the
 performance and quality impact of some of the compression trials, refinement
 passes, and the heuristics which drive them. To make things easier to
 cross-reference, I've inserted some comments in the code to identify passes
@@ -24,3 +24,33 @@ optimization actually improves the performance of 4x4 blocks in `-fast` and
 `-medium`. However, it makes 5x5 blocks marginally slower and the slow down
 increases as block size increases.
 
+
+## Optimization one: Only search one component for 2/3 partition dual plane
+
+astcenc 2.0 checks the two color components that are least correlated when
+testing for use of second plane of weights.
+
+The first change made during the review is to change this to check only the
+least correlated color component when encoding two partitions. This causes
+negligible quality impact (< 0.008 dB) when using `-fast` and `-medium`,
+and slightly larger with `-thorough`. It buys up to ~10% performance
+improvement for `-medium`, so it is a significant optimization.
+
+Performance improvement depends on block size; it helps larger block sizes
+more than smaller once.
+
+Kodak: 4x4
+  Coding time:    Mean: +1.01x    Std: 0.02x
+  Image quality:  Mean: -0.00 dB  Std: 0.00 dB
+
+Kodak: 6x6
+  Coding time:    Mean: +1.07x    Std: 0.03x
+  Image quality:  Mean: -0.00 dB  Std: 0.00 dB
+
+Kodak: 8x8
+  Coding time:    Mean: +1.08x    Std: 0.03x
+  Image quality:  Mean: -0.00 dB  Std: 0.00 dB
+
+This optimizations also allows some simplification of the implementation of
+`find_best_partitionings()` as we only have to manage and return a single
+result.

--- a/Docs/Analysis.md
+++ b/Docs/Analysis.md
@@ -2,12 +2,11 @@
 
 This page is a working document explaining the current understanding of the
 performance and quality impact of some of the compression trials, refinement
-passes, and the heuristics which drive them. To make things easier to
-cross-reference, I've inserted some comments in the code to identify passes
-that have been analyzed.
+passes, and the heuristics which drive them.
 
-This information will hopefully allow as "tuned up" a future version of the
-codec. At the moment it's just research.
+This information will hopefully allow a "tuned up" future version of the codec.
+It includes a mixture of both ongoing research, and a log of optimizations
+that have been applied during the current post-2.0 development.
 
 ## Configuration sensitivity
 

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -779,7 +779,6 @@ void find_best_partitionings(
 	int partition_count,
 	const imageblock* pb,
 	const error_weight_block* ewb,
-	int candidates_to_return,
 	int* best_partitions_uncorrelated,
 	int* best_partitions_samechroma,
 	int* best_partitions_dual_weight_planes);

--- a/Test/testlib/resultset.py
+++ b/Test/testlib/resultset.py
@@ -120,14 +120,14 @@ class ResultSummary():
         result = ["\nSet Status: %s (Pass: %u | Warn: %u | Fail: %u)" % dat]
 
         # Performance summaries
-        dat = (np.mean(self.tTimes), np.var(self.tTimes))
-        result.append("\nTotal time:     Mean: %+0.2fx    Var: %0.2fx" % dat)
+        dat = (np.mean(self.tTimes), np.std(self.tTimes))
+        result.append("\nTotal time:     Mean: %+0.2fx    Std: %0.2fx" % dat)
 
-        dat = (np.mean(self.cTimes), np.var(self.cTimes))
-        result.append("Coding time:    Mean: %+0.2fx    Var: %0.2fx" % dat)
+        dat = (np.mean(self.cTimes), np.std(self.cTimes))
+        result.append("Coding time:    Mean: %+0.2fx    Std: %0.2fx" % dat)
 
-        dat = (np.mean(self.psnrs), np.var(self.psnrs))
-        result.append("Image quality:  Mean: %+0.2f dB  Var: %0.2f dB" % dat)
+        dat = (np.mean(self.psnrs), np.std(self.psnrs))
+        result.append("Image quality:  Mean: %+0.2f dB  Std: %0.2f dB" % dat)
 
         return "\n".join(result)
 


### PR DESCRIPTION
In the original code running trials for 2 or 3 partitions using two planes of weights, two different color components were tested as candidates for the second weight plane. The second component is rarely a good candidate, so the IQ benefits of this are tiny given the processing cost. 

For the Kodak test set with `-medium` compression we get an average of 8% performance improvement, for negligible quality loss (< 0.01 dB). 

```
Coding time:    Mean: +1.08x    Std: 0.03x
Image quality:  Mean: -0.00 dB  Std: 0.00 dB
```

There is a larger quality impact for `-through` and `-exhaustive` - although it is still very small (0.03 dB) - in particular for normal maps. However, in reality no developers are really using those search modes in production as they are far too slow so this seems acceptable. 