### PR TITLE
Fix two component normal unpack documentation

### DIFF
--- a/Docs/Encoding.md
+++ b/Docs/Encoding.md
@@ -159,9 +159,10 @@ To encode this we therefore want to store two input channels and should
 therefore use the `rrrg` coding swizzle, and the `.ga` sampling swizzle. The
 OpenGL ES shader code for reconstruction of the Z value is:
 
-    vec3 normal;
-    normal.xy = texture(...).ga;
-    normal.z = sqrt(1 - dot(normal.xy, normal.xy));
+    vec3 nml;
+    nml.xy = texture(...).ga;                // Load normals (range 0 to 1)
+    nml.xy = nml.xy * 2.0f - 1.0f;           // Unpack normals (range -1 to +1)
+    nml.z = sqrt(1 - dot(nml.xy, nml.xy));   // Compute Z, given unit length
 
 In addition to this it is useful to optimize for angular error in the resulting
 vector rather than for absolute color error in the data, which improves the

--- a/Test/astc_test_result_report.py
+++ b/Test/astc_test_result_report.py
@@ -235,9 +235,9 @@ def print_result_set(imageSet, quality, encoders, results, printHeader):
 
         dr = DeltaRecord(imageSet, quality, encoders, recordSet)
 
-        if first:
+        if printHeader:
             print(dr.get_full_row_header_csv())
-            first = False
+            printHeader = False
 
         print(dr.get_full_row_csv())
 
@@ -260,7 +260,7 @@ def main():
         qualitySet = sorted(qualityTree.keys())
 
         for qual in qualitySet:
-            encoderTree = qualityTree[quality]
+            encoderTree = qualityTree[qual]
             encoderSet = sorted(encoderTree.keys())
 
             if len(encoderSet) > 1:


### PR DESCRIPTION
At some point in the editorial process the normal unpack step to convert from 0-1 unorm to -1 to +1 signed was lost.