### PR TITLE
QE-2134: Remove Artifactory promote

### DIFF
--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -177,7 +177,6 @@ pipeline {
           steps {
             zip zipFile: 'astcenc.zip', dir: 'upload', archive: false
             cepeArtifactoryUpload(sourcePattern: '*.zip')
-            cepeArtifactoryPromote()
           }
         }
       }


### PR DESCRIPTION
We are no longer using this method to promote release builds.