### PR TITLE
simd: vectorize compute_angular_offsets and atan2

### DIFF
--- a/Source/astcenc_vecmathlib.h
+++ b/Source/astcenc_vecmathlib.h
@@ -542,6 +542,10 @@ SIMD_INLINE void print(vint a)
 
 #ifdef ASTCENC_SIMD_ISA_SCALAR
 
+#include <algorithm>
+#include <math.h>
+#include <string.h>
+
 #define ASTCENC_SIMD_WIDTH 1
 
 struct vfloat
@@ -596,7 +600,7 @@ SIMD_INLINE vfloat min(vfloat a, vfloat b) { a.m = a.m < b.m ? a.m : b.m; return
 SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = a.m > b.m ? a.m : b.m; return a; }
 SIMD_INLINE vfloat saturate(vfloat a) { return vfloat(std::min(std::max(a.m,0.0f), 1.0f)); }
 
-SIMD_INLINE vfloat abs(vfloat x) { return vfloat(std::abs(a.m)); }
+SIMD_INLINE vfloat abs(vfloat x) { return vfloat(std::abs(x.m)); }
 
 SIMD_INLINE vfloat round(vfloat v)
 {

--- a/Source/astcenc_vecmathlib.h
+++ b/Source/astcenc_vecmathlib.h
@@ -130,6 +130,7 @@ SIMD_INLINE vfloat loada(const float* p) { return vfloat(_mm256_load_ps(p)); }
 SIMD_INLINE vfloat operator+ (vfloat a, vfloat b) { a.m = _mm256_add_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator- (vfloat a, vfloat b) { a.m = _mm256_sub_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator* (vfloat a, vfloat b) { a.m = _mm256_mul_ps(a.m, b.m); return a; }
+SIMD_INLINE vfloat operator/ (vfloat a, vfloat b) { a.m = _mm256_div_ps(a.m, b.m); return a; }
 
 // Per-lane float comparison operations
 SIMD_INLINE vmask operator==(vfloat a, vfloat b) { return vmask(_mm256_cmp_ps(a.m, b.m, _CMP_EQ_OQ)); }
@@ -163,6 +164,12 @@ SIMD_INLINE vfloat saturate(vfloat a)
 	return vfloat(_mm256_min_ps(_mm256_max_ps(a.m, zero), one));
 }
 
+SIMD_INLINE vfloat abs(vfloat x)
+{
+	__m256 msk = _mm256_castsi256_ps(_mm256_set1_epi32(0x7fffffff));
+	return vfloat(_mm256_and_ps(x.m, msk));
+}
+
 // Round to nearest integer (nearest even for .5 cases)
 SIMD_INLINE vfloat round(vfloat v)
 {
@@ -174,6 +181,8 @@ SIMD_INLINE vint floatToInt(vfloat v) { return vint(_mm256_cvttps_epi32(v.m)); }
 
 // Reinterpret-bitcast integer vector as a float vector (this is basically a no-op on the CPU)
 SIMD_INLINE vfloat intAsFloat(vint v) { return vfloat(_mm256_castsi256_ps(v.m)); }
+// Reinterpret-bitcast float vector as an integer vector (this is basically a no-op on the CPU)
+SIMD_INLINE vint floatAsInt(vfloat v) { return vint(_mm256_castps_si256(v.m)); }
 
 SIMD_INLINE vint operator~ (vint a) { return vint(_mm256_xor_si256(a.m, _mm256_set1_epi32(-1))); }
 SIMD_INLINE vmask operator~ (vmask a) { return vmask(_mm256_xor_si256(_mm256_castps_si256(a.m), _mm256_set1_epi32(-1))); }
@@ -181,6 +190,11 @@ SIMD_INLINE vmask operator~ (vmask a) { return vmask(_mm256_xor_si256(_mm256_cas
 // Per-lane arithmetic integer operations
 SIMD_INLINE vint operator+ (vint a, vint b) { a.m = _mm256_add_epi32(a.m, b.m); return a; }
 SIMD_INLINE vint operator- (vint a, vint b) { a.m = _mm256_sub_epi32(a.m, b.m); return a; }
+
+// Per-lane logical bit operations
+SIMD_INLINE vint operator| (vint a, vint b) { return vint(_mm256_or_si256(a.m, b.m)); }
+SIMD_INLINE vint operator& (vint a, vint b) { return vint(_mm256_and_si256(a.m, b.m)); }
+SIMD_INLINE vint operator^ (vint a, vint b) { return vint(_mm256_xor_si256(a.m, b.m)); }
 
 // Per-lane integer comparison operations
 SIMD_INLINE vmask operator< (vint a, vint b) { return vmask(_mm256_cmpgt_epi32(b.m, a.m)); }
@@ -342,6 +356,7 @@ SIMD_INLINE vfloat loada(const float* p) { return vfloat(_mm_load_ps(p)); }
 SIMD_INLINE vfloat operator+ (vfloat a, vfloat b) { a.m = _mm_add_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator- (vfloat a, vfloat b) { a.m = _mm_sub_ps(a.m, b.m); return a; }
 SIMD_INLINE vfloat operator* (vfloat a, vfloat b) { a.m = _mm_mul_ps(a.m, b.m); return a; }
+SIMD_INLINE vfloat operator/ (vfloat a, vfloat b) { a.m = _mm_div_ps(a.m, b.m); return a; }
 SIMD_INLINE vmask operator==(vfloat a, vfloat b) { return vmask(_mm_cmpeq_ps(a.m, b.m)); }
 SIMD_INLINE vmask operator!=(vfloat a, vfloat b) { return vmask(_mm_cmpneq_ps(a.m, b.m)); }
 SIMD_INLINE vmask operator< (vfloat a, vfloat b) { return vmask(_mm_cmplt_ps(a.m, b.m)); }
@@ -363,6 +378,12 @@ SIMD_INLINE vfloat saturate(vfloat a)
 	__m128 zero = _mm_setzero_ps();
 	__m128 one = _mm_set1_ps(1.0f);
 	return vfloat(_mm_min_ps(_mm_max_ps(a.m, zero), one));
+}
+
+SIMD_INLINE vfloat abs(vfloat x)
+{
+	__m128 msk = _mm_castsi128_ps(_mm_set1_epi32(0x7fffffff));
+	return vfloat(_mm_and_ps(x.m, msk));
 }
 
 SIMD_INLINE vfloat round(vfloat v)
@@ -389,12 +410,16 @@ SIMD_INLINE vfloat round(vfloat v)
 SIMD_INLINE vint floatToInt(vfloat v) { return vint(_mm_cvttps_epi32(v.m)); }
 
 SIMD_INLINE vfloat intAsFloat(vint v) { return vfloat(_mm_castsi128_ps(v.m)); }
+SIMD_INLINE vint floatAsInt(vfloat v) { return vint(_mm_castps_si128(v.m)); }
 
 SIMD_INLINE vint operator~ (vint a) { return vint(_mm_xor_si128(a.m, _mm_set1_epi32(-1))); }
 SIMD_INLINE vmask operator~ (vmask a) { return vmask(_mm_xor_si128(_mm_castps_si128(a.m), _mm_set1_epi32(-1))); }
 
 SIMD_INLINE vint operator+ (vint a, vint b) { a.m = _mm_add_epi32(a.m, b.m); return a; }
 SIMD_INLINE vint operator- (vint a, vint b) { a.m = _mm_sub_epi32(a.m, b.m); return a; }
+SIMD_INLINE vint operator| (vint a, vint b) { return vint(_mm_or_si128(a.m, b.m)); }
+SIMD_INLINE vint operator& (vint a, vint b) { return vint(_mm_and_si128(a.m, b.m)); }
+SIMD_INLINE vint operator^ (vint a, vint b) { return vint(_mm_xor_si128(a.m, b.m)); }
 SIMD_INLINE vmask operator< (vint a, vint b) { return vmask(_mm_cmplt_epi32(a.m, b.m)); }
 SIMD_INLINE vmask operator> (vint a, vint b) { return vmask(_mm_cmpgt_epi32(a.m, b.m)); }
 SIMD_INLINE vmask operator==(vint a, vint b) { return vmask(_mm_cmpeq_epi32(a.m, b.m)); }
@@ -553,6 +578,7 @@ SIMD_INLINE vfloat loada(const float* p) { return vfloat(*p); }
 SIMD_INLINE vfloat operator+ (vfloat a, vfloat b) { a.m = a.m + b.m; return a; }
 SIMD_INLINE vfloat operator- (vfloat a, vfloat b) { a.m = a.m - b.m; return a; }
 SIMD_INLINE vfloat operator* (vfloat a, vfloat b) { a.m = a.m * b.m; return a; }
+SIMD_INLINE vfloat operator/ (vfloat a, vfloat b) { a.m = a.m / b.m; return a; }
 SIMD_INLINE vmask operator==(vfloat a, vfloat b) { return vmask(a.m = a.m == b.m); }
 SIMD_INLINE vmask operator!=(vfloat a, vfloat b) { return vmask(a.m = a.m != b.m); }
 SIMD_INLINE vmask operator< (vfloat a, vfloat b) { return vmask(a.m = a.m < b.m); }
@@ -570,6 +596,8 @@ SIMD_INLINE vfloat min(vfloat a, vfloat b) { a.m = a.m < b.m ? a.m : b.m; return
 SIMD_INLINE vfloat max(vfloat a, vfloat b) { a.m = a.m > b.m ? a.m : b.m; return a; }
 SIMD_INLINE vfloat saturate(vfloat a) { return vfloat(std::min(std::max(a.m,0.0f), 1.0f)); }
 
+SIMD_INLINE vfloat abs(vfloat x) { return vfloat(std::abs(a.m)); }
+
 SIMD_INLINE vfloat round(vfloat v)
 {
 	return vfloat(std::floor(v.m + 0.5f));
@@ -578,10 +606,14 @@ SIMD_INLINE vfloat round(vfloat v)
 SIMD_INLINE vint floatToInt(vfloat v) { return vint(v.m); }
 
 SIMD_INLINE vfloat intAsFloat(vint v) { vfloat r; memcpy(&r.m, &v.m, 4); return r; }
+SIMD_INLINE vint floatAsInt(vfloat v) { vint r; memcpy(&r.m, &v.m, 4); return r; }
 
 SIMD_INLINE vint operator~ (vint a) { a.m = ~a.m; return a; }
 SIMD_INLINE vint operator+ (vint a, vint b) { a.m = a.m + b.m; return a; }
 SIMD_INLINE vint operator- (vint a, vint b) { a.m = a.m - b.m; return a; }
+SIMD_INLINE vint operator| (vint a, vint b) { return vint(a.m | b.m); }
+SIMD_INLINE vint operator& (vint a, vint b) { return vint(a.m & b.m); }
+SIMD_INLINE vint operator^ (vint a, vint b) { return vint(a.m ^ b.m); }
 SIMD_INLINE vmask operator< (vint a, vint b) { return vmask(a.m = a.m < b.m); }
 SIMD_INLINE vmask operator> (vint a, vint b) { return vmask(a.m = a.m > b.m); }
 SIMD_INLINE vmask operator==(vint a, vint b) { return vmask(a.m = a.m == b.m); }
@@ -625,5 +657,53 @@ SIMD_INLINE vint select(vint a, vint b, vmask cond)
 
 
 #endif // #ifdef ASTCENC_SIMD_ISA_SCALAR
+
+
+// ----------------------------------------------------------------------------
+
+// Return x, with each lane having its sign flipped where the corresponding y lane is negative, i.e. msb(y) ? -x : x
+SIMD_INLINE vfloat changesign(vfloat x, vfloat y)
+{
+	vint ix = floatAsInt(x);
+	vint iy = floatAsInt(y);
+	vint signMask((int)0x80000000);
+	vint r = ix ^ (iy & signMask);
+	return intAsFloat(r);
+}
+
+#define ASTCENC_PI_OVER_TWO (1.57079632679489661923f) // pi/2
+#define ASTCENC_PI (3.14159265358979323846f)
+
+SIMD_INLINE vfloat atan(vfloat x)
+{
+	vmask c = abs(x) > vfloat(1.0f);
+	vfloat z = changesign(vfloat(ASTCENC_PI_OVER_TWO), x);
+	vfloat y = select(x, vfloat(1.0f) / x, c);
+
+	// max error 0.000167
+	/*
+	vfloat c1(0.999802172f);
+	vfloat c3(-0.325227708f);
+	vfloat c5(0.153163940f);
+	vfloat c7(-0.042340223f);
+	vfloat y2 = y * y;
+	vfloat y4 = y2 * y2;
+	vfloat y6 = y4 * y2;
+	y = y * (c7 * y6 + (c5 * y4 + (c3 * y2 + c1)));
+	 */
+	// max error 0.004883, matches astc::atan2 approximation
+	vfloat y2 = y * y;
+	y = y / (y2 * vfloat(0.28f) + vfloat(1.0f));
+
+	return select(y, z - y, c);
+}
+
+SIMD_INLINE vfloat atan2(vfloat y, vfloat x)
+{
+	vfloat z = atan(abs(y / x));
+	vmask xmask = vmask(floatAsInt(x).m);
+	return changesign(select(z, vfloat(ASTCENC_PI) - z, xmask), y);
+}
+
 
 #endif // #ifndef ASTC_VECMATHLIB_H_INCLUDED

--- a/Source/astcenc_weight_align.cpp
+++ b/Source/astcenc_weight_align.cpp
@@ -79,9 +79,9 @@ alignas(ASTCENC_VECALIGN) static const float angular_steppings[ANGULAR_STEPS] = 
     // This is "redundant" and only used in more-than-4-wide
     // SIMD code paths, to make the steps table size
     // be a multiple of SIMD width. Values are replicated
-    // from previous row so that AVX2 and SSE code paths
+    // from last entry so that AVX2 and SSE code paths
     // return the same results.
-    32.0f, 33.0f, 34.0f, 35.0f,
+    35.0f, 35.0f, 35.0f, 35.0f,
 #endif
 };
 

--- a/Source/astcenc_weight_align.cpp
+++ b/Source/astcenc_weight_align.cpp
@@ -59,6 +59,7 @@
 #else
     #error Unknown SIMD width
 #endif
+static_assert((ANGULAR_STEPS % ASTCENC_SIMD_WIDTH) == 0, "ANGULAR_STEPS should be multiple of ASTCENC_SIMD_WIDTH");
 
 alignas(ASTCENC_VECALIGN) static const float angular_steppings[ANGULAR_STEPS] = {
 	 1.0f, 1.25f, 1.5f, 1.75f,

--- a/Source/astcenc_weight_align.cpp
+++ b/Source/astcenc_weight_align.cpp
@@ -93,8 +93,8 @@ static int max_angular_steps_needed_for_quant_level[13];
 // slight quality loss compared to using sin() and cos() directly. Must be 2^N.
 #define SINCOS_STEPS 64
 
-static float sin_table[SINCOS_STEPS][ANGULAR_STEPS];
-static float cos_table[SINCOS_STEPS][ANGULAR_STEPS];
+alignas(ASTCENC_VECALIGN) static float sin_table[SINCOS_STEPS][ANGULAR_STEPS];
+alignas(ASTCENC_VECALIGN) static float cos_table[SINCOS_STEPS][ANGULAR_STEPS];
 
 void prepare_angular_tables()
 {
@@ -135,15 +135,11 @@ static void compute_angular_offsets(
 	int max_angular_steps,
 	float* offsets
 ) {
-	float anglesum_x[ANGULAR_STEPS];
-	float anglesum_y[ANGULAR_STEPS];
-
-	for (int i = 0; i < max_angular_steps; i++)
-	{
-		anglesum_x[i] = 0;
-		anglesum_y[i] = 0;
-	}
-
+	alignas(ASTCENC_VECALIGN) float anglesum_x[ANGULAR_STEPS];
+	alignas(ASTCENC_VECALIGN) float anglesum_y[ANGULAR_STEPS];
+	memset(anglesum_x, 0, max_angular_steps*sizeof(anglesum_x[0]));
+	memset(anglesum_y, 0, max_angular_steps*sizeof(anglesum_y[0]));
+	
 	// compute the angle-sums.
 	for (int i = 0; i < samplecount; i++)
 	{
@@ -156,21 +152,25 @@ static void compute_angular_offsets(
 		const float *sinptr = sin_table[isample];
 		const float *cosptr = cos_table[isample];
 
-		for (int j = 0; j < max_angular_steps; j++)
+		vfloat sample_weightv(sample_weight);
+		for (int j = 0; j < max_angular_steps; j += ASTCENC_SIMD_WIDTH) // arrays are multiple of SIMD width (ANGULAR_STEPS), safe to overshoot max
 		{
-			float cp = cosptr[j];
-			float sp = sinptr[j];
-
-			anglesum_x[j] += cp * sample_weight;
-			anglesum_y[j] += sp * sample_weight;
+			vfloat cp = loada(&cosptr[j]);
+			vfloat sp = loada(&sinptr[j]);
+			vfloat ax = loada(&anglesum_x[j]) + cp * sample_weightv;
+			vfloat ay = loada(&anglesum_y[j]) + sp * sample_weightv;
+			store(ax, &anglesum_x[j]);
+			store(ay, &anglesum_y[j]);
 		}
 	}
 
 	// post-process the angle-sums
-	for (int i = 0; i < max_angular_steps; i++)
+	vfloat mult = vfloat(1.0f / (2.0f * (float)M_PI));
+	for (int i = 0; i < max_angular_steps; i += ASTCENC_SIMD_WIDTH) // arrays are multiple of SIMD width (ANGULAR_STEPS), safe to overshoot max
 	{
-		float angle = astc::atan2(anglesum_y[i], anglesum_x[i]);
-		offsets[i] = angle * (stepsizes[i] * (1.0f / (2.0f * (float)M_PI)));
+		vfloat angle = atan2(loada(&anglesum_y[i]), loada(&anglesum_x[i]));
+		vfloat ofs = angle * (loada(&stepsizes[i]) * mult);
+		store(ofs, &offsets[i]);
 	}
 }
 


### PR DESCRIPTION
For the SIMD `atan2` I went with the same approximation as already is in `astc::atan2`. There's a commented out code path with a more exact approximation, for now went for identical results as before.

Also, AVX2 now actually returns identical result (PSNR at least) compared to SSE2/SSE4.2

On 2048x2048 image, 6x6 block size, -medium, coding time:
- Mac (2018 MBP, Core i9 2.9GHz):
    - SSE2: 5.20s -> 5.05s
    - SSE4.2: 5.13s -> 4.49s
    - AVX2: 4.74s -> 4.28s
- Windows (AMD ThreadRipper 1950X, 3.4GHz, 16 threads):
    - SSE2: 2.89s -> 2.76s
    - SSE4.2: 2.52s -> 2.39s
    - AVX2: 2.59s -> 2.52s

PSNR unchanged

This would "logically conflict" with NEON (#167) since that one would be missing some of the ops I've added here (`abs`, division etc.). I can rebase and fixup that one onto this if needed.