### PR TITLE
Skip dual weight plane searches for luminance-only blocks

### DIFF
--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1399,7 +1399,7 @@ float compress_symbolic_block(
 		// * Blocks with higher component correlation than the tuning cutoff
 		if ((partition_count == 4) ||
 		    (blk->grayscale && !uses_alpha) ||
-			(lowest_correl > ctx.config.tune_two_plane_early_out_limit))
+		    (lowest_correl > ctx.config.tune_two_plane_early_out_limit))
 		{
 			continue;
 		}

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1393,19 +1393,19 @@ float compress_symbolic_block(
 			goto END_OF_TESTS;
 		}
 
-		// don't bother to check 4 partitions for dual plane of weights, ever.
-		if (partition_count == 4)
+		// Skip testing dual weight planes for:
+		// * 4 partitions (can't be encoded by the format)
+		// * Luminance only blocks (never need for a second plane)
+		// * Blocks with higher component correlation than the tuning cutoff
+		if ((partition_count == 4) ||
+		    (blk->grayscale && !uses_alpha) ||
+			(lowest_correl > ctx.config.tune_two_plane_early_out_limit))
 		{
-			break;
+			continue;
 		}
 
 		for (int i = 0; i < 2; i++)
 		{
-			if (lowest_correl > ctx.config.tune_two_plane_early_out_limit)
-			{
-				continue;
-			}
-
 			compress_symbolic_block_fixed_partition_2_planes(decode_mode,
 															 mode_cutoff,
 															 ctx.config.tune_refinement_limit,


### PR DESCRIPTION
If you are using the luminance CEM, you will never need a second weight plane as you are only storing a single color value in the endpoint. This change early-outs the second weight plane search, giving substantial performance improvements to these block types, with +18% performance for a texture compressed using `-medium` and +30% for a texture compressed using `-thorough`. 

There is no image quality impact for this optimization; the work was completely redundant in this case.