### PR TITLE
Densely pack valid block weight modes (10-20% speedup)

### DIFF
--- a/Source/astcenc_block_sizes2.cpp
+++ b/Source/astcenc_block_sizes2.cpp
@@ -659,8 +659,8 @@ static void construct_block_size_descriptor_2d(
 #endif
 
 	// then construct the list of block formats
-	int idx = 0;
-	for (int i = 0; i < 2048; i++)
+	int packed_idx = 0;
+	for (int i = 0; i < MAX_WEIGHT_MODES; i++)
 	{
 		int x_weights, y_weights;
 		int is_dual_plane;
@@ -683,24 +683,24 @@ static void construct_block_size_descriptor_2d(
 		if (!permit_encode) // also disallow decode of grid size larger than block size.
 			continue;
 		int decimation_mode = decimation_mode_index[y_weights * 16 + x_weights];
-		bsd->block_modes_packed[idx].decimation_mode = decimation_mode;
-		bsd->block_modes_packed[idx].quantization_mode = quantization_mode;
-		bsd->block_modes_packed[idx].is_dual_plane = is_dual_plane;
-		bsd->block_modes_packed[idx].mode_index = i;
+		bsd->block_modes_packed[packed_idx].decimation_mode = decimation_mode;
+		bsd->block_modes_packed[packed_idx].quantization_mode = quantization_mode;
+		bsd->block_modes_packed[packed_idx].is_dual_plane = is_dual_plane;
+		bsd->block_modes_packed[packed_idx].mode_index = i;
 
 #if !defined(ASTCENC_DECOMPRESS_ONLY)
-		bsd->block_modes_packed[idx].percentile = percentiles[i];
+		bsd->block_modes_packed[packed_idx].percentile = percentiles[i];
 		if (bsd->decimation_mode_percentile[decimation_mode] > percentiles[i])
 		{
 			bsd->decimation_mode_percentile[decimation_mode] = percentiles[i];
 		}
 #else
-		bsd->block_modes_packed[idx].percentile = 0.0f;
+		bsd->block_modes_packed[packed_idx].percentile = 0.0f;
 #endif
-		bsd->block_mode_to_packed[i] = idx;
-		++idx;
+		bsd->block_mode_to_packed[i] = packed_idx;
+		++packed_idx;
 	}
-	bsd->block_mode_packed_count = idx;
+	bsd->block_mode_packed_count = packed_idx;
 
 #if !defined(ASTCENC_DECOMPRESS_ONLY)
 	delete[] percentiles;
@@ -841,8 +841,8 @@ static void construct_block_size_descriptor_3d(
 	bsd->decimation_mode_count = decimation_mode_count;
 
 	// then construct the list of block formats
-	int idx = 0;
-	for (int i = 0; i < 2048; i++)
+	int packed_idx = 0;
+	for (int i = 0; i < MAX_WEIGHT_MODES; i++)
 	{
 		int x_weights, y_weights, z_weights;
 		int is_dual_plane;
@@ -865,20 +865,20 @@ static void construct_block_size_descriptor_3d(
 			continue;
 		
 		int decimation_mode = decimation_mode_index[z_weights * 64 + y_weights * 8 + x_weights];
-		bsd->block_modes_packed[idx].decimation_mode = decimation_mode;
-		bsd->block_modes_packed[idx].quantization_mode = quantization_mode;
-		bsd->block_modes_packed[idx].is_dual_plane = is_dual_plane;
-		bsd->block_modes_packed[idx].mode_index = i;
+		bsd->block_modes_packed[packed_idx].decimation_mode = decimation_mode;
+		bsd->block_modes_packed[packed_idx].quantization_mode = quantization_mode;
+		bsd->block_modes_packed[packed_idx].is_dual_plane = is_dual_plane;
+		bsd->block_modes_packed[packed_idx].mode_index = i;
 
-		bsd->block_modes_packed[idx].percentile = 0.0f; // No percentile table
+		bsd->block_modes_packed[packed_idx].percentile = 0.0f; // No percentile table
 		if (bsd->decimation_mode_percentile[decimation_mode] > 0.0f)
 		{
 			bsd->decimation_mode_percentile[decimation_mode] = 0.0f;
 		}
-		bsd->block_mode_to_packed[i] = idx;
-		++idx;
+		bsd->block_mode_to_packed[i] = packed_idx;
+		++packed_idx;
 	}
-	bsd->block_mode_packed_count = idx;
+	bsd->block_mode_packed_count = packed_idx;
 
 	if (xdim * ydim * zdim <= 64)
 	{

--- a/Source/astcenc_color_quantize.cpp
+++ b/Source/astcenc_color_quantize.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
 
 #include "astcenc_internal.h"
 
@@ -2069,6 +2070,7 @@ int pack_color_endpoints(
 	int* output,
 	int quantization_level
 ) {
+	assert(quantization_level >= 0 && quantization_level < 21);
 	// we do not support negative colors.
 	color0.x = MAX(color0.x, 0.0f);
 	color0.y = MAX(color0.y, 0.0f);

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -22,6 +22,7 @@
 #include "astcenc_internal.h"
 
 #include <stdio.h>
+#include <assert.h>
 
 static int compute_value_of_texel_int(
 	int texel_to_get,
@@ -206,11 +207,14 @@ void decompress_symbolic_block(
 	// get the appropriate block descriptor
 	const decimation_table *const *ixtab2 = bsd->decimation_tables;
 
-	const decimation_table *it = ixtab2[bsd->block_modes[scb->block_mode].decimation_mode];
+	const int packed_index = bsd->block_mode_to_packed[scb->block_mode];
+	assert(packed_index >= 0 && packed_index < bsd->block_mode_packed_count);
+	const block_mode& bm = bsd->block_modes_packed[packed_index];
+	const decimation_table *it = ixtab2[bm.decimation_mode];
 
-	int is_dual_plane = bsd->block_modes[scb->block_mode].is_dual_plane;
+	int is_dual_plane = bm.is_dual_plane;
 
-	int weight_quantization_level = bsd->block_modes[scb->block_mode].quantization_mode;
+	int weight_quantization_level = bm.quantization_mode;
 
 	// decode the color endpoints
 	uint4 color_endpoint0[4];

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -345,8 +345,7 @@ struct block_mode
 	int8_t decimation_mode;
 	int8_t quantization_mode;
 	int8_t is_dual_plane;
-	int8_t permit_encode;
-	int8_t permit_decode;
+	int16_t mode_index;
 	float percentile;
 };
 
@@ -364,7 +363,16 @@ struct block_size_descriptor
 	float decimation_mode_percentile[MAX_DECIMATION_MODES];
 	int permit_encode[MAX_DECIMATION_MODES];
 	const decimation_table *decimation_tables[MAX_DECIMATION_MODES];
-	block_mode block_modes[MAX_WEIGHT_MODES];
+
+	// out of all possible 2048 weight modes, only a subset is
+	// actually valid for the current configuration (e.g. 6x6
+	// 2D LDR has 370 valid modes); the valid ones are packed into
+	// block_modes_packed array.
+	block_mode block_modes_packed[MAX_WEIGHT_MODES];
+	int block_mode_packed_count;
+	// get index of block mode inside the block_modes_packed array,
+	// or -1 if mode is not valid for the current configuration.
+	int16_t block_mode_to_packed[MAX_WEIGHT_MODES];
 
 	// for the k-means bed bitmap partitioning algorithm, we don't
 	// want to consider more than 64 texels; this array specifies

--- a/Source/astcenc_pick_best_endpoint_format.cpp
+++ b/Source/astcenc_pick_best_endpoint_format.cpp
@@ -978,7 +978,7 @@ void determine_optimal_set_of_endpoint_formats_to_use(
 		// reference; scalar code
 		float best_ep_error = 1e30f;
 		int best_error_index = -1;
-		for (int j = 0, npack = bsd->block_mode_packed_count; j != npack; ++j)
+		for (int j = 0, npack = bsd->block_mode_packed_count; j < npack; ++j)
 		{
 			if (errors_of_best_combination[j] < best_ep_error && best_quantization_levels[j] >= 5)
 			{

--- a/Source/astcenc_symbolic_physical.cpp
+++ b/Source/astcenc_symbolic_physical.cpp
@@ -21,6 +21,8 @@
 
 #include "astcenc_internal.h"
 
+#include <assert.h>
+
 // routine to write up to 8 bits
 static inline void write_bits(
 	int value,
@@ -123,10 +125,14 @@ void symbolic_to_physical(
 	}
 
 	const decimation_table *const *ixtab2 = bsd.decimation_tables;
+	
+	const int packed_index = bsd.block_mode_to_packed[scb.block_mode];
+	assert(packed_index >= 0 && packed_index < bsd.block_mode_packed_count);
+	const block_mode& bm = bsd.block_modes_packed[packed_index];
 
-	int weight_count = ixtab2[bsd.block_modes[scb.block_mode].decimation_mode]->num_weights;
-	int weight_quantization_method = bsd.block_modes[scb.block_mode].quantization_mode;
-	int is_dual_plane = bsd.block_modes[scb.block_mode].is_dual_plane;
+	int weight_count = ixtab2[bm.decimation_mode]->num_weights;
+	int weight_quantization_method = bm.quantization_mode;
+	int is_dual_plane = bm.is_dual_plane;
 
 	int real_weight_count = is_dual_plane ? 2 * weight_count : weight_count;
 
@@ -321,15 +327,18 @@ void physical_to_symbolic(
 		return;
 	}
 
-	if (bsd.block_modes[block_mode].permit_decode == 0)
+	const int packed_index = bsd.block_mode_to_packed[block_mode];
+	if (packed_index < 0)
 	{
 		scb.error_block = 1;
 		return;
 	}
+	assert(packed_index >= 0 && packed_index < bsd.block_mode_packed_count);
+	const struct block_mode& bm = bsd.block_modes_packed[packed_index];
 
-	int weight_count = ixtab2[bsd.block_modes[block_mode].decimation_mode]->num_weights;
-	int weight_quantization_method = bsd.block_modes[block_mode].quantization_mode;
-	int is_dual_plane = bsd.block_modes[block_mode].is_dual_plane;
+	int weight_count = ixtab2[bm.decimation_mode]->num_weights;
+	int weight_quantization_method = bm.quantization_mode;
+	int is_dual_plane = bm.is_dual_plane;
 
 	int real_weight_count = is_dual_plane ? 2 * weight_count : weight_count;
 

--- a/Source/astcenc_weight_align.cpp
+++ b/Source/astcenc_weight_align.cpp
@@ -396,15 +396,16 @@ void compute_angular_endpoints_1plane(
 		                                                  decimated_weights + i * MAX_WEIGHTS_PER_BLOCK, quant_mode, low_values[i], high_values[i]);
 	}
 
-	for (int i = 0; i < MAX_WEIGHT_MODES; i++)
+	for (int i = 0, ni = bsd->block_mode_packed_count; i < ni; ++i)
 	{
-		if (bsd->block_modes[i].is_dual_plane != 0 || bsd->block_modes[i].percentile > mode_cutoff)
+		const block_mode& bm = bsd->block_modes_packed[i];
+		if (bm.is_dual_plane != 0 || bm.percentile > mode_cutoff)
 		{
 			continue;
 		}
 
-		int quant_mode = bsd->block_modes[i].quantization_mode;
-		int decim_mode = bsd->block_modes[i].decimation_mode;
+		int quant_mode = bm.quantization_mode;
+		int decim_mode = bm.decimation_mode;
 
 		low_value[i] = low_values[decim_mode][quant_mode];
 		high_value[i] = high_values[decim_mode][quant_mode];
@@ -448,15 +449,16 @@ void compute_angular_endpoints_2planes(
 		                                                  decimated_weights + (2 * i + 1) * MAX_WEIGHTS_PER_BLOCK, quant_mode, low_values2[i], high_values2[i]);
 	}
 
-	for (int i = 0; i < MAX_WEIGHT_MODES; i++)
+	for (int i = 0, ni = bsd->block_mode_packed_count; i < ni; ++i)
 	{
-		if (bsd->block_modes[i].is_dual_plane != 1 || bsd->block_modes[i].percentile > mode_cutoff)
+		const block_mode& bm = bsd->block_modes_packed[i];
+		if (bm.is_dual_plane != 1 || bm.percentile > mode_cutoff)
 		{
 			continue;
 		}
 
-		int quant_mode = bsd->block_modes[i].quantization_mode;
-		int decim_mode = bsd->block_modes[i].decimation_mode;
+		int quant_mode = bm.quantization_mode;
+		int decim_mode = bm.decimation_mode;
 
 		low_value1[i] = low_values1[decim_mode][quant_mode];
 		high_value1[i] = high_values1[decim_mode][quant_mode];


### PR DESCRIPTION
Since there's only a small subset of 2048 ones that are valid. For 2D LDR block sizes, this is the valid mode count -- 4x4: 145, 5x5: 255, 6x6: 370, 8x8: 555, 10x10: 687, 12x12: 775. But the code was looping over all the possible 2048 ones, doing checks "is this valid?" or sentinel values to skip over them.

Coding time of 2048x2048 image:

- 6x6 medium: Mac 4.28s -> 3.81s, PC 2.38s -> 2.22s
- 6x6 fast: Mac 0.72s -> 0.57s, PC 0.64s -> 0.57s
- 4x4 medium: Mac 8.53s -> 6.47s, PC 3.92s -> 3.28s
- 4x4 fast: Mac 1.27s -> 0.88s, PC 0.95s -> 0.76s

(Mac being 2018 MBP, Core i9 2.9GHz; PC being AMD ThreadRipper 1950X 3.4GHz; both tested with AVX2 code path)

It's entirely possible I have messed something up, e.g. missed an index update somewhere. That said, PSNR on this one image I tested on is exactly the same before & after the change.