### PR TITLE
Add image preprocessing options

### DIFF
--- a/Docs/ChangeLog.md
+++ b/Docs/ChangeLog.md
@@ -20,6 +20,14 @@ recompile your client-side code using the updated `astcenc.h` header.
 * **General:**
   * **Improvement:** SSE4.2 profile changed to SSE4.1, which more accurately
     reflects the feature set used as we were not using any SSE4.2 intrinsics.
+* **Command Line:**
+  * New image preprocess `-pp-normalize` option added. This forces normal
+    vectors to be unit length, which is useful when compressing source textures
+    that use normal length to encode an NDF, which is incompatible with ASTC's
+    two channel encoding.
+  * New image preprocess `-pp-premultiply` option added. This scales RGB values
+    by the alpha value. This can be useful to minimize cross-channel color
+    bleed caused by GPU post-multiply filtering/blending.
 * **Core API:**
   * **API Change:** Images using region-based metrics no longer need to include
     padding; all input images should be tightly packed and `dim_pad` is removed

--- a/Source/astcenccli_toplevel_help.cpp
+++ b/Source/astcenccli_toplevel_help.cpp
@@ -187,6 +187,18 @@ COMPRESSION
            "_<slice>" to find the file to load. For example, an input
            named "input.png" would load as input_0.png, input_1.png, etc.
 
+       -pp-normalize
+            Run a preprocess over the image that forces normal vectors to
+            be unit length. Preprocessing applies before any codec
+            encoding swizzle, so normal data must be in the RGB channels
+            in the source image.
+
+       -pp-premultiply
+            Run a preprocess over the image that scales RGB components
+            in the image by the alpha value. Preprocessing applies before any
+            codec encoding swizzle, so color data must be in the RGB
+            channels in the source image.
+
 COMPRESSION TIPS & TRICKS
        ASTC is a block-based format that can be prone to block artifacts.
        If block artifacts are a problem when compressing a given texture,


### PR DESCRIPTION
Add some commonly requested image preprocessing options to the command line front-end. Note that these are entirely local to the front-end, they are not part of the core codec/library interface.

The `-pp-normalize` option is designed to work with the `-normalize` option, and forces normal vectors in a normal map to be unit length. This is useful when compressing source textures that use normal length to encode an NDF, as per the M. Toksvig paper, which is incompatible with ASTC's two channel encoding that relies on normals being unit length.

The `-pp-premultiply` option is used to scale RGB by the alpha value to minimize cross-channel color bleed caused by GPU post-multiply filtering/blending.

