### PR TITLE
More SIMD optimizations (optimize determine_optimal_set_of_endpoint_formats_to_use, compute_ideal_quantized_weights_for_decimation_table)

### DIFF
--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -1024,10 +1024,10 @@ struct alignas(ASTCENC_VECALIGN) compress_fixed_partition_buffers
 	endpoints_and_weights ei2;
 	endpoints_and_weights eix1[MAX_DECIMATION_MODES];
 	endpoints_and_weights eix2[MAX_DECIMATION_MODES];
-	float decimated_quantized_weights[2 * MAX_DECIMATION_MODES * MAX_WEIGHTS_PER_BLOCK];
-	float decimated_weights[2 * MAX_DECIMATION_MODES * MAX_WEIGHTS_PER_BLOCK];
-	float flt_quantized_decimated_quantized_weights[2 * MAX_WEIGHT_MODES * MAX_WEIGHTS_PER_BLOCK];
-	uint8_t u8_quantized_decimated_quantized_weights[2 * MAX_WEIGHT_MODES * MAX_WEIGHTS_PER_BLOCK];
+	alignas(ASTCENC_VECALIGN) float decimated_quantized_weights[2 * MAX_DECIMATION_MODES * MAX_WEIGHTS_PER_BLOCK];
+	alignas(ASTCENC_VECALIGN) float decimated_weights[2 * MAX_DECIMATION_MODES * MAX_WEIGHTS_PER_BLOCK];
+	alignas(ASTCENC_VECALIGN) float flt_quantized_decimated_quantized_weights[2 * MAX_WEIGHT_MODES * MAX_WEIGHTS_PER_BLOCK];
+	alignas(ASTCENC_VECALIGN) uint8_t u8_quantized_decimated_quantized_weights[2 * MAX_WEIGHT_MODES * MAX_WEIGHTS_PER_BLOCK];
 };
 
 struct compress_symbolic_block_buffers

--- a/Source/astcenc_pick_best_endpoint_format.cpp
+++ b/Source/astcenc_pick_best_endpoint_format.cpp
@@ -972,22 +972,22 @@ void determine_optimal_set_of_endpoint_formats_to_use(
 			}
 		}
 #else
-        // find best mode, SIMD N-wide way
-        vint vbest_error_index(-1);
-        vfloat vbest_ep_error(1e30f);
-        vint lane_ids = vint::lane_id();
+		// find best mode, SIMD N-wide way
+		vint vbest_error_index(-1);
+		vfloat vbest_ep_error(1e30f);
+		vint lane_ids = vint::lane_id();
 		for (int j = 0; j < MAX_WEIGHT_MODES; j += ASTCENC_SIMD_WIDTH)
 		{
-            vfloat err = vfloat(&errors_of_best_combination[j]);
-            vmask mask1 = err < vbest_ep_error;
-            vmask mask2 = vint(&best_quantization_levels[j]) > vint(4);
-            vmask mask = mask1 & mask2;
-            vbest_ep_error = select(vbest_ep_error, err, mask);
-            vbest_error_index = select(vbest_error_index, lane_ids, mask);
-            lane_ids = lane_ids + vint(ASTCENC_SIMD_WIDTH);
+			vfloat err = vfloat(&errors_of_best_combination[j]);
+			vmask mask1 = err < vbest_ep_error;
+			vmask mask2 = vint(&best_quantization_levels[j]) > vint(4);
+			vmask mask = mask1 & mask2;
+			vbest_ep_error = select(vbest_ep_error, err, mask);
+			vbest_error_index = select(vbest_error_index, lane_ids, mask);
+			lane_ids = lane_ids + vint(ASTCENC_SIMD_WIDTH);
 		}
-        
-        // pick final best mode from the SIMD result.
+
+		// pick final best mode from the SIMD result.
 		// note that if multiple SIMD lanes have "best" score,
 		// we want to pick one with the lowest index, i.e. what
 		// would happen if code was purely scalar.

--- a/Source/astcenc_pick_best_endpoint_format.cpp
+++ b/Source/astcenc_pick_best_endpoint_format.cpp
@@ -813,7 +813,7 @@ void determine_optimal_set_of_endpoint_formats_to_use(
 		    format_of_choice[i]);
 	}
 
-	float errors_of_best_combination[MAX_WEIGHT_MODES];
+	alignas(ASTCENC_VECALIGN) float errors_of_best_combination[MAX_WEIGHT_MODES];
 	int best_quantization_levels[MAX_WEIGHT_MODES];
 	int best_quantization_levels_mod[MAX_WEIGHT_MODES];
 	int best_ep_formats[MAX_WEIGHT_MODES][4];
@@ -973,6 +973,7 @@ void determine_optimal_set_of_endpoint_formats_to_use(
 		}
 #else
 		// find best mode, SIMD N-wide way
+		static_assert((MAX_WEIGHT_MODES % ASTCENC_SIMD_WIDTH) == 0, "MAX_WEIGHT_MODES should be multiple of ASTCENC_SIMD_WIDTH");
 		vint vbest_error_index(-1);
 		vfloat vbest_ep_error(1e30f);
 		vint lane_ids = vint::lane_id();

--- a/Source/astcenc_pick_best_endpoint_format.cpp
+++ b/Source/astcenc_pick_best_endpoint_format.cpp
@@ -814,7 +814,7 @@ void determine_optimal_set_of_endpoint_formats_to_use(
 	}
 
 	alignas(ASTCENC_VECALIGN) float errors_of_best_combination[MAX_WEIGHT_MODES];
-	int best_quantization_levels[MAX_WEIGHT_MODES];
+	alignas(ASTCENC_VECALIGN) int best_quantization_levels[MAX_WEIGHT_MODES];
 	int best_quantization_levels_mod[MAX_WEIGHT_MODES];
 	int best_ep_formats[MAX_WEIGHT_MODES][4];
 

--- a/Source/astcenc_vecmathlib.h
+++ b/Source/astcenc_vecmathlib.h
@@ -29,17 +29,17 @@
 #endif
 
 #if defined(_MSC_VER)
-#define SIMD_INLINE __forceinline
+	#define SIMD_INLINE __forceinline
 #else
-#define SIMD_INLINE __attribute__((unused, always_inline, nodebug)) inline
+	#define SIMD_INLINE __attribute__((unused, always_inline, nodebug)) inline
 #endif
 
 #if ASTCENC_AVX >= 2
-    #define ASTCENC_SIMD_ISA_AVX2
+	#define ASTCENC_SIMD_ISA_AVX2
 #elif ASTCENC_SSE >= 20
-    #define ASTCENC_SIMD_ISA_SSE
+	#define ASTCENC_SIMD_ISA_SSE
 #else
-    #define ASTCENC_SIMD_ISA_SCALAR
+	#define ASTCENC_SIMD_ISA_SCALAR
 #endif
 
 
