### PR TITLE
First pass at new API for 2D slice image

### DIFF
--- a/Docs/ChangeLog.md
+++ b/Docs/ChangeLog.md
@@ -24,7 +24,9 @@ recompile your client-side code using the updated `astcenc.h` header.
   * **API Change:** Images using region-based metrics no longer need to include
     padding; all input images should be tightly packed and `dim_pad` is removed
     from the `astcenc_image` structure.
-
+  * **API Change:** Image `data` is no longer a 3D array accessed using
+    `data[z][y][x]` indexing, it's an array of 2D slices. This makes it easier
+	to directly use images loaded from other libraries.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 2.1

--- a/Docs/ChangeLog.md
+++ b/Docs/ChangeLog.md
@@ -17,10 +17,10 @@ Reminder for users of the library interface - the API is not designed to be
 stable across versions, and this release is not compatible with 2.1. Please
 recompile your client-side code using the updated `astcenc.h` header.
 
-** **General:**
+* **General:**
   * **Improvement:** SSE4.2 profile changed to SSE4.1, which more accurately
     reflects the feature set used as we were not using any SSE4.2 intrinsics.
-** **Core API:**
+* **Core API:**
   * **API Change:** Images using region-based metrics no longer need to include
     padding; all input images should be tightly packed and `dim_pad` is removed
     from the `astcenc_image` structure.

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -539,7 +539,7 @@ astcenc_error astcenc_context_alloc(
  * @param[out]    data_out       Pointer to output data array.
  * @param         data_len       Length of the output data array.
  * @param         thread_index   Thread index [0..N-1] of calling thread.
-
+ *
  * @return ASTCENC_SUCCESS on success, or an error if compression failed.
  */
 astcenc_error astcenc_compress_image(

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -76,21 +76,21 @@
  * Images
  * ======
  *
- * Images are passed in as a astcenc_image structure. Inputs can be either
- * 8-bit unorm inputs (passed in via the data8 pointer), or 16-bit floating
- * point inputs (passed in via the data16 pointer). The unused pointer should
- * be set to nullptr.
+ * Images are passed in as an astcenc_image structure. Inputs can be either
+ * 8-bit unorm, 16-bit half-float, or 32-bit float, as indicated by the
+ * data_type field.
  *
  * Images can be any dimension; there is no requirement for them to be a
  * multiple of the ASTC block size.
  *
- * Data is always passed in as 4 color channels, and accessed as 3D array
- * indexed using e.g.
+ * Data is always passed in as 4 color channels, and accessed as an array of
+ * 2D image slices. Data within an image slice is always tightly packed without
+ * padding. Addresing looks like this:
  *
- *     data8[z_coord][y_coord][x_coord * 4    ]   // Red
- *     data8[z_coord][y_coord][x_coord * 4 + 1]   // Green
- *     data8[z_coord][y_coord][x_coord * 4 + 2]   // Blue
- *     data8[z_coord][y_coord][x_coord * 4 + 3]   // Alpha
+ *     data[z_coord][y_coord * x_dim * 4 + x_coord * 4    ]   // Red
+ *     data[z_coord][y_coord * x_dim * 4 + x_coord * 4 + 1]   // Green
+ *     data[z_coord][y_coord * x_dim * 4 + x_coord * 4 + 2]   // Blue
+ *     data[z_coord][y_coord * x_dim * 4 + x_coord * 4 + 3]   // Alpha
  *
  * Common compressor usage
  * =======================
@@ -456,22 +456,20 @@ struct astcenc_config {
 /**
  * @brief An uncompressed 2D or 3D image.
  *
- * Inputs can be either 8-bit unorm inputs (passed in via the data8 pointer),
- * or 16-bit floating point inputs (passed in via the data16 pointer). The
- * unused pointer must be set to nullptr. Data is always passed in as 4 color
- * channels, and accessed as 3D array indexed using [Z][Y][(X * 4) + (0..3)].
+ * 3D image are passed in as an array of 2D slices. Each slice has identical
+ * size and color format.
  */
 struct astcenc_image {
 	/** @brief The X dimension of the image, in texels. */
 	unsigned int dim_x;
 	/** @brief The Y dimension of the image, in texels. */
 	unsigned int dim_y;
-	/** @brief The X dimension of the image, in texels. */
+	/** @brief The Z dimension of the image, in texels. */
 	unsigned int dim_z;
 	/** @brief The data type per channel. */
 	astcenc_type data_type;
-	/** @brief The data; actually of type <t>***. */
-	void *data;
+	/** @brief The array of 2D slices, of length dim_z. */
+	void** data;
 };
 
 /**
@@ -536,12 +534,12 @@ astcenc_error astcenc_context_alloc(
  * available. Each thread must have a unique thread_index.
  *
  * @param         context        Codec context.
- * @param[in,out] image          Input image.
+ * @param[in,out] image          An input image, in 2D slices.
  * @param         swizzle        Compression data swizzle.
  * @param[out]    data_out       Pointer to output data array.
  * @param         data_len       Length of the output data array.
  * @param         thread_index   Thread index [0..N-1] of calling thread.
- *
+
  * @return ASTCENC_SUCCESS on success, or an error if compression failed.
  */
 astcenc_error astcenc_compress_image(

--- a/Source/astcenc_compute_variance.cpp
+++ b/Source/astcenc_compute_variance.cpp
@@ -167,8 +167,6 @@ static void compute_pixel_region_variance(
 	// Load N and N^2 values into the work buffers
 	if (img->data_type == ASTCENC_TYPE_U8)
 	{
-		uint8_t*** data8 = static_cast<uint8_t***>(img->data);
-
 		// Swizzle data structure 4 = ZERO, 5 = ONE
 		uint8_t data[6];
 		data[ASTCENC_SWZ_0] = 0;
@@ -178,6 +176,7 @@ static void compute_pixel_region_variance(
 		{
 			int z_src = (z - zd_start) + offset_z - kernel_radius_z;
 			z_src = astc::clamp(z_src, 0, (int)(img->dim_z - 1));
+			uint8_t* data8 = static_cast<uint8_t*>(img->data[z_src]);
 
 			for (int y = 1; y < padsize_y; y++)
 			{
@@ -189,10 +188,10 @@ static void compute_pixel_region_variance(
 					int x_src = (x - 1) + offset_x - kernel_radius_xy;
 					x_src = astc::clamp(x_src, 0, (int)(img->dim_x - 1));
 
-					data[0] = data8[z_src][y_src][4 * x_src    ];
-					data[1] = data8[z_src][y_src][4 * x_src + 1];
-					data[2] = data8[z_src][y_src][4 * x_src + 2];
-					data[3] = data8[z_src][y_src][4 * x_src + 3];
+					data[0] = data8[(4 * img->dim_x * y_src) + (4 * x_src    )];
+					data[1] = data8[(4 * img->dim_x * y_src) + (4 * x_src + 1)];
+					data[2] = data8[(4 * img->dim_x * y_src) + (4 * x_src + 2)];
+					data[3] = data8[(4 * img->dim_x * y_src) + (4 * x_src + 3)];
 
 					uint8_t r = data[swz.r];
 					uint8_t g = data[swz.g];
@@ -220,8 +219,6 @@ static void compute_pixel_region_variance(
 	}
 	else if (img->data_type == ASTCENC_TYPE_F16)
 	{
-		uint16_t*** data16 = static_cast<uint16_t***>(img->data);
-
 		// Swizzle data structure 4 = ZERO, 5 = ONE (in FP16)
 		uint16_t data[6];
 		data[ASTCENC_SWZ_0] = 0;
@@ -231,6 +228,7 @@ static void compute_pixel_region_variance(
 		{
 			int z_src = (z - zd_start) + offset_z - kernel_radius_z;
 			z_src = astc::clamp(z_src, 0, (int)(img->dim_z - 1));
+			uint16_t* data16 = static_cast<uint16_t*>(img->data[z_src]);
 
 			for (int y = 1; y < padsize_y; y++)
 			{
@@ -242,10 +240,10 @@ static void compute_pixel_region_variance(
 					int x_src = (x - 1) + offset_x - kernel_radius_xy;
 					x_src = astc::clamp(x_src, 0, (int)(img->dim_x - 1));
 
-					data[0] = data16[z_src][y_src][4 * x_src    ];
-					data[1] = data16[z_src][y_src][4 * x_src + 1];
-					data[2] = data16[z_src][y_src][4 * x_src + 2];
-					data[3] = data16[z_src][y_src][4 * x_src + 3];
+					data[0] = data16[(4 * img->dim_x * y_src) + (4 * x_src    )];
+					data[1] = data16[(4 * img->dim_x * y_src) + (4 * x_src + 1)];
+					data[2] = data16[(4 * img->dim_x * y_src) + (4 * x_src + 2)];
+					data[3] = data16[(4 * img->dim_x * y_src) + (4 * x_src + 3)];
 
 					uint16_t r = data[swz.r];
 					uint16_t g = data[swz.g];
@@ -274,7 +272,6 @@ static void compute_pixel_region_variance(
 	else // if (img->data_type == ASTCENC_TYPE_F32)
 	{
 		assert(img->data_type == ASTCENC_TYPE_F32);
-		float*** data32 = static_cast<float***>(img->data);
 
 		// Swizzle data structure 4 = ZERO, 5 = ONE (in FP16)
 		float data[6];
@@ -285,6 +282,7 @@ static void compute_pixel_region_variance(
 		{
 			int z_src = (z - zd_start) + offset_z - kernel_radius_z;
 			z_src = astc::clamp(z_src, 0, (int)(img->dim_z - 1));
+			float* data32 = static_cast<float*>(img->data[z_src]);
 
 			for (int y = 1; y < padsize_y; y++)
 			{
@@ -296,10 +294,10 @@ static void compute_pixel_region_variance(
 					int x_src = (x - 1) + offset_x - kernel_radius_xy;
 					x_src = astc::clamp(x_src, 0, (int)(img->dim_x - 1));
 
-					data[0] = data32[z_src][y_src][4 * x_src    ];
-					data[1] = data32[z_src][y_src][4 * x_src + 1];
-					data[2] = data32[z_src][y_src][4 * x_src + 2];
-					data[3] = data32[z_src][y_src][4 * x_src + 3];
+					data[0] = data32[(4 * img->dim_x * y_src) + (4 * x_src    )];
+					data[1] = data32[(4 * img->dim_x * y_src) + (4 * x_src + 1)];
+					data[2] = data32[(4 * img->dim_x * y_src) + (4 * x_src + 2)];
+					data[3] = data32[(4 * img->dim_x * y_src) + (4 * x_src + 3)];
 
 					float r = data[swz.r];
 					float g = data[swz.g];

--- a/Source/astcenc_image.cpp
+++ b/Source/astcenc_image.cpp
@@ -297,34 +297,23 @@ void fetch_imageblock(
 		data[ASTCENC_SWZ_0] = 0x00;
 		data[ASTCENC_SWZ_1] = 0xFF;
 
-		uint8_t*** data8 = static_cast<uint8_t***>(img.data);
 		for (int z = 0; z < bsd->zdim; z++)
 		{
+			int zi = astc::clamp(zpos + z, 0, zsize - 1);
+			uint8_t* data8 = static_cast<uint8_t*>(img.data[zi]);
+
 			for (int y = 0; y < bsd->ydim; y++)
 			{
+				int yi = astc::clamp(ypos + y, 0, ysize - 1);
+
 				for (int x = 0; x < bsd->xdim; x++)
 				{
-					int xi = xpos + x;
-					int yi = ypos + y;
-					int zi = zpos + z;
-					// clamp XY coordinates to the picture.
-					if (xi < 0)
-						xi = 0;
-					if (yi < 0)
-						yi = 0;
-					if (zi < 0)
-						zi = 0;
-					if (xi >= xsize)
-						xi = xsize - 1;
-					if (yi >= ysize)
-						yi = ysize - 1;
-					if (zi >= zsize)
-						zi = zsize - 1;
+					int xi = astc::clamp(xpos + x, 0, xsize - 1);
 
-					int r = data8[zi][yi][4 * xi    ];
-					int g = data8[zi][yi][4 * xi + 1];
-					int b = data8[zi][yi][4 * xi + 2];
-					int a = data8[zi][yi][4 * xi + 3];
+					int r = data8[(4 * xsize * yi) + (4 * xi    )];
+					int g = data8[(4 * xsize * yi) + (4 * xi + 1)];
+					int b = data8[(4 * xsize * yi) + (4 * xi + 2)];
+					int a = data8[(4 * xsize * yi) + (4 * xi + 3)];
 
 					if (needs_swz)
 					{
@@ -354,34 +343,23 @@ void fetch_imageblock(
 		data[ASTCENC_SWZ_0] = 0x0000;
 		data[ASTCENC_SWZ_1] = 0x3C00;
 
-		uint16_t*** data16 = static_cast<uint16_t***>(img.data);
 		for (int z = 0; z < bsd->zdim; z++)
 		{
+			int zi = astc::clamp(zpos + z, 0, zsize - 1);
+			uint16_t* data16 = static_cast<uint16_t*>(img.data[zi]);
+
 			for (int y = 0; y < bsd->ydim; y++)
 			{
+				int yi = astc::clamp(ypos + y, 0, ysize - 1);
+
 				for (int x = 0; x < bsd->xdim; x++)
 				{
-					int xi = xpos + x;
-					int yi = ypos + y;
-					int zi = zpos + z;
-					// clamp XY coordinates to the picture.
-					if (xi < 0)
-						xi = 0;
-					if (yi < 0)
-						yi = 0;
-					if (zi < 0)
-						zi = 0;
-					if (xi >= xsize)
-						xi = xsize - 1;
-					if (yi >= ysize)
-						yi = ysize - 1;
-					if (zi >= ysize)
-						zi = zsize - 1;
+					int xi = astc::clamp(xpos + x, 0, xsize - 1);
 
-					int r = data16[zi][yi][4 * xi    ];
-					int g = data16[zi][yi][4 * xi + 1];
-					int b = data16[zi][yi][4 * xi + 2];
-					int a = data16[zi][yi][4 * xi + 3];
+					int r = data16[(4 * xsize * yi) + (4 * xi    )];
+					int g = data16[(4 * xsize * yi) + (4 * xi + 1)];
+					int b = data16[(4 * xsize * yi) + (4 * xi + 2)];
+					int a = data16[(4 * xsize * yi) + (4 * xi + 3)];
 
 					if (needs_swz)
 					{
@@ -413,34 +391,23 @@ void fetch_imageblock(
 		data[ASTCENC_SWZ_0] = 0.0f;
 		data[ASTCENC_SWZ_1] = 1.0f;
 
-		float*** data32 = static_cast<float***>(img.data);
 		for (int z = 0; z < bsd->zdim; z++)
 		{
+			int zi = astc::clamp(zpos + z, 0, zsize - 1);
+			float* data32 = static_cast<float*>(img.data[zi]);
+
 			for (int y = 0; y < bsd->ydim; y++)
 			{
+				int yi = astc::clamp(ypos + y, 0, ysize - 1);
+
 				for (int x = 0; x < bsd->xdim; x++)
 				{
-					int xi = xpos + x;
-					int yi = ypos + y;
-					int zi = zpos + z;
-					// clamp XY coordinates to the picture.
-					if (xi < 0)
-						xi = 0;
-					if (yi < 0)
-						yi = 0;
-					if (zi < 0)
-						zi = 0;
-					if (xi >= xsize)
-						xi = xsize - 1;
-					if (yi >= ysize)
-						yi = ysize - 1;
-					if (zi >= ysize)
-						zi = zsize - 1;
+					int xi = astc::clamp(xpos + x, 0, xsize - 1);
 
-					float r = data32[zi][yi][4 * xi    ];
-					float g = data32[zi][yi][4 * xi + 1];
-					float b = data32[zi][yi][4 * xi + 2];
-					float a = data32[zi][yi][4 * xi + 3];
+					float r = data32[(4 * xsize * yi) + (4 * xi    )];
+					float g = data32[(4 * xsize * yi) + (4 * xi + 1)];
+					float b = data32[(4 * xsize * yi) + (4 * xi + 2)];
+					float a = data32[(4 * xsize * yi) + (4 * xi + 3)];
 
 					if (needs_swz)
 					{
@@ -510,9 +477,11 @@ void write_imageblock(
 	int idx = 0;
 	if (img.data_type == ASTCENC_TYPE_U8)
 	{
-		uint8_t*** data8 = static_cast<uint8_t***>(img.data);
 		for (int z = 0; z < bsd->zdim; z++)
 		{
+			int zc = astc::clamp(zpos + z, 0, zsize - 1);
+			uint8_t* data8 = static_cast<uint8_t*>(img.data[zc]);
+
 			for (int y = 0; y < bsd->ydim; y++)
 			{
 				for (int x = 0; x < bsd->xdim; x++)
@@ -565,10 +534,10 @@ void write_imageblock(
 							ai = astc::flt2int_rtn(MIN(pb->data_a[idx], 1.0f) * 255.0f);
 						}
 
-						data8[zi][yi][4 * xi    ] = ri;
-						data8[zi][yi][4 * xi + 1] = gi;
-						data8[zi][yi][4 * xi + 2] = bi;
-						data8[zi][yi][4 * xi + 3] = ai;
+						data8[(4 * xsize * yi) + (4 * xi    )] = ri;
+						data8[(4 * xsize * yi) + (4 * xi + 1)] = gi;
+						data8[(4 * xsize * yi) + (4 * xi + 2)] = bi;
+						data8[(4 * xsize * yi) + (4 * xi + 3)] = ai;
 					}
 					idx++;
 					nptr++;
@@ -578,9 +547,11 @@ void write_imageblock(
 	}
 	else if (img.data_type == ASTCENC_TYPE_F16)
 	{
-		uint16_t*** data16 = static_cast<uint16_t***>(img.data);
 		for (int z = 0; z < bsd->zdim; z++)
 		{
+			int zc = astc::clamp(zpos + z, 0, zsize - 1);
+			uint16_t* data16 = static_cast<uint16_t*>(img.data[zc]);
+
 			for (int y = 0; y < bsd->ydim; y++)
 			{
 				for (int x = 0; x < bsd->xdim; x++)
@@ -632,10 +603,10 @@ void write_imageblock(
 							ai = float_to_sf16(pb->data_a[idx], SF_NEARESTEVEN);
 						}
 
-						data16[zi][yi][4 * xi    ] = ri;
-						data16[zi][yi][4 * xi + 1] = gi;
-						data16[zi][yi][4 * xi + 2] = bi;
-						data16[zi][yi][4 * xi + 3] = ai;
+						data16[(4 * xsize * yi) + (4 * xi    )] = ri;
+						data16[(4 * xsize * yi) + (4 * xi + 1)] = gi;
+						data16[(4 * xsize * yi) + (4 * xi + 2)] = bi;
+						data16[(4 * xsize * yi) + (4 * xi + 3)] = ai;
 					}
 					idx++;
 					nptr++;
@@ -646,9 +617,12 @@ void write_imageblock(
 	else // if (img.data_type == ASTCENC_TYPE_F32)
 	{
 		assert(img.data_type == ASTCENC_TYPE_F32);
-		float*** data32 = static_cast<float***>(img.data);
+
 		for (int z = 0; z < bsd->zdim; z++)
 		{
+			int zc = astc::clamp(zpos + z, 0, zsize - 1);
+			float* data32 = static_cast<float*>(img.data[zc]);
+
 			for (int y = 0; y < bsd->ydim; y++)
 			{
 				for (int x = 0; x < bsd->xdim; x++)
@@ -700,10 +674,10 @@ void write_imageblock(
 							af = pb->data_a[idx];
 						}
 
-						data32[zi][yi][4 * xi    ] = rf;
-						data32[zi][yi][4 * xi + 1] = gf;
-						data32[zi][yi][4 * xi + 2] = bf;
-						data32[zi][yi][4 * xi + 3] = af;
+						data32[(4 * xsize * yi) + (4 * xi    )] = rf;
+						data32[(4 * xsize * yi) + (4 * xi + 1)] = gf;
+						data32[(4 * xsize * yi) + (4 * xi + 2)] = bf;
+						data32[(4 * xsize * yi) + (4 * xi + 3)] = af;
 					}
 					idx++;
 					nptr++;

--- a/Source/astcenccli_error_metrics.cpp
+++ b/Source/astcenccli_error_metrics.cpp
@@ -156,6 +156,8 @@ void compute_error_metrics(
 	}
 
 	float rgb_peak = 0.0f;
+	unsigned int xsize1 = img1->dim_x;
+	unsigned int xsize2 = img2->dim_x;
 
 	for (unsigned int z = 0; z < dim_z; z++)
 	{
@@ -168,60 +170,60 @@ void compute_error_metrics(
 
 				if (img1->data_type == ASTCENC_TYPE_U8)
 				{
-					uint8_t*** data8 = static_cast<uint8_t***>(img1->data);
+					uint8_t* data8 = static_cast<uint8_t*>(img1->data[z]);
 					color1 = float4(
-					    data8[z][y][4 * x    ] * (1.0f / 255.0f),
-					    data8[z][y][4 * x + 1] * (1.0f / 255.0f),
-					    data8[z][y][4 * x + 2] * (1.0f / 255.0f),
-					    data8[z][y][4 * x + 3] * (1.0f / 255.0f));
+					    data8[(4 * xsize1 * y) + (4 * x    )] * (1.0f / 255.0f),
+					    data8[(4 * xsize1 * y) + (4 * x + 1)] * (1.0f / 255.0f),
+					    data8[(4 * xsize1 * y) + (4 * x + 2)] * (1.0f / 255.0f),
+					    data8[(4 * xsize1 * y) + (4 * x + 3)] * (1.0f / 255.0f));
 				}
 				else if (img1->data_type == ASTCENC_TYPE_F16)
 				{
-					uint16_t*** data16 = static_cast<uint16_t***>(img1->data);
+					uint16_t* data16 = static_cast<uint16_t*>(img1->data[z]);
 					color1 = float4(
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x    ])),
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x + 1])),
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x + 2])),
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x + 3])));
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x    )])),
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x + 1)])),
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x + 2)])),
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x + 3)])));
 				}
 				else // if (img1->data_type == ASTCENC_TYPE_F32)
 				{
 					assert(img1->data_type == ASTCENC_TYPE_F32);
-					float*** data32 = static_cast<float***>(img1->data);
+					float* data32 = static_cast<float*>(img1->data[z]);
 					color1 = float4(
-					    astc::clamp64Kf(data32[z][y][4 * x    ]),
-					    astc::clamp64Kf(data32[z][y][4 * x + 1]),
-					    astc::clamp64Kf(data32[z][y][4 * x + 2]),
-					    astc::clamp64Kf(data32[z][y][4 * x + 3]));
+					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x    )]),
+					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x + 1)]),
+					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x + 2)]),
+					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x + 3)]));
 				}
 
 				if (img2->data_type == ASTCENC_TYPE_U8)
 				{
-					uint8_t*** data8 = static_cast<uint8_t***>(img2->data);
+					uint8_t* data8 = static_cast<uint8_t*>(img2->data[z]);
 					color2 = float4(
-					    data8[z][y][4 * x    ] * (1.0f / 255.0f),
-					    data8[z][y][4 * x + 1] * (1.0f / 255.0f),
-					    data8[z][y][4 * x + 2] * (1.0f / 255.0f),
-					    data8[z][y][4 * x + 3] * (1.0f / 255.0f));
+					    data8[(4 * xsize2 * y) + (4 * x    )] * (1.0f / 255.0f),
+					    data8[(4 * xsize2 * y) + (4 * x + 1)] * (1.0f / 255.0f),
+					    data8[(4 * xsize2 * y) + (4 * x + 2)] * (1.0f / 255.0f),
+					    data8[(4 * xsize2 * y) + (4 * x + 3)] * (1.0f / 255.0f));
 				}
 				else if (img2->data_type == ASTCENC_TYPE_F16)
 				{
-					uint16_t*** data16 = static_cast<uint16_t***>(img2->data);
+					uint16_t* data16 = static_cast<uint16_t*>(img2->data[z]);
 					color2 = float4(
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x    ])),
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x + 1])),
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x + 2])),
-					    astc::clamp64Kf(sf16_to_float(data16[z][y][4 * x + 3])));
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x    )])),
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x + 1)])),
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x + 2)])),
+					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x + 3)])));
 				}
 				else // if (img2->data_type == ASTCENC_TYPE_F32)
 				{
 					assert(img2->data_type == ASTCENC_TYPE_F32);
-					float*** data16 = static_cast<float***>(img2->data);
+					float* data16 = static_cast<float*>(img2->data[z]);
 					color2 = float4(
-					    astc::clamp64Kf(data16[z][y][4 * x    ]),
-					    astc::clamp64Kf(data16[z][y][4 * x + 1]),
-					    astc::clamp64Kf(data16[z][y][4 * x + 2]),
-					    astc::clamp64Kf(data16[z][y][4 * x + 3]));
+					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x    )]),
+					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x + 1)]),
+					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x + 2)]),
+					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x + 3)]));
 				}
 
 				rgb_peak = MAX(MAX(color1.r, color1.g), MAX(color1.b, rgb_peak));

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1030,8 +1030,6 @@ static astcenc_image* load_ktx_uncompressed_image(
 
 	for (unsigned int z = 0; z < dim_z; z++)
 	{
-		unsigned int zdst = z;
-
 		for (unsigned int y = 0; y < dim_y; y++)
 		{
 			unsigned int ymod = y_flip ? dim_y - y - 1 : y;
@@ -1040,14 +1038,14 @@ static astcenc_image* load_ktx_uncompressed_image(
 
 			if (astc_img->data_type == ASTCENC_TYPE_U8)
 			{
-				uint8_t*** data8 = static_cast<uint8_t***>(astc_img->data);
-				dst = static_cast<void*>(data8[zdst][ydst]);
+				uint8_t* data8 = static_cast<uint8_t*>(astc_img->data[z]);
+				dst = static_cast<void*>(&data8[4 * dim_x * ydst]);
 			}
 			else // if (astc_img->data_type == ASTCENC_TYPE_F16)
 			{
 				assert(astc_img->data_type == ASTCENC_TYPE_F16);
-				uint16_t*** data16 = static_cast<uint16_t***>(astc_img->data);
-				dst = static_cast<void*>(data16[zdst][ydst]);
+				uint16_t* data16 = static_cast<uint16_t*>(astc_img->data[z]);
+				dst = static_cast<void*>(&data16[4 * dim_x * ydst]);
 			}
 
 			uint8_t *src = buf + (z * ystride) + (y * xstride);
@@ -1259,9 +1257,9 @@ static int store_ktx_uncompressed_image(
 			}
 		}
 
-		uint8_t*** data8 = static_cast<uint8_t***>(img->data);
 		for (unsigned int z = 0; z < dim_z; z++)
 		{
+			uint8_t* data8 = static_cast<uint8_t*>(img->data[z]);
 			for (unsigned int y = 0; y < dim_y; y++)
 			{
 				int ym = y_flip ? dim_y - y - 1 : y;
@@ -1270,31 +1268,31 @@ static int store_ktx_uncompressed_image(
 				case 1:		// single-component, treated as Luminance
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][x] = data8[z][ym][4 * x];
+						row_pointers8[z][y][x] = data8[(4 * dim_x * ym) + (4 * x    )];
 					}
 					break;
 				case 2:		// two-component, treated as Luminance-Alpha
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][2 * x]     = data8[z][ym][4 * x];
-						row_pointers8[z][y][2 * x + 1] = data8[z][ym][4 * x + 3];
+						row_pointers8[z][y][2 * x    ] = data8[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers8[z][y][2 * x + 1] = data8[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				case 3:		// three-component, treated a
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][3 * x]     = data8[z][ym][4 * x];
-						row_pointers8[z][y][3 * x + 1] = data8[z][ym][4 * x + 1];
-						row_pointers8[z][y][3 * x + 2] = data8[z][ym][4 * x + 2];
+						row_pointers8[z][y][3 * x    ] = data8[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers8[z][y][3 * x + 1] = data8[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers8[z][y][3 * x + 2] = data8[(4 * dim_x * ym) + (4 * x + 2)];
 					}
 					break;
 				case 4:		// four-component, treated as RGBA
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][4 * x]     = data8[z][ym][4 * x];
-						row_pointers8[z][y][4 * x + 1] = data8[z][ym][4 * x + 1];
-						row_pointers8[z][y][4 * x + 2] = data8[z][ym][4 * x + 2];
-						row_pointers8[z][y][4 * x + 3] = data8[z][ym][4 * x + 3];
+						row_pointers8[z][y][4 * x    ] = data8[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers8[z][y][4 * x + 1] = data8[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers8[z][y][4 * x + 2] = data8[(4 * dim_x * ym) + (4 * x + 2)];
+						row_pointers8[z][y][4 * x + 3] = data8[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				}
@@ -1321,9 +1319,9 @@ static int store_ktx_uncompressed_image(
 			}
 		}
 
-		uint16_t*** data16 = static_cast<uint16_t***>(img->data);
 		for (unsigned int z = 0; z < dim_z; z++)
 		{
+			uint16_t* data16 = static_cast<uint16_t*>(img->data[z]);
 			for (unsigned int y = 0; y < dim_y; y++)
 			{
 				int ym = y_flip ? dim_y - y - 1 : y;
@@ -1332,31 +1330,31 @@ static int store_ktx_uncompressed_image(
 				case 1:		// single-component, treated as Luminance
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][x] = data16[z][ym][4 * x];
+						row_pointers16[z][y][x] = data16[(4 * dim_x * ym) + (4 * x    )];
 					}
 					break;
 				case 2:		// two-component, treated as Luminance-Alpha
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][2 * x]     = data16[z][ym][4 * x];
-						row_pointers16[z][y][2 * x + 1] = data16[z][ym][4 * x + 3];
+						row_pointers16[z][y][2 * x    ] = data16[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers16[z][y][2 * x + 1] = data16[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				case 3:		// three-component, treated as RGB
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][3 * x]     = data16[z][ym][4 * x];
-						row_pointers16[z][y][3 * x + 1] = data16[z][ym][4 * x + 1];
-						row_pointers16[z][y][3 * x + 2] = data16[z][ym][4 * x + 2];
+						row_pointers16[z][y][3 * x    ] = data16[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers16[z][y][3 * x + 1] = data16[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers16[z][y][3 * x + 2] = data16[(4 * dim_x * ym) + (4 * x + 2)];
 					}
 					break;
 				case 4:		// four-component, treated as RGBA
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][4 * x]     = data16[z][ym][4 * x];
-						row_pointers16[z][y][4 * x + 1] = data16[z][ym][4 * x + 1];
-						row_pointers16[z][y][4 * x + 2] = data16[z][ym][4 * x + 2];
-						row_pointers16[z][y][4 * x + 3] = data16[z][ym][4 * x + 3];
+						row_pointers16[z][y][4 * x    ] = data16[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers16[z][y][4 * x + 1] = data16[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers16[z][y][4 * x + 2] = data16[(4 * dim_x * ym) + (4 * x + 2)];
+						row_pointers16[z][y][4 * x + 3] = data16[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				}
@@ -1740,8 +1738,6 @@ astcenc_image* load_dds_uncompressed_image(
 
 	for (unsigned int z = 0; z < dim_z; z++)
 	{
-		unsigned int zdst = dim_z == 1 ? z : z;
-
 		for (unsigned int y = 0; y < dim_y; y++)
 		{
 			unsigned int ymod = y_flip ? dim_y - y - 1 : y;
@@ -1750,14 +1746,14 @@ astcenc_image* load_dds_uncompressed_image(
 
 			if (astc_img->data_type == ASTCENC_TYPE_U8)
 			{
-				uint8_t*** data8 = static_cast<uint8_t***>(astc_img->data);
-				dst = static_cast<void*>(data8[zdst][ydst]);
+				uint8_t* data8 = static_cast<uint8_t*>(astc_img->data[z]);
+				dst = static_cast<void*>(&data8[4 * dim_x * ydst]);
 			}
 			else // if (astc_img->data_type == ASTCENC_TYPE_F16)
 			{
 				assert(astc_img->data_type == ASTCENC_TYPE_F16);
-				uint16_t*** data16 = static_cast<uint16_t***>(astc_img->data);
-				dst = static_cast<void*>(data16[zdst][ydst]);
+				uint16_t* data16 = static_cast<uint16_t*>(astc_img->data[z]);
+				dst = static_cast<void*>(&data16[4 * dim_x * ydst]);
 			}
 
 			uint8_t *src = buf + (z * ystride) + (y * xstride);
@@ -1865,9 +1861,10 @@ static int store_dds_uncompressed_image(
 			}
 		}
 
-		uint8_t*** data8 = static_cast<uint8_t***>(img->data);
 		for (unsigned int z = 0; z < dim_z; z++)
 		{
+			uint8_t* data8 = static_cast<uint8_t*>(img->data[z]);
+
 			for (unsigned int y = 0; y < dim_y; y++)
 			{
 				int ym = y_flip ? dim_y - y - 1 : y;
@@ -1876,31 +1873,31 @@ static int store_dds_uncompressed_image(
 				case 1:		// single-component, treated as Luminance
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][x] = data8[z][ym][4 * x];
+						row_pointers8[z][y][x] = data8[(4 * dim_x * ym) + (4 * x    )];
 					}
 					break;
 				case 2:		// two-component, treated as Luminance-Alpha
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][2 * x]     = data8[z][ym][4 * x];
-						row_pointers8[z][y][2 * x + 1] = data8[z][ym][4 * x + 3];
+						row_pointers8[z][y][2 * x    ] = data8[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers8[z][y][2 * x + 1] = data8[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				case 3:		// three-component, treated as RGB
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][3 * x]     = data8[z][ym][4 * x];
-						row_pointers8[z][y][3 * x + 1] = data8[z][ym][4 * x + 1];
-						row_pointers8[z][y][3 * x + 2] = data8[z][ym][4 * x + 2];
+						row_pointers8[z][y][3 * x    ] = data8[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers8[z][y][3 * x + 1] = data8[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers8[z][y][3 * x + 2] = data8[(4 * dim_x * ym) + (4 * x + 2)];
 					}
 					break;
 				case 4:		// four-component, treated as RGBA
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers8[z][y][4 * x]     = data8[z][ym][4 * x];
-						row_pointers8[z][y][4 * x + 1] = data8[z][ym][4 * x + 1];
-						row_pointers8[z][y][4 * x + 2] = data8[z][ym][4 * x + 2];
-						row_pointers8[z][y][4 * x + 3] = data8[z][ym][4 * x + 3];
+						row_pointers8[z][y][4 * x    ] = data8[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers8[z][y][4 * x + 1] = data8[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers8[z][y][4 * x + 2] = data8[(4 * dim_x * ym) + (4 * x + 2)];
+						row_pointers8[z][y][4 * x + 3] = data8[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				}
@@ -1927,9 +1924,10 @@ static int store_dds_uncompressed_image(
 			}
 		}
 
-		uint16_t*** data16 = static_cast<uint16_t***>(img->data);
 		for (unsigned int z = 0; z < dim_z; z++)
 		{
+			uint16_t* data16 = static_cast<uint16_t*>(img->data[z]);
+
 			for (unsigned int y = 0; y < dim_y; y++)
 			{
 				int ym = y_flip ? dim_y - y - 1: y;
@@ -1938,31 +1936,31 @@ static int store_dds_uncompressed_image(
 				case 1:		// single-component, treated as Luminance
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][x] = data16[z][ym][4 * x];
+						row_pointers16[z][y][x] = data16[(4 * dim_x * ym) + (4 * x    )];
 					}
 					break;
 				case 2:		// two-component, treated as Luminance-Alpha
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][2 * x]     = data16[z][ym][4 * x];
-						row_pointers16[z][y][2 * x + 1] = data16[z][ym][4 * x + 3];
+						row_pointers16[z][y][2 * x    ] = data16[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers16[z][y][2 * x + 1] = data16[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				case 3:		// three-component, treated as RGB
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][3 * x]     = data16[z][ym][4 * x];
-						row_pointers16[z][y][3 * x + 1] = data16[z][ym][4 * x + 1];
-						row_pointers16[z][y][3 * x + 2] = data16[z][ym][4 * x + 2];
+						row_pointers16[z][y][3 * x    ] = data16[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers16[z][y][3 * x + 1] = data16[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers16[z][y][3 * x + 2] = data16[(4 * dim_x * ym) + (4 * x + 2)];
 					}
 					break;
 				case 4:		// four-component, treated as RGBA
 					for (unsigned int x = 0; x < dim_x; x++)
 					{
-						row_pointers16[z][y][4 * x]     = data16[z][ym][4 * x];
-						row_pointers16[z][y][4 * x + 1] = data16[z][ym][4 * x + 1];
-						row_pointers16[z][y][4 * x + 2] = data16[z][ym][4 * x + 2];
-						row_pointers16[z][y][4 * x + 3] = data16[z][ym][4 * x + 3];
+						row_pointers16[z][y][4 * x    ] = data16[(4 * dim_x * ym) + (4 * x    )];
+						row_pointers16[z][y][4 * x + 1] = data16[(4 * dim_x * ym) + (4 * x + 1)];
+						row_pointers16[z][y][4 * x + 2] = data16[(4 * dim_x * ym) + (4 * x + 2)];
+						row_pointers16[z][y][4 * x + 3] = data16[(4 * dim_x * ym) + (4 * x + 3)];
 					}
 					break;
 				}

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -254,27 +254,28 @@ static astcenc_image* load_uncomp_file(
 			// Combine 2D source images into one 3D image
 			for (unsigned int z = 0; z < dim_z; z++)
 			{
+				// TODO: This is now a pointless copy, so don't do this ...
 				if (image->data_type == ASTCENC_TYPE_U8)
 				{
-					uint8_t*** data8 = static_cast<uint8_t***>(image->data);
-					uint8_t*** data8src = static_cast<uint8_t***>(slices[z]->data);
+					uint8_t* data8 = static_cast<uint8_t*>(image->data[z]);
+					uint8_t* data8src = static_cast<uint8_t*>(slices[z]->data[0]);
 					size_t copy_size = slice_size * 4 * sizeof(uint8_t);
-					memcpy(*data8[z], *data8src[0], copy_size);
+					memcpy(data8, data8src, copy_size);
 				}
 				else if (image->data_type == ASTCENC_TYPE_F16)
 				{
-					uint16_t*** data16 = static_cast<uint16_t***>(image->data);
-					uint16_t*** data16src = static_cast<uint16_t***>(slices[z]->data);
+					uint16_t* data16 = static_cast<uint16_t*>(image->data[z]);
+					uint16_t* data16src = static_cast<uint16_t*>(slices[z]->data[0]);
 					size_t copy_size = slice_size * 4 * sizeof(uint16_t);
-					memcpy(*data16[z], *data16src[0], copy_size);
+					memcpy(data16, data16src, copy_size);
 				}
 				else // if (image->data_type == ASTCENC_TYPE_F32)
 				{
 					assert(image->data_type == ASTCENC_TYPE_F32);
-					float*** data32 = static_cast<float***>(image->data);
-					float*** data32src = static_cast<float***>(slices[z]->data);
+					float* data32 = static_cast<float*>(image->data[z]);
+					float* data32src = static_cast<float*>(slices[z]->data[0]);
 					size_t copy_size = slice_size * 4 * sizeof(float);
-					memcpy(*data32[z], *data32src[0], copy_size);
+					memcpy(data32, data32src, copy_size);
 				}
 			}
 		}


### PR DESCRIPTION
This implementation changes the core codec API for images so they they are no longer 3D arrays (which require a pointer tree to get allocated and created). Instead images are passed as an array of 2D image slices, building up 3D images in layers. Each slice consists of tightly packed 4 channel data with no padding between rows. 

The common case usage of ASTC is 2D images, so in the common case the slice array consists of just a single slice, while leaving support for 3D as an option in the API when it's needed. In addition passing raw data slices loaded from other libraries is now possible, as there is no longer need for the pointer preamble. This can remove additional memory allocation and copy overheads

Slight performance improvement for `-fastest` is expected - but will be < 1%. The main improvement here is just improved ease of integration with data from other sources, and the ability to avoid two memory allocations for the same data. 

Note that this change is ONLY the API change; the command line wrapper is still creating copies of the data from stb_image and tiny_exr, which isn't really needed. This will get fixed in a later PR.