### PR TITLE
Avoid 1 partition 1 plane early-out for small blocks

### DIFF
--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1237,7 +1237,7 @@ float compress_symbolic_block(
 	// then with the specified mode cutoff. This causes an early-out that
 	// speeds up encoding of easy blocks. However, this optimization is
 	// disabled for 4x4 and 5x4 blocks where it nearly always slows down the
-	// compresion and slightly reduces image quality.
+	// compression and slightly reduces image quality.
 
 	float modecutoffs[2];
 	float errorval_mult[2] = { 2.5, 1 };

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1246,8 +1246,7 @@ float compress_symbolic_block(
 
 	float best_errorval_in_mode;
 
-
-	int start_trial = bsd->texel_count < 25 ? 1 : 0;
+	int start_trial = bsd->texel_count < TUNE_MIN_TEXELS_MODE0_FASTPATH ? 1 : 0;
 	for (int i = start_trial; i < 2; i++)
 	{
 		compress_symbolic_block_fixed_partition_1_plane(decode_mode, modecutoffs[i], ctx.config.tune_refinement_limit, bsd, 1,	// partition count

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -59,6 +59,9 @@
 #define MAX_DECIMATION_MODES 87
 #define MAX_WEIGHT_MODES 2048
 
+// Compile-time tuning parameters
+static const int TUNE_MIN_TEXELS_MODE0_FASTPATH { 25 };
+
 // uncomment this macro to enable checking for inappropriate NaNs;
 // works on Linux only, and slows down encoding significantly.
 // #define DEBUG_CAPTURE_NAN


### PR DESCRIPTION
The optimization is actually actually a de-optimization for both performance and image quality for 4x4 and 5x4 blocks. This PR changes it to be conditional based on current block size.