@@ -53,72 +53,72 @@
 // N-wide float
 struct vfloat
 {
-    SIMD_INLINE vfloat() {}
+	SIMD_INLINE vfloat() {}
 	// Initialize with N floats from an unaligned memory address.
 	// Using loada() when address is aligned might be more optimal.
-    SIMD_INLINE explicit vfloat(const float *p) { m = _mm256_loadu_ps(p); }
+	SIMD_INLINE explicit vfloat(const float *p) { m = _mm256_loadu_ps(p); }
 	// Initialize with the same given float value in all lanes.
-    SIMD_INLINE explicit vfloat(float v) { m = _mm256_set1_ps(v); }
+	SIMD_INLINE explicit vfloat(float v) { m = _mm256_set1_ps(v); }
 
-    SIMD_INLINE explicit vfloat(__m256 v) { m = v; }
+	SIMD_INLINE explicit vfloat(__m256 v) { m = v; }
 
 	// Get SIMD lane #i value.
-    SIMD_INLINE float lane(int i) const
-    {
-        #ifdef _MSC_VER
-        return m.m256_f32[i];
-        #else
-        union { __m256 m; float f[ASTCENC_SIMD_WIDTH]; } cvt;
-        cvt.m = m;
-        return cvt.f[i];
-        #endif
-    }
-	
-	// Float vector with all zero values
-    static SIMD_INLINE vfloat zero() { return vfloat(_mm256_setzero_ps()); }
-	
-	// Float vector with each lane having the lane index (0, 1, 2, ...)
-    static SIMD_INLINE vfloat lane_id() { return vfloat(_mm256_set_ps(7, 6, 5, 4, 3, 2, 1, 0)); }
+	SIMD_INLINE float lane(int i) const
+	{
+		#ifdef _MSC_VER
+		return m.m256_f32[i];
+		#else
+		union { __m256 m; float f[ASTCENC_SIMD_WIDTH]; } cvt;
+		cvt.m = m;
+		return cvt.f[i];
+		#endif
+	}
 
-    __m256 m;
+	// Float vector with all zero values
+	static SIMD_INLINE vfloat zero() { return vfloat(_mm256_setzero_ps()); }
+
+	// Float vector with each lane having the lane index (0, 1, 2, ...)
+	static SIMD_INLINE vfloat lane_id() { return vfloat(_mm256_set_ps(7, 6, 5, 4, 3, 2, 1, 0)); }
+
+	__m256 m;
 };
 
 // N-wide integer (32 bit in each lane)
 struct vint
 {
-    SIMD_INLINE vint() {}
+	SIMD_INLINE vint() {}
 	// Initialize with N ints from an unaligned memory address.
-    SIMD_INLINE explicit vint(const int *p) { m = _mm256_loadu_si256((const __m256i*)p); }
+	SIMD_INLINE explicit vint(const int *p) { m = _mm256_loadu_si256((const __m256i*)p); }
 	// Initialize with the same given integer value in all lanes.
-    SIMD_INLINE explicit vint(int v) { m = _mm256_set1_epi32(v); }
+	SIMD_INLINE explicit vint(int v) { m = _mm256_set1_epi32(v); }
 
-    SIMD_INLINE explicit vint(__m256i v) { m = v; }
+	SIMD_INLINE explicit vint(__m256i v) { m = v; }
 
 	// Get SIMD lane #i value
-    SIMD_INLINE int lane(int i) const
-    {
-        #ifdef _MSC_VER
-        return m.m256i_i32[i];
-        #else
-        union { __m256i m; int f[ASTCENC_SIMD_WIDTH]; } cvt;
-        cvt.m = m;
-        return cvt.f[i];
-        #endif
-    }
+	SIMD_INLINE int lane(int i) const
+	{
+		#ifdef _MSC_VER
+		return m.m256i_i32[i];
+		#else
+		union { __m256i m; int f[ASTCENC_SIMD_WIDTH]; } cvt;
+		cvt.m = m;
+		return cvt.f[i];
+		#endif
+	}
 
 	// Integer vector with each lane having the lane index (0, 1, 2, ...)
-    static SIMD_INLINE vint lane_id() { return vint(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0)); }
+	static SIMD_INLINE vint lane_id() { return vint(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0)); }
 
-    __m256i m;
+	__m256i m;
 };
 
 // N-wide comparison mask. vmask is a result of comparison operators,
 // and an argument for select() function below.
 struct vmask
 {
-    SIMD_INLINE explicit vmask(__m256 v) { m = v; }
+	SIMD_INLINE explicit vmask(__m256 v) { m = v; }
 	SIMD_INLINE explicit vmask(__m256i v) { m = _mm256_castsi256_ps(v); }
-    __m256 m;
+	__m256 m;
 };
 
 // Initialize with one float in all SIMD lanes, from an aligned memory address.
