### PR TITLE
QE-2141: Update Jenkins shared libs for Artifactory Housekeeping job

### DIFF
--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('hive-infra-library@changes/18/246018/1') _
+@Library('hive-infra-library@changes/91/265891/1') _
 
 pipeline {
   agent none

--- a/jenkins/dockerimage.Jenkinsfile
+++ b/jenkins/dockerimage.Jenkinsfile
@@ -1,3 +1,3 @@
-@Library('hive-infra-library@changes/18/246018/1') _
+@Library('hive-infra-library@master') _
 
 dockerBuildImage('jenkins/build.Dockerfile', 'astcenc')


### PR DESCRIPTION
Updates to shared library to stop removing artefacts from Artifactory when the builds are removed. 
Artefact housekeeping will be performed separately in the future.