@@ -158,15 +158,15 @@ SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = _mm256_max_ps(a.m, b.m); retu
 // Per-lane clamp to 0..1 range
 SIMD_INLINE vfloat saturate(vfloat a)
 {
-    __m256 zero = _mm256_setzero_ps();
-    __m256 one = _mm256_set1_ps(1.0f);
-    return vfloat(_mm256_min_ps(_mm256_max_ps(a.m, zero), one));
+	__m256 zero = _mm256_setzero_ps();
+	__m256 one = _mm256_set1_ps(1.0f);
+	return vfloat(_mm256_min_ps(_mm256_max_ps(a.m, zero), one));
 }
 
 // Round to nearest integer (nearest even for .5 cases)
 SIMD_INLINE vfloat round(vfloat v)
 {
-    return vfloat(_mm256_round_ps(v.m, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+	return vfloat(_mm256_round_ps(v.m, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
 }
 
 // Per-lane convert to integer (truncate)
@@ -196,18 +196,18 @@ SIMD_INLINE vint max(vint a, vint b) { a.m = _mm256_max_epi32(a.m, b.m); return 
 // set to the minimum value of the input vector.
 SIMD_INLINE vfloat hmin(vfloat v)
 {
-    __m128 vlow  = _mm256_castps256_ps128(v.m);
-    __m128 vhigh = _mm256_extractf128_ps(v.m, 1);
-           vlow  = _mm_min_ps(vlow, vhigh);
+	__m128 vlow  = _mm256_castps256_ps128(v.m);
+	__m128 vhigh = _mm256_extractf128_ps(v.m, 1);
+		   vlow  = _mm_min_ps(vlow, vhigh);
 
-    // First do an horizontal reduction.                                // v = [ D C | B A ]
-    __m128 shuf = _mm_shuffle_ps(vlow, vlow, _MM_SHUFFLE(2, 3, 0, 1));  //     [ C D | A B ]
-    __m128 mins = _mm_min_ps(vlow, shuf);                            // mins = [ D+C C+D | B+A A+B ]
-    shuf        = _mm_movehl_ps(shuf, mins);                         //        [   C   D | D+C C+D ]
-    mins        = _mm_min_ss(mins, shuf);
+	// First do an horizontal reduction.                                // v = [ D C | B A ]
+	__m128 shuf = _mm_shuffle_ps(vlow, vlow, _MM_SHUFFLE(2, 3, 0, 1));  //     [ C D | A B ]
+	__m128 mins = _mm_min_ps(vlow, shuf);                            // mins = [ D+C C+D | B+A A+B ]
+	shuf        = _mm_movehl_ps(shuf, mins);                         //        [   C   D | D+C C+D ]
+	mins        = _mm_min_ss(mins, shuf);
 
-    vfloat vmin(_mm256_permute_ps(_mm256_set_m128(mins, mins), 0)); // _MM256_PERMUTE(0, 0, 0, 0, 0, 0, 0, 0)
-    return vmin;
+	vfloat vmin(_mm256_permute_ps(_mm256_set_m128(mins, mins), 0)); // _MM256_PERMUTE(0, 0, 0, 0, 0, 0, 0, 0)
+	return vmin;
 }
 
 SIMD_INLINE vint hmin(vint v)
@@ -216,8 +216,8 @@ SIMD_INLINE vint hmin(vint v)
 	m = _mm_min_epi32(m, _mm_shuffle_epi32(m, _MM_SHUFFLE(0,0,3,2)));
 	m = _mm_min_epi32(m, _mm_shuffle_epi32(m, _MM_SHUFFLE(0,0,0,1)));
 	m = _mm_shuffle_epi32(m, _MM_SHUFFLE(0,0,0,0));
-    vint vmin(_mm256_set_m128i(m, m));
-    return vmin;
+	vint vmin(_mm256_set_m128i(m, m));
+	return vmin;
 }
 
 // Store float vector into an aligned address.
@@ -231,32 +231,32 @@ SIMD_INLINE void store_nbytes(vint v, uint8_t* ptr) { _mm_storeu_si64(ptr, _mm25
 // SIMD "gather" - load each lane with base[indices[i]]
 SIMD_INLINE vfloat gatherf(const float* base, vint indices)
 {
-    return vfloat(_mm256_i32gather_ps(base, indices.m, 4));
+	return vfloat(_mm256_i32gather_ps(base, indices.m, 4));
 }
 SIMD_INLINE vint gatheri(const int* base, vint indices)
 {
-    return vint(_mm256_i32gather_epi32(base, indices.m, 4));
+	return vint(_mm256_i32gather_epi32(base, indices.m, 4));
 }
 
 // Pack low 8 bits of each lane into low 64 bits of result.
 SIMD_INLINE vint pack_low_bytes(vint v)
 {
-    __m256i shuf = _mm256_set_epi8(0,0,0,0,0,0,0,0, 0,0,0,0,28,24,20,16, 0,0,0,0,0,0,0,0, 0,0,0,0,12,8,4,0);
+	__m256i shuf = _mm256_set_epi8(0,0,0,0,0,0,0,0, 0,0,0,0,28,24,20,16, 0,0,0,0,0,0,0,0, 0,0,0,0,12,8,4,0);
 	__m256i a = _mm256_shuffle_epi8(v.m, shuf);
 	__m128i a0 = _mm256_extracti128_si256(a, 0);
 	__m128i a1 = _mm256_extracti128_si256(a, 1);
 	__m128i b = _mm_unpacklo_epi32(a0, a1);
-    return vint(_mm256_set_m128i(b, b));
+	return vint(_mm256_set_m128i(b, b));
 }
 
 // "select", i.e. highbit(cond) ? b : a
 SIMD_INLINE vfloat select(vfloat a, vfloat b, vmask cond)
 {
-    return vfloat(_mm256_blendv_ps(a.m, b.m, cond.m));
+	return vfloat(_mm256_blendv_ps(a.m, b.m, cond.m));
 }
 SIMD_INLINE vint select(vint a, vint b, vmask cond)
 {
-    return vint(_mm256_blendv_epi8(a.m, b.m, _mm256_castps_si256(cond.m)));
+	return vint(_mm256_blendv_epi8(a.m, b.m, _mm256_castps_si256(cond.m)));
 }
 
 SIMD_INLINE void print(vfloat a)
@@ -289,50 +289,50 @@ SIMD_INLINE void print(vint a)
 
 struct vfloat
 {
-    SIMD_INLINE vfloat() {}
-    SIMD_INLINE explicit vfloat(const float *p) { m = _mm_loadu_ps(p); }
-    SIMD_INLINE explicit vfloat(float v) { m = _mm_set_ps1(v); }
-    SIMD_INLINE explicit vfloat(__m128 v) { m = v; }
-    SIMD_INLINE float lane(int i) const
-    {
-        #ifdef _MSC_VER
-        return m.m128_f32[i];
-        #else
-        union { __m128 m; float f[ASTCENC_SIMD_WIDTH]; } cvt;
-        cvt.m = m;
-        return cvt.f[i];
-        #endif
-    }
-    static SIMD_INLINE vfloat zero() { return vfloat(_mm_setzero_ps()); }
-    static SIMD_INLINE vfloat lane_id() { return vfloat(_mm_set_ps(3, 2, 1, 0)); }
-    __m128 m;
+	SIMD_INLINE vfloat() {}
+	SIMD_INLINE explicit vfloat(const float *p) { m = _mm_loadu_ps(p); }
+	SIMD_INLINE explicit vfloat(float v) { m = _mm_set_ps1(v); }
+	SIMD_INLINE explicit vfloat(__m128 v) { m = v; }
+	SIMD_INLINE float lane(int i) const
+	{
+		#ifdef _MSC_VER
+		return m.m128_f32[i];
+		#else
+		union { __m128 m; float f[ASTCENC_SIMD_WIDTH]; } cvt;
+		cvt.m = m;
+		return cvt.f[i];
+		#endif
+	}
+	static SIMD_INLINE vfloat zero() { return vfloat(_mm_setzero_ps()); }
+	static SIMD_INLINE vfloat lane_id() { return vfloat(_mm_set_ps(3, 2, 1, 0)); }
+	__m128 m;
 };
 
 struct vint
 {
-    SIMD_INLINE vint() {}
-    SIMD_INLINE explicit vint(const int *p) { m = _mm_load_si128((const __m128i*)p); }
-    SIMD_INLINE explicit vint(int v) { m = _mm_set1_epi32(v); }
-    SIMD_INLINE explicit vint(__m128i v) { m = v; }
-    SIMD_INLINE int lane(int i) const
-    {
-        #ifdef _MSC_VER
-        return m.m128i_i32[i];
-        #else
-        union { __m128i m; int f[ASTCENC_SIMD_WIDTH]; } cvt;
-        cvt.m = m;
-        return cvt.f[i];
-        #endif
-    }
-    static SIMD_INLINE vint lane_id() { return vint(_mm_set_epi32(3, 2, 1, 0)); }
-    __m128i m;
+	SIMD_INLINE vint() {}
+	SIMD_INLINE explicit vint(const int *p) { m = _mm_load_si128((const __m128i*)p); }
+	SIMD_INLINE explicit vint(int v) { m = _mm_set1_epi32(v); }
+	SIMD_INLINE explicit vint(__m128i v) { m = v; }
+	SIMD_INLINE int lane(int i) const
+	{
+		#ifdef _MSC_VER
+		return m.m128i_i32[i];
+		#else
+		union { __m128i m; int f[ASTCENC_SIMD_WIDTH]; } cvt;
+		cvt.m = m;
+		return cvt.f[i];
+		#endif
+	}
+	static SIMD_INLINE vint lane_id() { return vint(_mm_set_epi32(3, 2, 1, 0)); }
+	__m128i m;
 };
 
 struct vmask
 {
-    SIMD_INLINE explicit vmask(__m128 v) { m = v; }
+	SIMD_INLINE explicit vmask(__m128 v) { m = v; }
 	SIMD_INLINE explicit vmask(__m128i v) { m = _mm_castsi128_ps(v); }
-    __m128 m;
+	__m128 m;
 };
 
 
@@ -360,29 +360,29 @@ SIMD_INLINE vfloat min(vfloat a, vfloat b) { a.m = _mm_min_ps(a.m, b.m); return 
 SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = _mm_max_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat saturate(vfloat a)
 {
-    __m128 zero = _mm_setzero_ps();
-    __m128 one = _mm_set1_ps(1.0f);
-    return vfloat(_mm_min_ps(_mm_max_ps(a.m, zero), one));
+	__m128 zero = _mm_setzero_ps();
+	__m128 one = _mm_set1_ps(1.0f);
+	return vfloat(_mm_min_ps(_mm_max_ps(a.m, zero), one));
 }
 
 SIMD_INLINE vfloat round(vfloat v)
 {
 #if ASTCENC_SSE >= 41
-    return vfloat(_mm_round_ps(v.m, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+	return vfloat(_mm_round_ps(v.m, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
 #else
-    __m128 V = v.m;
-    __m128 negZero = _mm_castsi128_ps(_mm_set1_epi32(0x80000000));
-    __m128 noFraction = _mm_set_ps1(8388608.0f);
-    __m128 absMask = _mm_castsi128_ps(_mm_set1_epi32(0x7FFFFFFF));
-    __m128 sign = _mm_and_ps(V, negZero);
-    __m128 sMagic = _mm_or_ps(noFraction, sign);
-    __m128 R1 = _mm_add_ps(V, sMagic);
-    R1 = _mm_sub_ps(R1, sMagic);
-    __m128 R2 = _mm_and_ps(V, absMask);
-    __m128 mask = _mm_cmple_ps(R2, noFraction);
-    R2 = _mm_andnot_ps(mask, V);
-    R1 = _mm_and_ps(R1, mask);
-    return vfloat(_mm_xor_ps(R1, R2));
+	__m128 V = v.m;
+	__m128 negZero = _mm_castsi128_ps(_mm_set1_epi32(0x80000000));
+	__m128 noFraction = _mm_set_ps1(8388608.0f);
+	__m128 absMask = _mm_castsi128_ps(_mm_set1_epi32(0x7FFFFFFF));
+	__m128 sign = _mm_and_ps(V, negZero);
+	__m128 sMagic = _mm_or_ps(noFraction, sign);
+	__m128 R1 = _mm_add_ps(V, sMagic);
+	R1 = _mm_sub_ps(R1, sMagic);
+	__m128 R2 = _mm_and_ps(V, absMask);
+	__m128 mask = _mm_cmple_ps(R2, noFraction);
+	R2 = _mm_andnot_ps(mask, V);
+	R1 = _mm_and_ps(R1, mask);
+	return vfloat(_mm_xor_ps(R1, R2));
 #endif
 }
 
@@ -424,15 +424,15 @@ SIMD_INLINE vint max(vint a, vint b) {
 
 SIMD_INLINE vfloat hmin(vfloat v)
 {
-    v = min(v, ASTCENC_SHUFFLE4F(v, 2, 3, 0, 0));
-    v = min(v, ASTCENC_SHUFFLE4F(v, 1, 0, 0, 0));
-    return ASTCENC_SHUFFLE4F(v, 0,0,0,0);
+	v = min(v, ASTCENC_SHUFFLE4F(v, 2, 3, 0, 0));
+	v = min(v, ASTCENC_SHUFFLE4F(v, 1, 0, 0, 0));
+	return ASTCENC_SHUFFLE4F(v, 0,0,0,0);
 }
 SIMD_INLINE vint hmin(vint v)
 {
-    v = min(v, ASTCENC_SHUFFLE4I(v, 2, 3, 0, 0));
-    v = min(v, ASTCENC_SHUFFLE4I(v, 1, 0, 0, 0));
-    return ASTCENC_SHUFFLE4I(v, 0,0,0,0);
+	v = min(v, ASTCENC_SHUFFLE4I(v, 2, 3, 0, 0));
+	v = min(v, ASTCENC_SHUFFLE4I(v, 1, 0, 0, 0));
+	return ASTCENC_SHUFFLE4I(v, 0,0,0,0);
 }
 
 SIMD_INLINE void store(vfloat v, float* ptr) { _mm_store_ps(ptr, v.m); }
@@ -442,29 +442,29 @@ SIMD_INLINE void store_nbytes(vint v, uint8_t* ptr) { _mm_storeu_si32(ptr, v.m);
 
 SIMD_INLINE vfloat gatherf(const float* base, vint indices)
 {
-    int idx[4];
-    store(indices, idx);
-    return vfloat(_mm_set_ps(base[idx[3]], base[idx[2]], base[idx[1]], base[idx[0]]));
+	int idx[4];
+	store(indices, idx);
+	return vfloat(_mm_set_ps(base[idx[3]], base[idx[2]], base[idx[1]], base[idx[0]]));
 }
 
 SIMD_INLINE vint gatheri(const int* base, vint indices)
 {
-    int idx[4];
-    store(indices, idx);
-    return vint(_mm_set_epi32(base[idx[3]], base[idx[2]], base[idx[1]], base[idx[0]]));
+	int idx[4];
+	store(indices, idx);
+	return vint(_mm_set_epi32(base[idx[3]], base[idx[2]], base[idx[1]], base[idx[0]]));
 }
 
 // packs low 8 bits of each lane into low 32 bits of result
 SIMD_INLINE vint pack_low_bytes(vint v)
 {
-    #if ASTCENC_SSE >= 41
-    __m128i shuf = _mm_set_epi8(0,0,0,0, 0,0,0,0, 0,0,0,0, 12,8,4,0);
-    return vint(_mm_shuffle_epi8(v.m, shuf));
-    #else
-    __m128i va = _mm_unpacklo_epi8(v.m, _mm_shuffle_epi32(v.m, _MM_SHUFFLE(1,1,1,1)));
-    __m128i vb = _mm_unpackhi_epi8(v.m, _mm_shuffle_epi32(v.m, _MM_SHUFFLE(3,3,3,3)));
-    return vint(_mm_unpacklo_epi16(va, vb));
-    #endif
+	#if ASTCENC_SSE >= 41
+	__m128i shuf = _mm_set_epi8(0,0,0,0, 0,0,0,0, 0,0,0,0, 12,8,4,0);
+	return vint(_mm_shuffle_epi8(v.m, shuf));
+	#else
+	__m128i va = _mm_unpacklo_epi8(v.m, _mm_shuffle_epi32(v.m, _MM_SHUFFLE(1,1,1,1)));
+	__m128i vb = _mm_unpackhi_epi8(v.m, _mm_shuffle_epi32(v.m, _MM_SHUFFLE(3,3,3,3)));
+	return vint(_mm_unpacklo_epi16(va, vb));
+	#endif
 }
 
 // "select", i.e. highbit(cond) ? b : a
@@ -474,21 +474,21 @@ SIMD_INLINE vint pack_low_bytes(vint v)
 SIMD_INLINE vfloat select(vfloat a, vfloat b, vmask cond)
 {
 #if ASTCENC_SSE >= 41
-    a.m = _mm_blendv_ps(a.m, b.m, cond.m);
+	a.m = _mm_blendv_ps(a.m, b.m, cond.m);
 #else
-    __m128 d = _mm_castsi128_ps(_mm_srai_epi32(_mm_castps_si128(cond.m), 31));
-    a.m = _mm_or_ps(_mm_and_ps(d, b.m), _mm_andnot_ps(d, a.m));
+	__m128 d = _mm_castsi128_ps(_mm_srai_epi32(_mm_castps_si128(cond.m), 31));
+	a.m = _mm_or_ps(_mm_and_ps(d, b.m), _mm_andnot_ps(d, a.m));
 #endif
-    return a;
+	return a;
 }
 
 SIMD_INLINE vint select(vint a, vint b, vmask cond)
 {
 #if ASTCENC_SSE >= 41
-    return vint(_mm_blendv_epi8(a.m, b.m, _mm_castps_si128(cond.m)));
+	return vint(_mm_blendv_epi8(a.m, b.m, _mm_castps_si128(cond.m)));
 #else
-    __m128i d = _mm_srai_epi32(_mm_castps_si128(cond.m), 31);
-    return vint(_mm_or_si128(_mm_and_si128(d, b.m), _mm_andnot_si128(d, a.m)));
+	__m128i d = _mm_srai_epi32(_mm_castps_si128(cond.m), 31);
+	return vint(_mm_or_si128(_mm_and_si128(d, b.m), _mm_andnot_si128(d, a.m)));
 #endif
 }
 
@@ -521,29 +521,29 @@ SIMD_INLINE void print(vint a)
 
 struct vfloat
 {
-    SIMD_INLINE vfloat() {}
-    SIMD_INLINE explicit vfloat(const float *p) { m = *p; }
-    SIMD_INLINE explicit vfloat(float v) { m = v; }
-    SIMD_INLINE float lane(int i) const { return m; }
-    static SIMD_INLINE vfloat zero() { return vfloat(0.0f); }
-    static SIMD_INLINE vfloat lane_id() { return vfloat(0.0f); }
-    float m;
+	SIMD_INLINE vfloat() {}
+	SIMD_INLINE explicit vfloat(const float *p) { m = *p; }
+	SIMD_INLINE explicit vfloat(float v) { m = v; }
+	SIMD_INLINE float lane(int i) const { return m; }
+	static SIMD_INLINE vfloat zero() { return vfloat(0.0f); }
+	static SIMD_INLINE vfloat lane_id() { return vfloat(0.0f); }
+	float m;
 };
 
 struct vint
 {
-    SIMD_INLINE vint() {}
-    SIMD_INLINE explicit vint(const int *p) { m = *p; }
-    SIMD_INLINE explicit vint(int v) { m = v; }
-    SIMD_INLINE int lane(int i) const { return m; }
-    static SIMD_INLINE vint lane_id() { return vint(0); }
-    int m;
+	SIMD_INLINE vint() {}
+	SIMD_INLINE explicit vint(const int *p) { m = *p; }
+	SIMD_INLINE explicit vint(int v) { m = v; }
+	SIMD_INLINE int lane(int i) const { return m; }
+	static SIMD_INLINE vint lane_id() { return vint(0); }
+	int m;
 };
 
 struct vmask
 {
-    SIMD_INLINE explicit vmask(bool v) { m = v; }
-    bool m;
+	SIMD_INLINE explicit vmask(bool v) { m = v; }
+	bool m;
 };
 
 
@@ -572,7 +572,7 @@ SIMD_INLINE vfloat saturate(vfloat a) { return vfloat(std::min(std::max(a.m,0.0f
 
 SIMD_INLINE vfloat round(vfloat v)
 {
-    return vfloat(std::floor(v.m + 0.5f));
+	return vfloat(std::floor(v.m + 0.5f));
 }
 
 SIMD_INLINE vint floatToInt(vfloat v) { return vint(v.m); }
@@ -599,28 +599,28 @@ SIMD_INLINE void store_nbytes(vint v, uint8_t* ptr) { *ptr = (uint8_t)v.m; }
 
 SIMD_INLINE vfloat gatherf(const float* base, vint indices)
 {
-    return vfloat(base[indices.m]);
+	return vfloat(base[indices.m]);
 }
 SIMD_INLINE vint gatheri(const int* base, vint indices)
 {
-    return vint(base[indices.m]);
+	return vint(base[indices.m]);
 }
 
 // packs low 8 bits of each lane into low 8 bits of result (a no-op in scalar code path)
 SIMD_INLINE vint pack_low_bytes(vint v)
 {
-    return v;
+	return v;
 }
 
 
 // "select", i.e. highbit(cond) ? b : a
 SIMD_INLINE vfloat select(vfloat a, vfloat b, vmask cond)
 {
-    return cond.m ? b : a;
+	return cond.m ? b : a;
 }
 SIMD_INLINE vint select(vint a, vint b, vmask cond)
 {
-    return cond.m ? b : a;
+	return cond.m ? b : a;
 }
 
 

--- a/Source/astcenc_vecmathlib.h
+++ b/Source/astcenc_vecmathlib.h
@@ -196,9 +196,9 @@ SIMD_INLINE vint max(vint a, vint b) { a.m = _mm256_max_epi32(a.m, b.m); return 
 // set to the minimum value of the input vector.
 SIMD_INLINE vfloat hmin(vfloat v)
 {
-	__m128 vlow  = _mm256_castps256_ps128(v.m);
+	__m128 vlow = _mm256_castps256_ps128(v.m);
 	__m128 vhigh = _mm256_extractf128_ps(v.m, 1);
-		   vlow  = _mm_min_ps(vlow, vhigh);
+    vlow  = _mm_min_ps(vlow, vhigh);
 
 	// First do an horizontal reduction.                                // v = [ D C | B A ]
 	__m128 shuf = _mm_shuffle_ps(vlow, vlow, _MM_SHUFFLE(2, 3, 0, 1));  //     [ C D | A B ]

--- a/Source/astcenc_vecmathlib.h
+++ b/Source/astcenc_vecmathlib.h
@@ -56,7 +56,18 @@ struct vfloat
     SIMD_INLINE explicit vfloat(const float *p) { m = _mm256_loadu_ps(p); }
     SIMD_INLINE explicit vfloat(float v) { m = _mm256_set1_ps(v); }
     SIMD_INLINE explicit vfloat(__m256 v) { m = v; }
-    static vfloat zero() { return vfloat(_mm256_setzero_ps()); }
+    SIMD_INLINE float lane(int i) const
+    {
+        #ifdef _MSC_VER
+        return m.m256_f32[i];
+        #else
+        union { __m256 m; float f[ASTCENC_SIMD_WIDTH]; } cvt;
+        cvt.m = m;
+        return cvt.f[i];
+        #endif
+    }
+    static SIMD_INLINE vfloat zero() { return vfloat(_mm256_setzero_ps()); }
+    static SIMD_INLINE vfloat lane_id() { return vfloat(_mm256_set_ps(7, 6, 5, 4, 3, 2, 1, 0)); }
     __m256 m;
 };
 
@@ -66,7 +77,25 @@ struct vint
     SIMD_INLINE explicit vint(const int *p) { m = _mm256_loadu_si256((const __m256i*)p); }
     SIMD_INLINE explicit vint(int v) { m = _mm256_set1_epi32(v); }
     SIMD_INLINE explicit vint(__m256i v) { m = v; }
+    SIMD_INLINE int lane(int i) const
+    {
+        #ifdef _MSC_VER
+        return m.m256i_i32[i];
+        #else
+        union { __m256i m; int f[ASTCENC_SIMD_WIDTH]; } cvt;
+        cvt.m = m;
+        return cvt.f[i];
+        #endif
+    }
+    static SIMD_INLINE vint lane_id() { return vint(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0)); }
     __m256i m;
+};
+
+struct vmask
+{
+    SIMD_INLINE explicit vmask(__m256 v) { m = v; }
+	SIMD_INLINE explicit vmask(__m256i v) { m = _mm256_castsi256_ps(v); }
+    __m256 m;
 };
 
 SIMD_INLINE vfloat load1a(const float* p) { return vfloat(_mm256_broadcast_ss(p)); }
@@ -75,12 +104,20 @@ SIMD_INLINE vfloat loada(const float* p) { return vfloat(_mm256_load_ps(p)); }
 SIMD_INLINE vfloat operator+ (vfloat a, vfloat b) { a.m = _mm256_add_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator- (vfloat a, vfloat b) { a.m = _mm256_sub_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator* (vfloat a, vfloat b) { a.m = _mm256_mul_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator==(vfloat a, vfloat b) { a.m = _mm256_cmp_ps(a.m, b.m, _CMP_EQ_OQ); return a; }
-SIMD_INLINE vfloat operator!=(vfloat a, vfloat b) { a.m = _mm256_cmp_ps(a.m, b.m, _CMP_NEQ_OQ); return a; }
-SIMD_INLINE vfloat operator< (vfloat a, vfloat b) { a.m = _mm256_cmp_ps(a.m, b.m, _CMP_LT_OQ); return a; }
-SIMD_INLINE vfloat operator> (vfloat a, vfloat b) { a.m = _mm256_cmp_ps(a.m, b.m, _CMP_GT_OQ); return a; }
-SIMD_INLINE vfloat operator<=(vfloat a, vfloat b) { a.m = _mm256_cmp_ps(a.m, b.m, _CMP_LE_OQ); return a; }
-SIMD_INLINE vfloat operator>=(vfloat a, vfloat b) { a.m = _mm256_cmp_ps(a.m, b.m, _CMP_GE_OQ); return a; }
+SIMD_INLINE vmask operator==(vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_EQ_OQ)); }
+SIMD_INLINE vmask operator!=(vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_NEQ_OQ)); }
+SIMD_INLINE vmask operator< (vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_LT_OQ)); }
+SIMD_INLINE vmask operator> (vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_GT_OQ)); }
+SIMD_INLINE vmask operator<=(vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_LE_OQ)); }
+SIMD_INLINE vmask operator>=(vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_GE_OQ)); }
+SIMD_INLINE vmask operator| (vmask a, vmask b) { return vmask(_mm256_or_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator& (vmask a, vmask b) { return vmask(_mm256_and_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator^ (vmask a, vmask b) { return vmask(_mm256_xor_ps(a.m, b.m)); }
+// Returns a 8-bit code where bit0..bit7 map to lanes
+SIMD_INLINE unsigned mask(vmask v) { return _mm256_movemask_ps(v.m); }
+SIMD_INLINE bool any(vmask v) { return mask(v) != 0; }
+SIMD_INLINE bool all(vmask v) { return mask(v) == 0xFF; }
+
 
 SIMD_INLINE vfloat min(vfloat a, vfloat b) { a.m = _mm256_min_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = _mm256_max_ps(a.m, b.m); return a; }
@@ -90,17 +127,35 @@ SIMD_INLINE vfloat round(vfloat v)
     return vfloat(_mm256_round_ps(v.m, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
 }
 
+SIMD_INLINE vfloat hmin(vfloat v)
+{
+    __m128 vlow  = _mm256_castps256_ps128(v.m);
+    __m128 vhigh = _mm256_extractf128_ps(v.m, 1);
+           vlow  = _mm_min_ps(vlow, vhigh);
+
+    // First do an horizontal reduction.                                // v = [ D C | B A ]
+    __m128 shuf = _mm_shuffle_ps(vlow, vlow, _MM_SHUFFLE(2, 3, 0, 1));  //     [ C D | A B ]
+    __m128 mins = _mm_min_ps(vlow, shuf);                            // mins = [ D+C C+D | B+A A+B ]
+    shuf        = _mm_movehl_ps(shuf, mins);                         //        [   C   D | D+C C+D ]
+    mins        = _mm_min_ss(mins, shuf);
+
+    vfloat vmin(_mm256_permute_ps(_mm256_set_m128(mins, mins), 0)); // _MM256_PERMUTE(0, 0, 0, 0, 0, 0, 0, 0)
+    return vmin;
+}
+
 SIMD_INLINE vint floatToInt(vfloat v) { return vint(_mm256_cvtps_epi32(v.m)); }
 
 SIMD_INLINE vfloat intAsFloat(vint v) { return vfloat(_mm256_castsi256_ps(v.m)); }
 
 SIMD_INLINE vint operator~ (vint a) { return vint(_mm256_xor_si256(a.m, _mm256_set1_epi32(-1))); }
+SIMD_INLINE vmask operator~ (vmask a) { return vmask(_mm256_xor_si256(_mm256_castps_si256(a.m), _mm256_set1_epi32(-1))); }
+
 SIMD_INLINE vint operator+ (vint a, vint b) { a.m = _mm256_add_epi32(a.m, b.m); return a; }
 SIMD_INLINE vint operator- (vint a, vint b) { a.m = _mm256_sub_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator<(vint a, vint b) { a.m = _mm256_cmpgt_epi32(b.m, a.m); return a; }
-SIMD_INLINE vint operator>(vint a, vint b) { a.m = _mm256_cmpgt_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator==(vint a, vint b) { a.m = _mm256_cmpeq_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator!=(vint a, vint b) { a.m = _mm256_cmpeq_epi32(a.m, b.m); return ~a; }
+SIMD_INLINE vmask operator< (vint a, vint b) { return vmask(_mm256_cmpgt_epi32(b.m, a.m)); }
+SIMD_INLINE vmask operator> (vint a, vint b) { return vmask(_mm256_cmpgt_epi32(a.m, b.m)); }
+SIMD_INLINE vmask operator==(vint a, vint b) { return vmask(_mm256_cmpeq_epi32(a.m, b.m)); }
+SIMD_INLINE vmask operator!=(vint a, vint b) { return ~vmask(_mm256_cmpeq_epi32(a.m, b.m)); }
 SIMD_INLINE vint min(vint a, vint b) { a.m = _mm256_min_epi32(a.m, b.m); return a; }
 SIMD_INLINE vint max(vint a, vint b) { a.m = _mm256_max_epi32(a.m, b.m); return a; }
 
@@ -109,13 +164,13 @@ SIMD_INLINE void store(vint v, int* ptr) { _mm256_store_si256((__m256i*)ptr, v.m
 
 
 // "select", i.e. highbit(cond) ? b : a
-SIMD_INLINE vfloat select(vfloat a, vfloat b, vfloat cond)
+SIMD_INLINE vfloat select(vfloat a, vfloat b, vmask cond)
 {
     return vfloat(_mm256_blendv_ps(a.m, b.m, cond.m));
 }
-SIMD_INLINE vint select(vint a, vint b, vint cond)
+SIMD_INLINE vint select(vint a, vint b, vmask cond)
 {
-    return vint(_mm256_blendv_epi8(a.m, b.m, cond.m));
+    return vint(_mm256_blendv_epi8(a.m, b.m, _mm256_castps_si256(cond.m)));
 }
 
 SIMD_INLINE void print(vfloat a)
@@ -152,7 +207,18 @@ struct vfloat
     SIMD_INLINE explicit vfloat(const float *p) { m = _mm_loadu_ps(p); }
     SIMD_INLINE explicit vfloat(float v) { m = _mm_set_ps1(v); }
     SIMD_INLINE explicit vfloat(__m128 v) { m = v; }
-    static vfloat zero() { return vfloat(_mm_setzero_ps()); }
+    SIMD_INLINE float lane(int i) const
+    {
+        #ifdef _MSC_VER
+        return m.m128_f32[i];
+        #else
+        union { __m128 m; float f[ASTCENC_SIMD_WIDTH]; } cvt;
+        cvt.m = m;
+        return cvt.f[i];
+        #endif
+    }
+    static SIMD_INLINE vfloat zero() { return vfloat(_mm_setzero_ps()); }
+    static SIMD_INLINE vfloat lane_id() { return vfloat(_mm_set_ps(3, 2, 1, 0)); }
     __m128 m;
 };
 
@@ -162,8 +228,27 @@ struct vint
     SIMD_INLINE explicit vint(const int *p) { m = _mm_load_si128((const __m128i*)p); }
     SIMD_INLINE explicit vint(int v) { m = _mm_set1_epi32(v); }
     SIMD_INLINE explicit vint(__m128i v) { m = v; }
+    SIMD_INLINE int lane(int i) const
+    {
+        #ifdef _MSC_VER
+        return m.m128i_i32[i];
+        #else
+        union { __m128i m; int f[ASTCENC_SIMD_WIDTH]; } cvt;
+        cvt.m = m;
+        return cvt.f[i];
+        #endif
+    }
+    static SIMD_INLINE vint lane_id() { return vint(_mm_set_epi32(3, 2, 1, 0)); }
     __m128i m;
 };
+
+struct vmask
+{
+    SIMD_INLINE explicit vmask(__m128 v) { m = v; }
+	SIMD_INLINE explicit vmask(__m128i v) { m = _mm_castsi128_ps(v); }
+    __m128 m;
+};
+
 
 SIMD_INLINE vfloat load1a(const float* p) { return vfloat(_mm_load_ps1(p)); }
 SIMD_INLINE vfloat loada(const float* p) { return vfloat(_mm_load_ps(p)); }
@@ -171,12 +256,19 @@ SIMD_INLINE vfloat loada(const float* p) { return vfloat(_mm_load_ps(p)); }
 SIMD_INLINE vfloat operator+ (vfloat a, vfloat b) { a.m = _mm_add_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator- (vfloat a, vfloat b) { a.m = _mm_sub_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator* (vfloat a, vfloat b) { a.m = _mm_mul_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator==(vfloat a, vfloat b) { a.m = _mm_cmpeq_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator!=(vfloat a, vfloat b) { a.m = _mm_cmpneq_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator< (vfloat a, vfloat b) { a.m = _mm_cmplt_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator> (vfloat a, vfloat b) { a.m = _mm_cmpgt_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator<=(vfloat a, vfloat b) { a.m = _mm_cmple_ps(a.m, b.m); return a; }
-SIMD_INLINE vfloat operator>=(vfloat a, vfloat b) { a.m = _mm_cmpge_ps(a.m, b.m); return a; }
+SIMD_INLINE vmask operator==(vfloat a, vfloat b) { return vmask(_mm_cmpeq_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator!=(vfloat a, vfloat b) { return vmask(_mm_cmpneq_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator< (vfloat a, vfloat b) { return vmask(_mm_cmplt_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator> (vfloat a, vfloat b) { return vmask(_mm_cmpgt_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator<=(vfloat a, vfloat b) { return vmask(_mm_cmple_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator>=(vfloat a, vfloat b) { return vmask(_mm_cmpge_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator| (vmask a, vmask b) { return vmask(_mm_or_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator& (vmask a, vmask b) { return vmask(_mm_and_ps(a.m, b.m)); }
+SIMD_INLINE vmask operator^ (vmask a, vmask b) { return vmask(_mm_xor_ps(a.m, b.m)); }
+// Returns a 4-bit code where bit0..bit3 is X..W
+SIMD_INLINE unsigned mask(vmask v) { return _mm_movemask_ps(v.m); }
+SIMD_INLINE bool any(vmask v) { return mask(v) != 0; }
+SIMD_INLINE bool all(vmask v) { return mask(v) == 0xF; }
 
 SIMD_INLINE vfloat min(vfloat a, vfloat b) { a.m = _mm_min_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = _mm_max_ps(a.m, b.m); return a; }
@@ -202,24 +294,34 @@ SIMD_INLINE vfloat round(vfloat v)
 #endif
 }
 
+#define ASTCENC_SHUFFLE4(V, X,Y,Z,W) vfloat(_mm_shuffle_ps((V).m, (V).m, _MM_SHUFFLE(W,Z,Y,X)))
+
+SIMD_INLINE vfloat hmin(vfloat v)
+{
+    v = min(v, ASTCENC_SHUFFLE4(v, 2, 3, 0, 0));
+    v = min(v, ASTCENC_SHUFFLE4(v, 1, 0, 0, 0));
+    return v;
+}
+
 SIMD_INLINE vint floatToInt(vfloat v) { return vint(_mm_cvtps_epi32(v.m)); }
 
 SIMD_INLINE vfloat intAsFloat(vint v) { return vfloat(_mm_castsi128_ps(v.m)); }
 
 SIMD_INLINE vint operator~ (vint a) { return vint(_mm_xor_si128(a.m, _mm_set1_epi32(-1))); }
+SIMD_INLINE vmask operator~ (vmask a) { return vmask(_mm_xor_si128(_mm_castps_si128(a.m), _mm_set1_epi32(-1))); }
+
 SIMD_INLINE vint operator+ (vint a, vint b) { a.m = _mm_add_epi32(a.m, b.m); return a; }
 SIMD_INLINE vint operator- (vint a, vint b) { a.m = _mm_sub_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator<(vint a, vint b) { a.m = _mm_cmplt_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator>(vint a, vint b) { a.m = _mm_cmpgt_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator==(vint a, vint b) { a.m = _mm_cmpeq_epi32(a.m, b.m); return a; }
-SIMD_INLINE vint operator!=(vint a, vint b) { a.m = _mm_cmpeq_epi32(a.m, b.m); return ~a; }
-
+SIMD_INLINE vmask operator< (vint a, vint b) { return vmask(_mm_cmplt_epi32(a.m, b.m)); }
+SIMD_INLINE vmask operator> (vint a, vint b) { return vmask(_mm_cmpgt_epi32(a.m, b.m)); }
+SIMD_INLINE vmask operator==(vint a, vint b) { return vmask(_mm_cmpeq_epi32(a.m, b.m)); }
+SIMD_INLINE vmask operator!=(vint a, vint b) { return ~vmask(_mm_cmpeq_epi32(a.m, b.m)); }
 SIMD_INLINE vint min(vint a, vint b) {
 #if ASTCENC_SSE >= 41
 	a.m = _mm_min_epi32(a.m, b.m);
 #else
-	vint d = a < b;
-	a.m = _mm_or_si128(_mm_and_si128(d.m, a.m), _mm_andnot_si128(d.m, b.m));
+	vmask d = a < b;
+	a.m = _mm_or_si128(_mm_and_si128(_mm_castps_si128(d.m), a.m), _mm_andnot_si128(_mm_castps_si128(d.m), b.m));
 #endif
 	return a;
 }
@@ -228,8 +330,8 @@ SIMD_INLINE vint max(vint a, vint b) {
 #if ASTCENC_SSE >= 41
 	a.m = _mm_max_epi32(a.m, b.m);
 #else
-	vint d = a > b;
-	a.m = _mm_or_si128(_mm_and_si128(d.m, a.m), _mm_andnot_si128(d.m, b.m));
+	vmask d = a > b;
+	a.m = _mm_or_si128(_mm_and_si128(_mm_castps_si128(d.m), a.m), _mm_andnot_si128(_mm_castps_si128(d.m), b.m));
 #endif
 	return a;
 }
@@ -242,7 +344,7 @@ SIMD_INLINE void store(vint v, int* ptr) { _mm_store_si128((__m128i*)ptr, v.m); 
 // on SSE4.1 and up this can be done easily via "blend" instruction;
 // on older SSEs we have to do some hoops, see
 // https://fgiesen.wordpress.com/2016/04/03/sse-mind-the-gap/
-SIMD_INLINE vfloat select(vfloat a, vfloat b, vfloat cond)
+SIMD_INLINE vfloat select(vfloat a, vfloat b, vmask cond)
 {
 #if ASTCENC_SSE >= 41
     a.m = _mm_blendv_ps(a.m, b.m, cond.m);
@@ -253,12 +355,12 @@ SIMD_INLINE vfloat select(vfloat a, vfloat b, vfloat cond)
     return a;
 }
 
-SIMD_INLINE vint select(vint a, vint b, vint cond)
+SIMD_INLINE vint select(vint a, vint b, vmask cond)
 {
 #if ASTCENC_SSE >= 41
-    return vint(_mm_blendv_epi8(a.m, b.m, cond.m));
+    return vint(_mm_blendv_epi8(a.m, b.m, _mm_castps_si128(cond.m)));
 #else
-    __m128i d = _mm_srai_epi32(cond.m, 31);
+    __m128i d = _mm_srai_epi32(_mm_castps_si128(cond.m), 31);
     return vint(_mm_or_si128(_mm_and_si128(d, b.m), _mm_andnot_si128(d, a.m)));
 #endif
 }
@@ -295,7 +397,9 @@ struct vfloat
     SIMD_INLINE vfloat() {}
     SIMD_INLINE explicit vfloat(const float *p) { m = *p; }
     SIMD_INLINE explicit vfloat(float v) { m = v; }
-    static vfloat zero() { return vfloat(0.0f); }
+    SIMD_INLINE float lane(int i) const { return m; }
+    static SIMD_INLINE vfloat zero() { return vfloat(0.0f); }
+    static SIMD_INLINE vfloat lane_id() { return vfloat(0.0f); }
     float m;
 };
 
@@ -304,8 +408,17 @@ struct vint
     SIMD_INLINE vint() {}
     SIMD_INLINE explicit vint(const int *p) { m = *p; }
     SIMD_INLINE explicit vint(int v) { m = v; }
+    SIMD_INLINE int lane(int i) const { return m; }
+    static SIMD_INLINE vint lane_id() { return vint(0); }
     int m;
 };
+
+struct vmask
+{
+    SIMD_INLINE explicit vmask(bool v) { m = v; }
+    bool m;
+};
+
 
 SIMD_INLINE vfloat load1a(const float* p) { return vfloat(*p); }
 SIMD_INLINE vfloat loada(const float* p) { return vfloat(*p); }
@@ -313,12 +426,18 @@ SIMD_INLINE vfloat loada(const float* p) { return vfloat(*p); }
 SIMD_INLINE vfloat operator+ (vfloat a, vfloat b) { a.m = a.m + b.m; return a; }
 SIMD_INLINE vfloat operator- (vfloat a, vfloat b) { a.m = a.m - b.m; return a; }
 SIMD_INLINE vfloat operator* (vfloat a, vfloat b) { a.m = a.m * b.m; return a; }
-SIMD_INLINE vfloat operator==(vfloat a, vfloat b) { a.m = a.m == b.m; return a; }
-SIMD_INLINE vfloat operator!=(vfloat a, vfloat b) { a.m = a.m != b.m; return a; }
-SIMD_INLINE vfloat operator< (vfloat a, vfloat b) { a.m = a.m < b.m; return a; }
-SIMD_INLINE vfloat operator> (vfloat a, vfloat b) { a.m = a.m > b.m; return a; }
-SIMD_INLINE vfloat operator<=(vfloat a, vfloat b) { a.m = a.m <= b.m; return a; }
-SIMD_INLINE vfloat operator>=(vfloat a, vfloat b) { a.m = a.m >= b.m; return a; }
+SIMD_INLINE vmask operator==(vfloat a, vfloat b) { return vmask(a.m = a.m == b.m); }
+SIMD_INLINE vmask operator!=(vfloat a, vfloat b) { return vmask(a.m = a.m != b.m); }
+SIMD_INLINE vmask operator< (vfloat a, vfloat b) { return vmask(a.m = a.m < b.m); }
+SIMD_INLINE vmask operator> (vfloat a, vfloat b) { return vmask(a.m = a.m > b.m); }
+SIMD_INLINE vmask operator<=(vfloat a, vfloat b) { return vmask(a.m = a.m <= b.m); }
+SIMD_INLINE vmask operator>=(vfloat a, vfloat b) { return vmask(a.m = a.m >= b.m); }
+SIMD_INLINE vmask operator| (vmask a, vmask b) { return vmask(a.m || b.m); }
+SIMD_INLINE vmask operator& (vmask a, vmask b) { return vmask(a.m && b.m); }
+SIMD_INLINE vmask operator^ (vmask a, vmask b) { return vmask(a.m ^ b.m); }
+SIMD_INLINE unsigned mask(vmask v) { return v.m; }
+SIMD_INLINE bool any(vmask v) { return mask(v) != 0; }
+SIMD_INLINE bool all(vmask v) { return mask(v) != 0; }
 
 SIMD_INLINE vfloat min(vfloat a, vfloat b) { a.m = a.m < b.m ? a.m : b.m; return a; }
 SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = a.m > b.m ? a.m : b.m; return a; }
@@ -327,6 +446,8 @@ SIMD_INLINE vfloat round(vfloat v)
 {
     return vfloat(std::floor(v.m + 0.5f));
 }
+SIMD_INLINE vfloat hmin(vfloat v) { return v; }
+
 
 SIMD_INLINE vint floatToInt(vfloat v) { return vint(v.m); }
 
@@ -335,10 +456,10 @@ SIMD_INLINE vfloat intAsFloat(vint v) { vfloat r; memcpy(&r.m, &v.m, 4); return 
 SIMD_INLINE vint operator~ (vint a) { a.m = ~a.m; return a; }
 SIMD_INLINE vint operator+ (vint a, vint b) { a.m = a.m + b.m; return a; }
 SIMD_INLINE vint operator- (vint a, vint b) { a.m = a.m - b.m; return a; }
-SIMD_INLINE vint operator<(vint a, vint b) { a.m = a.m < b.m; return a; }
-SIMD_INLINE vint operator>(vint a, vint b) { a.m = a.m > b.m; return a; }
-SIMD_INLINE vint operator==(vint a, vint b) { a.m = a.m == b.m; return a; }
-SIMD_INLINE vint operator!=(vint a, vint b) { a.m = a.m != b.m; return a; }
+SIMD_INLINE vmask operator< (vint a, vint b) { return vmask(a.m = a.m < b.m); }
+SIMD_INLINE vmask operator> (vint a, vint b) { return vmask(a.m = a.m > b.m); }
+SIMD_INLINE vmask operator==(vint a, vint b) { return vmask(a.m = a.m == b.m); }
+SIMD_INLINE vmask operator!=(vint a, vint b) { return vmask(a.m = a.m != b.m); }
 SIMD_INLINE vint min(vint a, vint b) { a.m = a.m < b.m ? a.m : b.m; return a; }
 SIMD_INLINE vint max(vint a, vint b) { a.m = a.m > b.m ? a.m : b.m; return a; }
 
@@ -347,11 +468,11 @@ SIMD_INLINE void store(vint v, int* ptr) { *ptr = v.m; }
 
 
 // "select", i.e. highbit(cond) ? b : a
-SIMD_INLINE vfloat select(vfloat a, vfloat b, vfloat cond)
+SIMD_INLINE vfloat select(vfloat a, vfloat b, vmask cond)
 {
     return cond.m ? b : a;
 }
-SIMD_INLINE vint select(vint a, vint b, vint cond)
+SIMD_INLINE vint select(vint a, vint b, vmask cond)
 {
     return cond.m ? b : a;
 }

--- a/Source/astcenc_weight_align.cpp
+++ b/Source/astcenc_weight_align.cpp
@@ -213,25 +213,25 @@ static void compute_lowest_and_highest_weight(
 			errval = errval + dwt * dif;
 
 			// Reset tracker on min hit.
-			vint mask = idxv < minidx;
+			vmask mask = idxv < minidx;
 			minidx = select(minidx, idxv, mask);
-			cut_low_weight_err = select(cut_low_weight_err, vfloat::zero(), intAsFloat(mask));
+			cut_low_weight_err = select(cut_low_weight_err, vfloat::zero(), mask);
 			
 			// Accumulate on min hit.
 			mask = idxv == minidx;
 			minidx = select(minidx, idxv, mask);
 			vfloat accum = cut_low_weight_err + wt - vfloat(2.0f) * dwt;
-			cut_low_weight_err = select(cut_low_weight_err, accum, intAsFloat(mask));
+			cut_low_weight_err = select(cut_low_weight_err, accum, mask);
 			
 			// Reset tracker on max hit.
 			mask = idxv > maxidx;
 			maxidx = select(maxidx, idxv, mask);
-			cut_high_weight_err = select(cut_high_weight_err, vfloat::zero(), intAsFloat(mask));
+			cut_high_weight_err = select(cut_high_weight_err, vfloat::zero(), mask);
 			
 			// Accumulate on max hit.
 			mask = idxv == maxidx;
 			accum = cut_high_weight_err + wt + vfloat(2.0f) * dwt;
-			cut_high_weight_err = select(cut_high_weight_err, accum, intAsFloat(mask));
+			cut_high_weight_err = select(cut_high_weight_err, accum, mask);
 		}
 
 		// Write out min weight and weight span; clamp span to a usable range


### PR DESCRIPTION
- Change vecmathlib header to have a separate `vmask` data type that is result of comparison operations, and an argument for `select()`
- Expand vecmathlib with additional operations (gather, horizontal min, extracting lane value etc.)
- Change loop in `determine_optimal_set_of_endpoint_formats_to_use` to be SIMD; this loops 4 times over 2048 sized arrays and was showing up in the profiler for me.
- Change `compute_ideal_quantized_weights_for_decimation_table` hardcoded 4-wide AVX2 loop to use vecmathlib, and so now it uses SIMD also on SSEn.

In my tests, on a 2048x2048 texture with 6x6 block sizes, -medium preset:
- Mac (2018 MacBookPro, Core i9 2.9GHz):
    - SSE2: 6.01s -> 5.20s
    - SSE4.2: 5.61s -> 5.13s
    - AVX2: 5.17s -> 4.74s
- Windows (AMD ThreadRipper 1950X 3.4GHz, 16 threads):
    - SSE2: 3.03s -> 2.89s
    - SSE4.2: 2.74s -> 2.52s
    - AVX2: 2.63s -> 2.59s
