### PR TITLE
Implement SIMD optimized compute_error_for_weight_set

### DIFF
--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -256,6 +256,10 @@ alignas(32) static const int s32_data[9] {
 	0, 1, 2, 3, 4, 5 , 6, 7, 8
 };
 
+alignas(32) static const uint8_t u8_data[9] {
+	0, 1, 2, 3, 4, 5 , 6, 7, 8
+};
+
 // VFLOAT4 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 /** @brief Test unaligned vfloat4 data load. */
@@ -803,6 +807,16 @@ TEST(vfloat4, float_to_int_rtn)
 TEST(vint4, UnalignedLoad)
 {
 	vint4 a(&(s32_data[1]));
+	EXPECT_EQ(a.lane<0>(), 1);
+	EXPECT_EQ(a.lane<1>(), 2);
+	EXPECT_EQ(a.lane<2>(), 3);
+	EXPECT_EQ(a.lane<3>(), 4);
+}
+
+/** @brief Test unaligned vint4 data load. */
+TEST(vint4, UnalignedLoad8)
+{
+	vint4 a(&(u8_data[1]));
 	EXPECT_EQ(a.lane<0>(), 1);
 	EXPECT_EQ(a.lane<1>(), 2);
 	EXPECT_EQ(a.lane<2>(), 3);
@@ -1861,6 +1875,21 @@ TEST(vint8, UnalignedLoad)
 	EXPECT_EQ(a.lane<6>(), 7);
 	EXPECT_EQ(a.lane<7>(), 8);
 }
+
+/** @brief Test unaligned vint8 data load. */
+TEST(vint8, UnalignedLoad8)
+{
+	vint8 a(&(u8_data[1]));
+	EXPECT_EQ(a.lane<0>(), 1);
+	EXPECT_EQ(a.lane<1>(), 2);
+	EXPECT_EQ(a.lane<2>(), 3);
+	EXPECT_EQ(a.lane<3>(), 4);
+	EXPECT_EQ(a.lane<4>(), 5);
+	EXPECT_EQ(a.lane<5>(), 6);
+	EXPECT_EQ(a.lane<6>(), 7);
+	EXPECT_EQ(a.lane<7>(), 8);
+}
+
 
 /** @brief Test scalar duplicated vint8 load. */
 TEST(vint8, ScalarDupLoad)

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -247,15 +247,21 @@ TEST(vfloat, Atan2)
 #endif
 
 static const float qnan = std::numeric_limits<float>::quiet_NaN();
-alignas(16) static const float f32x4_data[5] { 0.0f, 1.0f, 2.0f, 3.0f, 4.0f };
-alignas(16) static const int s32x4_data[5] {      0,    1,    2,    3,    4 };
+
+alignas(32) static const float f32_data[9] {
+	0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f
+};
+
+alignas(32) static const int s32_data[9] {
+	0, 1, 2, 3, 4, 5 , 6, 7, 8
+};
 
 // VFLOAT4 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 /** @brief Test unaligned vfloat4 data load. */
 TEST(vfloat4, UnalignedLoad)
 {
-	vfloat4 a(&(f32x4_data[1]));
+	vfloat4 a(&(f32_data[1]));
 	EXPECT_EQ(a.lane<0>(), 1.0f);
 	EXPECT_EQ(a.lane<1>(), 2.0f);
 	EXPECT_EQ(a.lane<2>(), 3.0f);
@@ -347,7 +353,7 @@ TEST(vfloat4, Load1)
 /** @brief Test vfloat4 loada. */
 TEST(vfloat4, Loada)
 {
-	vfloat4 a(&(f32x4_data[0]));
+	vfloat4 a(&(f32_data[0]));
 	EXPECT_EQ(a.lane<0>(), 0.0f);
 	EXPECT_EQ(a.lane<1>(), 1.0f);
 	EXPECT_EQ(a.lane<2>(), 2.0f);
@@ -716,7 +722,7 @@ TEST(vfloat4, select_msb)
 TEST(vfloat4, gatherf)
 {
 	vint4 indices(0, 4, 3, 2);
-	vfloat4 r = gatherf(f32x4_data, indices);
+	vfloat4 r = gatherf(f32_data, indices);
 	EXPECT_EQ(r.lane<0>(), 0.0f);
 	EXPECT_EQ(r.lane<1>(), 4.0f);
 	EXPECT_EQ(r.lane<2>(), 3.0f);
@@ -727,7 +733,7 @@ TEST(vfloat4, gatherf)
 TEST(vfloat4, store)
 {
 	alignas(16) float out[5];
-	vfloat4 a(f32x4_data);
+	vfloat4 a(f32_data);
 	store(a, &(out[1]));
 	EXPECT_EQ(out[1], 0.0f);
 	EXPECT_EQ(out[2], 1.0f);
@@ -739,7 +745,7 @@ TEST(vfloat4, store)
 TEST(vfloat4, storea)
 {
 	alignas(16) float out[4];
-	vfloat4 a(f32x4_data);
+	vfloat4 a(f32_data);
 	store(a, out);
 	EXPECT_EQ(out[0], 0.0f);
 	EXPECT_EQ(out[1], 1.0f);
@@ -787,7 +793,7 @@ TEST(vfloat4, float_to_int_rtn)
 /** @brief Test unaligned vint4 data load. */
 TEST(vint4, UnalignedLoad)
 {
-	vint4 a(&(s32x4_data[1]));
+	vint4 a(&(s32_data[1]));
 	EXPECT_EQ(a.lane<0>(), 1);
 	EXPECT_EQ(a.lane<1>(), 2);
 	EXPECT_EQ(a.lane<2>(), 3);
@@ -1032,7 +1038,7 @@ TEST(vint4, hmin)
 TEST(vint4, storea)
 {
 	alignas(16) int out[4];
-	vint4 a(s32x4_data);
+	vint4 a(s32_data);
 	storea(a, out);
 	EXPECT_EQ(out[0], 0);
 	EXPECT_EQ(out[1], 1);
@@ -1053,7 +1059,7 @@ TEST(vint4, store_nbytes)
 TEST(vint4, gatheri)
 {
 	vint4 indices(0, 4, 3, 2);
-	vint4 r = gatheri(s32x4_data, indices);
+	vint4 r = gatheri(s32_data, indices);
 	EXPECT_EQ(r.lane<0>(), 0);
 	EXPECT_EQ(r.lane<1>(), 4);
 	EXPECT_EQ(r.lane<2>(), 3);
@@ -1168,5 +1174,1096 @@ TEST(vmask4, not)
 	vmask4 r = ~m1;
 	EXPECT_EQ(mask(r), 0x5);
 }
+
+# if ASTCENC_SIMD_WIDTH == 8
+
+// VFLOAT8 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/** @brief Test unaligned vfloat8 data load. */
+TEST(vfloat8, UnalignedLoad)
+{
+	vfloat8 a(&(f32_data[1]));
+	EXPECT_EQ(a.lane<0>(), 1.0f);
+	EXPECT_EQ(a.lane<1>(), 2.0f);
+	EXPECT_EQ(a.lane<2>(), 3.0f);
+	EXPECT_EQ(a.lane<3>(), 4.0f);
+	EXPECT_EQ(a.lane<4>(), 5.0f);
+	EXPECT_EQ(a.lane<5>(), 6.0f);
+	EXPECT_EQ(a.lane<6>(), 7.0f);
+	EXPECT_EQ(a.lane<7>(), 8.0f);
+}
+
+/** @brief Test scalar duplicated vfloat8 load. */
+TEST(vfloat8, ScalarDupLoad)
+{
+	vfloat8 a(1.1f);
+	EXPECT_EQ(a.lane<0>(), 1.1f);
+	EXPECT_EQ(a.lane<1>(), 1.1f);
+	EXPECT_EQ(a.lane<2>(), 1.1f);
+	EXPECT_EQ(a.lane<3>(), 1.1f);
+	EXPECT_EQ(a.lane<4>(), 1.1f);
+	EXPECT_EQ(a.lane<5>(), 1.1f);
+	EXPECT_EQ(a.lane<6>(), 1.1f);
+	EXPECT_EQ(a.lane<7>(), 1.1f);
+}
+
+/** @brief Test scalar vfloat8 load. */
+TEST(vfloat8, ScalarLoad)
+{
+	vfloat8 a(1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f);
+	EXPECT_EQ(a.lane<0>(), 1.1f);
+	EXPECT_EQ(a.lane<1>(), 2.2f);
+	EXPECT_EQ(a.lane<2>(), 3.3f);
+	EXPECT_EQ(a.lane<3>(), 4.4f);
+	EXPECT_EQ(a.lane<4>(), 5.5f);
+	EXPECT_EQ(a.lane<5>(), 6.6f);
+	EXPECT_EQ(a.lane<6>(), 7.7f);
+	EXPECT_EQ(a.lane<7>(), 8.8f);
+}
+
+/** @brief Test copy vfloat8 load. */
+TEST(vfloat8, CopyLoad)
+{
+	vfloat8 s(1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f);
+	vfloat8 a(s.m);
+	EXPECT_EQ(a.lane<0>(), 1.1f);
+	EXPECT_EQ(a.lane<1>(), 2.2f);
+	EXPECT_EQ(a.lane<2>(), 3.3f);
+	EXPECT_EQ(a.lane<3>(), 4.4f);
+	EXPECT_EQ(a.lane<4>(), 5.5f);
+	EXPECT_EQ(a.lane<5>(), 6.6f);
+	EXPECT_EQ(a.lane<6>(), 7.7f);
+	EXPECT_EQ(a.lane<7>(), 8.8f);
+}
+
+/** @brief Test vfloat8 zero. */
+TEST(vfloat8, Zero)
+{
+	vfloat8 a = vfloat8::zero();
+	EXPECT_EQ(a.lane<0>(), 0.0f);
+	EXPECT_EQ(a.lane<1>(), 0.0f);
+	EXPECT_EQ(a.lane<2>(), 0.0f);
+	EXPECT_EQ(a.lane<3>(), 0.0f);
+	EXPECT_EQ(a.lane<4>(), 0.0f);
+	EXPECT_EQ(a.lane<5>(), 0.0f);
+	EXPECT_EQ(a.lane<6>(), 0.0f);
+	EXPECT_EQ(a.lane<7>(), 0.0f);
+}
+
+/** @brief Test vfloat8 load1. */
+TEST(vfloat8, Load1)
+{
+	float s = 3.14f;
+	vfloat8 a = vfloat8::load1(&s);
+	EXPECT_EQ(a.lane<0>(), 3.14f);
+	EXPECT_EQ(a.lane<1>(), 3.14f);
+	EXPECT_EQ(a.lane<2>(), 3.14f);
+	EXPECT_EQ(a.lane<3>(), 3.14f);
+	EXPECT_EQ(a.lane<4>(), 3.14f);
+	EXPECT_EQ(a.lane<5>(), 3.14f);
+	EXPECT_EQ(a.lane<6>(), 3.14f);
+	EXPECT_EQ(a.lane<7>(), 3.14f);
+}
+
+/** @brief Test vfloat8 loada. */
+TEST(vfloat8, Loada)
+{
+	vfloat8 a(&(f32_data[0]));
+	EXPECT_EQ(a.lane<0>(), 0.0f);
+	EXPECT_EQ(a.lane<1>(), 1.0f);
+	EXPECT_EQ(a.lane<2>(), 2.0f);
+	EXPECT_EQ(a.lane<3>(), 3.0f);
+	EXPECT_EQ(a.lane<4>(), 4.0f);
+	EXPECT_EQ(a.lane<5>(), 5.0f);
+	EXPECT_EQ(a.lane<6>(), 6.0f);
+	EXPECT_EQ(a.lane<7>(), 7.0f);
+}
+
+/** @brief Test vfloat8 lane_id. */
+TEST(vfloat8, LaneID)
+{
+	vfloat8 a = vfloat8::lane_id();
+	EXPECT_EQ(a.lane<0>(), 0.0f);
+	EXPECT_EQ(a.lane<1>(), 1.0f);
+	EXPECT_EQ(a.lane<2>(), 2.0f);
+	EXPECT_EQ(a.lane<3>(), 3.0f);
+	EXPECT_EQ(a.lane<4>(), 4.0f);
+	EXPECT_EQ(a.lane<5>(), 5.0f);
+	EXPECT_EQ(a.lane<6>(), 6.0f);
+	EXPECT_EQ(a.lane<7>(), 7.0f);
+}
+
+/** @brief Test vfloat8 add. */
+TEST(vfloat8, vadd)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	a = a + b;
+	EXPECT_EQ(a.lane<0>(), 1.0f + 0.1f);
+	EXPECT_EQ(a.lane<1>(), 2.0f + 0.2f);
+	EXPECT_EQ(a.lane<2>(), 3.0f + 0.3f);
+	EXPECT_EQ(a.lane<3>(), 4.0f + 0.4f);
+	EXPECT_EQ(a.lane<4>(), 5.0f + 0.5f);
+	EXPECT_EQ(a.lane<5>(), 6.0f + 0.6f);
+	EXPECT_EQ(a.lane<6>(), 7.0f + 0.7f);
+	EXPECT_EQ(a.lane<7>(), 8.0f + 0.8f);
+}
+
+/** @brief Test vfloat8 sub. */
+TEST(vfloat8, vsub)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	a = a - b;
+	EXPECT_EQ(a.lane<0>(), 1.0f - 0.1f);
+	EXPECT_EQ(a.lane<1>(), 2.0f - 0.2f);
+	EXPECT_EQ(a.lane<2>(), 3.0f - 0.3f);
+	EXPECT_EQ(a.lane<3>(), 4.0f - 0.4f);
+	EXPECT_EQ(a.lane<4>(), 5.0f - 0.5f);
+	EXPECT_EQ(a.lane<5>(), 6.0f - 0.6f);
+	EXPECT_EQ(a.lane<6>(), 7.0f - 0.7f);
+	EXPECT_EQ(a.lane<7>(), 8.0f - 0.8f);
+}
+
+/** @brief Test vfloat8 mul. */
+TEST(vfloat8, vmul)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	a = a * b;
+	EXPECT_EQ(a.lane<0>(), 1.0f * 0.1f);
+	EXPECT_EQ(a.lane<1>(), 2.0f * 0.2f);
+	EXPECT_EQ(a.lane<2>(), 3.0f * 0.3f);
+	EXPECT_EQ(a.lane<3>(), 4.0f * 0.4f);
+	EXPECT_EQ(a.lane<4>(), 5.0f * 0.5f);
+	EXPECT_EQ(a.lane<5>(), 6.0f * 0.6f);
+	EXPECT_EQ(a.lane<6>(), 7.0f * 0.7f);
+	EXPECT_EQ(a.lane<7>(), 8.0f * 0.8f);
+}
+
+/** @brief Test vfloat8 mul. */
+TEST(vfloat8, vsmul)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	float b = 3.14f;
+	a = a * b;
+	EXPECT_EQ(a.lane<0>(), 1.0f * 3.14f);
+	EXPECT_EQ(a.lane<1>(), 2.0f * 3.14f);
+	EXPECT_EQ(a.lane<2>(), 3.0f * 3.14f);
+	EXPECT_EQ(a.lane<3>(), 4.0f * 3.14f);
+	EXPECT_EQ(a.lane<4>(), 5.0f * 3.14f);
+	EXPECT_EQ(a.lane<5>(), 6.0f * 3.14f);
+	EXPECT_EQ(a.lane<6>(), 7.0f * 3.14f);
+	EXPECT_EQ(a.lane<7>(), 8.0f * 3.14f);
+}
+
+/** @brief Test vfloat8 mul. */
+TEST(vfloat8, svmul)
+{
+	float a = 3.14f;
+	vfloat8 b(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	b = a * b;
+	EXPECT_EQ(b.lane<0>(), 3.14f * 1.0f);
+	EXPECT_EQ(b.lane<1>(), 3.14f * 2.0f);
+	EXPECT_EQ(b.lane<2>(), 3.14f * 3.0f);
+	EXPECT_EQ(b.lane<3>(), 3.14f * 4.0f);
+	EXPECT_EQ(b.lane<4>(), 3.14f * 5.0f);
+	EXPECT_EQ(b.lane<5>(), 3.14f * 6.0f);
+	EXPECT_EQ(b.lane<6>(), 3.14f * 7.0f);
+	EXPECT_EQ(b.lane<7>(), 3.14f * 8.0f);
+}
+
+/** @brief Test vfloat8 div. */
+TEST(vfloat8, vdiv)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	a = a / b;
+	EXPECT_EQ(a.lane<0>(), 1.0f / 0.1f);
+	EXPECT_EQ(a.lane<1>(), 2.0f / 0.2f);
+	EXPECT_EQ(a.lane<2>(), 3.0f / 0.3f);
+	EXPECT_EQ(a.lane<3>(), 4.0f / 0.4f);
+	EXPECT_EQ(a.lane<4>(), 5.0f / 0.5f);
+	EXPECT_EQ(a.lane<5>(), 6.0f / 0.6f);
+	EXPECT_EQ(a.lane<6>(), 7.0f / 0.7f);
+	EXPECT_EQ(a.lane<7>(), 8.0f / 0.8f);
+}
+
+/** @brief Test vfloat8 ceq. */
+TEST(vfloat8, ceq)
+{
+	vfloat8 a1(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b1(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	vmask8 r1 = a1 == b1;
+	EXPECT_EQ(0, mask(r1));
+	EXPECT_EQ(false, any(r1));
+	EXPECT_EQ(false, all(r1));
+
+	vfloat8 a2(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b2(1.0f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	vmask8 r2 = a2 == b2;
+	EXPECT_EQ(0x1, mask(r2));
+	EXPECT_EQ(true, any(r2));
+	EXPECT_EQ(false, all(r2));
+
+	vfloat8 a3(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b3(1.0f, 0.2f, 3.0f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	vmask8 r3 = a3 == b3;
+	EXPECT_EQ(0x5, mask(r3));
+	EXPECT_EQ(true, any(r3));
+	EXPECT_EQ(false, all(r3));
+
+	vfloat8 a4(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vmask8 r4 = a4 == a4;
+	EXPECT_EQ(0xFF, mask(r4));
+	EXPECT_EQ(true, any(r4));
+	EXPECT_EQ(true, all(r4));
+}
+
+/** @brief Test vfloat8 cne. */
+TEST(vfloat8, cne)
+{
+	vfloat8 a1(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b1(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	vmask8 r1 = a1 != b1;
+	EXPECT_EQ(0xFF, mask(r1));
+	EXPECT_EQ(true, any(r1));
+	EXPECT_EQ(true, all(r1));
+
+	vfloat8 a2(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b2(1.0f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	vmask8 r2 = a2 != b2;
+	EXPECT_EQ(0xFE, mask(r2));
+	EXPECT_EQ(true, any(r2));
+	EXPECT_EQ(false, all(r2));
+
+	vfloat8 a3(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vfloat8 b3(1.0f, 0.2f, 3.0f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
+	vmask8 r3 = a3 != b3;
+	EXPECT_EQ(0xFA, mask(r3));
+	EXPECT_EQ(true, any(r3));
+	EXPECT_EQ(false, all(r3));
+
+	vfloat8 a4(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+	vmask8 r4 = a4 != a4;
+	EXPECT_EQ(0, mask(r4));
+	EXPECT_EQ(false, any(r4));
+	EXPECT_EQ(false, all(r4));
+}
+
+/** @brief Test vfloat8 clt. */
+TEST(vfloat8, clt)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 b(0.9f, 2.1f, 3.0f, 4.1f, 0.9f, 2.1f, 3.0f, 4.1f);
+	vmask8 r = a < b;
+	EXPECT_EQ(0xAA, mask(r));
+}
+
+/** @brief Test vfloat8 cle. */
+TEST(vfloat8, cle)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 b(0.9f, 2.1f, 3.0f, 4.1f, 0.9f, 2.1f, 3.0f, 4.1f);
+	vmask8 r = a <= b;
+	EXPECT_EQ(0xEE, mask(r));
+}
+
+/** @brief Test vfloat8 cgt. */
+TEST(vfloat8, cgt)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 b(0.9f, 2.1f, 3.0f, 4.1f, 0.9f, 2.1f, 3.0f, 4.1f);
+	vmask8 r = a > b;
+	EXPECT_EQ(0x11, mask(r));
+}
+
+/** @brief Test vfloat8 cge. */
+TEST(vfloat8, cge)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 b(0.9f, 2.1f, 3.0f, 4.1f, 0.9f, 2.1f, 3.0f, 4.1f);
+	vmask8 r = a >= b;
+	EXPECT_EQ(0x55, mask(r));
+}
+
+/** @brief Test vfloat8 min. */
+TEST(vfloat8, min)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 b(0.9f, 2.1f, 3.0f, 4.1f, 0.9f, 2.1f, 3.0f, 4.1f);
+	vfloat8 r = min(a, b);
+	EXPECT_EQ(r.lane<0>(), 0.9f);
+	EXPECT_EQ(r.lane<1>(), 2.0f);
+	EXPECT_EQ(r.lane<2>(), 3.0f);
+	EXPECT_EQ(r.lane<3>(), 4.0f);
+	EXPECT_EQ(r.lane<4>(), 0.9f);
+	EXPECT_EQ(r.lane<5>(), 2.0f);
+	EXPECT_EQ(r.lane<6>(), 3.0f);
+	EXPECT_EQ(r.lane<7>(), 4.0f);
+}
+
+/** @brief Test vfloat8 max. */
+TEST(vfloat8, max)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 b(0.9f, 2.1f, 3.0f, 4.1f, 0.9f, 2.1f, 3.0f, 4.1f);
+	vfloat8 r = max(a, b);
+	EXPECT_EQ(r.lane<0>(), 1.0f);
+	EXPECT_EQ(r.lane<1>(), 2.1f);
+	EXPECT_EQ(r.lane<2>(), 3.0f);
+	EXPECT_EQ(r.lane<3>(), 4.1f);
+	EXPECT_EQ(r.lane<4>(), 1.0f);
+	EXPECT_EQ(r.lane<5>(), 2.1f);
+	EXPECT_EQ(r.lane<6>(), 3.0f);
+	EXPECT_EQ(r.lane<7>(), 4.1f);
+}
+
+/** @brief Test vfloat8 clamp. */
+TEST(vfloat8, clamp)
+{
+	vfloat8 a1(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 r1 = clamp(2.1f, 3.0f, a1);
+	EXPECT_EQ(r1.lane<0>(), 2.1f);
+	EXPECT_EQ(r1.lane<1>(), 2.1f);
+	EXPECT_EQ(r1.lane<2>(), 3.0f);
+	EXPECT_EQ(r1.lane<3>(), 3.0f);
+	EXPECT_EQ(r1.lane<4>(), 2.1f);
+	EXPECT_EQ(r1.lane<5>(), 2.1f);
+	EXPECT_EQ(r1.lane<6>(), 3.0f);
+	EXPECT_EQ(r1.lane<7>(), 3.0f);
+
+	vfloat8 a2(1.0f, 2.0f, qnan, 4.0f, 1.0f, 2.0f, qnan, 4.0f);
+	vfloat8 r2 = clamp(2.1f, 3.0f, a2);
+	EXPECT_EQ(r2.lane<0>(), 2.1f);
+	EXPECT_EQ(r2.lane<1>(), 2.1f);
+	EXPECT_EQ(r2.lane<2>(), 2.1f);
+	EXPECT_EQ(r2.lane<3>(), 3.0f);
+	EXPECT_EQ(r2.lane<4>(), 2.1f);
+	EXPECT_EQ(r2.lane<5>(), 2.1f);
+	EXPECT_EQ(r2.lane<6>(), 2.1f);
+	EXPECT_EQ(r2.lane<7>(), 3.0f);
+}
+
+/** @brief Test vfloat8 clampz. */
+TEST(vfloat8, clampz)
+{
+	vfloat8 a1(-1.0f, 0.0f, 0.1f, 4.0f, -1.0f, 0.0f, 0.1f, 4.0f);
+	vfloat8 r1 = clampz(3.0f, a1);
+	EXPECT_EQ(r1.lane<0>(), 0.0f);
+	EXPECT_EQ(r1.lane<1>(), 0.0f);
+	EXPECT_EQ(r1.lane<2>(), 0.1f);
+	EXPECT_EQ(r1.lane<3>(), 3.0f);
+	EXPECT_EQ(r1.lane<4>(), 0.0f);
+	EXPECT_EQ(r1.lane<5>(), 0.0f);
+	EXPECT_EQ(r1.lane<6>(), 0.1f);
+	EXPECT_EQ(r1.lane<7>(), 3.0f);
+
+	vfloat8 a2(-1.0f, 0.0f, qnan, 4.0f, -1.0f, 0.0f, qnan, 4.0f);
+	vfloat8 r2 = clampz(3.0f, a2);
+	EXPECT_EQ(r2.lane<0>(), 0.0f);
+	EXPECT_EQ(r2.lane<1>(), 0.0f);
+	EXPECT_EQ(r2.lane<2>(), 0.0f);
+	EXPECT_EQ(r2.lane<3>(), 3.0f);
+	EXPECT_EQ(r2.lane<4>(), 0.0f);
+	EXPECT_EQ(r2.lane<5>(), 0.0f);
+	EXPECT_EQ(r2.lane<6>(), 0.0f);
+	EXPECT_EQ(r2.lane<7>(), 3.0f);
+}
+
+/** @brief Test vfloat8 clampz. */
+TEST(vfloat8, clampzo)
+{
+	vfloat8 a1(-1.0f, 0.0f, 0.1f, 4.0f, -1.0f, 0.0f, 0.1f, 4.0f);
+	vfloat8 r1 = clampzo(a1);
+	EXPECT_EQ(r1.lane<0>(), 0.0f);
+	EXPECT_EQ(r1.lane<1>(), 0.0f);
+	EXPECT_EQ(r1.lane<2>(), 0.1f);
+	EXPECT_EQ(r1.lane<3>(), 1.0f);
+	EXPECT_EQ(r1.lane<4>(), 0.0f);
+	EXPECT_EQ(r1.lane<5>(), 0.0f);
+	EXPECT_EQ(r1.lane<6>(), 0.1f);
+	EXPECT_EQ(r1.lane<7>(), 1.0f);
+
+	vfloat8 a2(-1.0f, 0.0f, qnan, 4.0f, -1.0f, 0.0f, qnan, 4.0f);
+	vfloat8 r2 = clampzo(a2);
+	EXPECT_EQ(r2.lane<0>(), 0.0f);
+	EXPECT_EQ(r2.lane<1>(), 0.0f);
+	EXPECT_EQ(r2.lane<2>(), 0.0f);
+	EXPECT_EQ(r2.lane<3>(), 1.0f);
+	EXPECT_EQ(r2.lane<4>(), 0.0f);
+	EXPECT_EQ(r2.lane<5>(), 0.0f);
+	EXPECT_EQ(r2.lane<6>(), 0.0f);
+	EXPECT_EQ(r2.lane<7>(), 1.0f);
+}
+
+/** @brief Test vfloat8 abs. */
+TEST(vfloat8, abs)
+{
+	vfloat8 a(-1.0f, 0.0f, 0.1f, 4.0f, -1.0f, 0.0f, 0.1f, 4.0f);
+	vfloat8 r = abs(a);
+	EXPECT_EQ(r.lane<0>(), 1.0f);
+	EXPECT_EQ(r.lane<1>(), 0.0f);
+	EXPECT_EQ(r.lane<2>(), 0.1f);
+	EXPECT_EQ(r.lane<3>(), 4.0f);
+	EXPECT_EQ(r.lane<4>(), 1.0f);
+	EXPECT_EQ(r.lane<5>(), 0.0f);
+	EXPECT_EQ(r.lane<6>(), 0.1f);
+	EXPECT_EQ(r.lane<7>(), 4.0f);
+}
+
+/** @brief Test vfloat8 round. */
+TEST(vfloat8, round)
+{
+	vfloat8 a(1.1f, 1.5f, 1.6f, 4.0f, 1.1f, 1.5f, 1.6f, 4.0f);
+	vfloat8 r = round(a);
+	EXPECT_EQ(r.lane<0>(), 1.0f);
+	EXPECT_EQ(r.lane<1>(), 2.0f);
+	EXPECT_EQ(r.lane<2>(), 2.0f);
+	EXPECT_EQ(r.lane<3>(), 4.0f);
+	EXPECT_EQ(r.lane<4>(), 1.0f);
+	EXPECT_EQ(r.lane<5>(), 2.0f);
+	EXPECT_EQ(r.lane<6>(), 2.0f);
+	EXPECT_EQ(r.lane<7>(), 4.0f);
+}
+
+/** @brief Test vfloat8 hmin. */
+TEST(vfloat8, hmin)
+{
+	vfloat8 a1(1.1f, 1.5f, 1.6f, 4.0f, 1.1f, 1.5f, 1.6f, 4.0f);
+	vfloat8 r1 = hmin(a1);
+	EXPECT_EQ(r1.lane<0>(), 1.1f);
+	EXPECT_EQ(r1.lane<1>(), 1.1f);
+	EXPECT_EQ(r1.lane<2>(), 1.1f);
+	EXPECT_EQ(r1.lane<3>(), 1.1f);
+	EXPECT_EQ(r1.lane<4>(), 1.1f);
+	EXPECT_EQ(r1.lane<5>(), 1.1f);
+	EXPECT_EQ(r1.lane<6>(), 1.1f);
+	EXPECT_EQ(r1.lane<7>(), 1.1f);
+
+	vfloat8 a2(1.1f, 1.5f, 1.6f, 0.2f, 1.1f, 1.5f, 1.6f, 0.2f);
+	vfloat8 r2 = hmin(a2);
+	EXPECT_EQ(r2.lane<0>(), 0.2f);
+	EXPECT_EQ(r2.lane<1>(), 0.2f);
+	EXPECT_EQ(r2.lane<2>(), 0.2f);
+	EXPECT_EQ(r2.lane<3>(), 0.2f);
+	EXPECT_EQ(r2.lane<4>(), 0.2f);
+	EXPECT_EQ(r2.lane<5>(), 0.2f);
+	EXPECT_EQ(r2.lane<6>(), 0.2f);
+	EXPECT_EQ(r2.lane<7>(), 0.2f);
+}
+
+/** @brief Test vfloat8 sqrt. */
+TEST(vfloat8, sqrt)
+{
+	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
+	vfloat8 r = sqrt(a);
+	EXPECT_EQ(r.lane<0>(), std::sqrt(1.0f));
+	EXPECT_EQ(r.lane<1>(), std::sqrt(2.0f));
+	EXPECT_EQ(r.lane<2>(), std::sqrt(3.0f));
+	EXPECT_EQ(r.lane<3>(), std::sqrt(4.0f));
+	EXPECT_EQ(r.lane<4>(), std::sqrt(1.0f));
+	EXPECT_EQ(r.lane<5>(), std::sqrt(2.0f));
+	EXPECT_EQ(r.lane<6>(), std::sqrt(3.0f));
+	EXPECT_EQ(r.lane<7>(), std::sqrt(4.0f));
+}
+
+/** @brief Test vfloat8 select. */
+TEST(vfloat8, select)
+{
+	vfloat8 m1(1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+	vfloat8 m2(1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f);
+	vmask8 cond = m1 == m2;
+
+	vfloat8 a(1.0f, 3.0f, 3.0f, 1.0f, 1.0f, 3.0f, 3.0f, 1.0);
+	vfloat8 b(4.0f, 2.0f, 2.0f, 4.0f, 4.0f, 2.0f, 2.0f, 4.0);
+
+	// Select in one direction
+	vfloat8 r1 = select(a, b, cond);
+	EXPECT_EQ(r1.lane<0>(), 4.0f);
+	EXPECT_EQ(r1.lane<1>(), 3.0f);
+	EXPECT_EQ(r1.lane<2>(), 2.0f);
+	EXPECT_EQ(r1.lane<3>(), 1.0f);
+	EXPECT_EQ(r1.lane<4>(), 4.0f);
+	EXPECT_EQ(r1.lane<5>(), 3.0f);
+	EXPECT_EQ(r1.lane<6>(), 2.0f);
+	EXPECT_EQ(r1.lane<7>(), 1.0f);
+
+	// Select in the other
+	vfloat8 r2 = select(b, a, cond);
+	EXPECT_EQ(r2.lane<0>(), 1.0f);
+	EXPECT_EQ(r2.lane<1>(), 2.0f);
+	EXPECT_EQ(r2.lane<2>(), 3.0f);
+	EXPECT_EQ(r2.lane<3>(), 4.0f);
+	EXPECT_EQ(r2.lane<4>(), 1.0f);
+	EXPECT_EQ(r2.lane<5>(), 2.0f);
+	EXPECT_EQ(r2.lane<6>(), 3.0f);
+	EXPECT_EQ(r2.lane<7>(), 4.0f);
+}
+
+/** @brief Test vfloat8 select MSB only. */
+TEST(vfloat8, select_msb)
+{
+	vint8 msb(0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0);
+	vmask8 cond(msb.m);
+
+	vfloat8 a(1.0f, 3.0f, 3.0f, 1.0f, 1.0f, 3.0f, 3.0f, 1.0f);
+	vfloat8 b(4.0f, 2.0f, 2.0f, 4.0f, 4.0f, 2.0f, 2.0f, 4.0f);
+
+	// Select in one direction
+	vfloat8 r1 = select(a, b, cond);
+	EXPECT_EQ(r1.lane<0>(), 4.0f);
+	EXPECT_EQ(r1.lane<1>(), 3.0f);
+	EXPECT_EQ(r1.lane<2>(), 2.0f);
+	EXPECT_EQ(r1.lane<3>(), 1.0f);
+	EXPECT_EQ(r1.lane<4>(), 4.0f);
+	EXPECT_EQ(r1.lane<5>(), 3.0f);
+	EXPECT_EQ(r1.lane<6>(), 2.0f);
+	EXPECT_EQ(r1.lane<7>(), 1.0f);
+
+
+	// Select in the other
+	vfloat8 r2 = select(b, a, cond);
+	EXPECT_EQ(r2.lane<0>(), 1.0f);
+	EXPECT_EQ(r2.lane<1>(), 2.0f);
+	EXPECT_EQ(r2.lane<2>(), 3.0f);
+	EXPECT_EQ(r2.lane<3>(), 4.0f);
+	EXPECT_EQ(r2.lane<4>(), 1.0f);
+	EXPECT_EQ(r2.lane<5>(), 2.0f);
+	EXPECT_EQ(r2.lane<6>(), 3.0f);
+	EXPECT_EQ(r2.lane<7>(), 4.0f);
+}
+
+/** @brief Test vfloat8 gatherf. */
+TEST(vfloat8, gatherf)
+{
+	vint8 indices(0, 4, 3, 2, 7, 4, 3, 2);
+	vfloat8 r = gatherf(f32_data, indices);
+	EXPECT_EQ(r.lane<0>(), 0.0f);
+	EXPECT_EQ(r.lane<1>(), 4.0f);
+	EXPECT_EQ(r.lane<2>(), 3.0f);
+	EXPECT_EQ(r.lane<3>(), 2.0f);
+	EXPECT_EQ(r.lane<4>(), 7.0f);
+	EXPECT_EQ(r.lane<5>(), 4.0f);
+	EXPECT_EQ(r.lane<6>(), 3.0f);
+	EXPECT_EQ(r.lane<7>(), 2.0f);
+}
+
+/** @brief Test vfloat8 store. */
+TEST(vfloat8, store)
+{
+	alignas(32) float out[9];
+	vfloat8 a(f32_data);
+	store(a, &(out[1]));
+	EXPECT_EQ(out[1], 0.0f);
+	EXPECT_EQ(out[2], 1.0f);
+	EXPECT_EQ(out[3], 2.0f);
+	EXPECT_EQ(out[4], 3.0f);
+	EXPECT_EQ(out[5], 4.0f);
+	EXPECT_EQ(out[6], 5.0f);
+	EXPECT_EQ(out[7], 6.0f);
+	EXPECT_EQ(out[8], 7.0f);
+}
+
+/** @brief Test vfloat8 storea. */
+TEST(vfloat8, storea)
+{
+	alignas(32) float out[9];
+	vfloat8 a(f32_data);
+	store(a, out);
+	EXPECT_EQ(out[0], 0.0f);
+	EXPECT_EQ(out[1], 1.0f);
+	EXPECT_EQ(out[2], 2.0f);
+	EXPECT_EQ(out[3], 3.0f);
+	EXPECT_EQ(out[4], 4.0f);
+	EXPECT_EQ(out[5], 5.0f);
+	EXPECT_EQ(out[6], 6.0f);
+	EXPECT_EQ(out[7], 7.0f);
+}
+
+/** @brief Test vfloat8 float_to_int. */
+TEST(vfloat8, float_to_int)
+{
+	vfloat8 a(1.1f, 1.5f, 1.6f, 4.0f, 1.1f, 1.5f, 1.6f, 4.0f);
+	vint8 r = float_to_int(a);
+	EXPECT_EQ(r.lane<0>(), 1);
+	EXPECT_EQ(r.lane<1>(), 1);
+	EXPECT_EQ(r.lane<2>(), 1);
+	EXPECT_EQ(r.lane<3>(), 4);
+	EXPECT_EQ(r.lane<4>(), 1);
+	EXPECT_EQ(r.lane<5>(), 1);
+	EXPECT_EQ(r.lane<6>(), 1);
+	EXPECT_EQ(r.lane<7>(), 4);
+}
+
+// vint8 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/** @brief Test unaligned vint8 data load. */
+TEST(vint8, UnalignedLoad)
+{
+	vint8 a(&(s32_data[1]));
+	EXPECT_EQ(a.lane<0>(), 1);
+	EXPECT_EQ(a.lane<1>(), 2);
+	EXPECT_EQ(a.lane<2>(), 3);
+	EXPECT_EQ(a.lane<3>(), 4);
+	EXPECT_EQ(a.lane<4>(), 5);
+	EXPECT_EQ(a.lane<5>(), 6);
+	EXPECT_EQ(a.lane<6>(), 7);
+	EXPECT_EQ(a.lane<7>(), 8);
+}
+
+/** @brief Test scalar duplicated vint8 load. */
+TEST(vint8, ScalarDupLoad)
+{
+	vint8 a(42);
+	EXPECT_EQ(a.lane<0>(), 42);
+	EXPECT_EQ(a.lane<1>(), 42);
+	EXPECT_EQ(a.lane<2>(), 42);
+	EXPECT_EQ(a.lane<3>(), 42);
+	EXPECT_EQ(a.lane<4>(), 42);
+	EXPECT_EQ(a.lane<5>(), 42);
+	EXPECT_EQ(a.lane<6>(), 42);
+	EXPECT_EQ(a.lane<7>(), 42);
+}
+
+/** @brief Test scalar vint8 load. */
+TEST(vint8, ScalarLoad)
+{
+	vint8 a(11, 22, 33, 44, 55, 66, 77, 88);
+	EXPECT_EQ(a.lane<0>(), 11);
+	EXPECT_EQ(a.lane<1>(), 22);
+	EXPECT_EQ(a.lane<2>(), 33);
+	EXPECT_EQ(a.lane<3>(), 44);
+	EXPECT_EQ(a.lane<4>(), 55);
+	EXPECT_EQ(a.lane<5>(), 66);
+	EXPECT_EQ(a.lane<6>(), 77);
+	EXPECT_EQ(a.lane<7>(), 88);
+}
+
+/** @brief Test copy vint8 load. */
+TEST(vint8, CopyLoad)
+{
+	vint8 s(11, 22, 33, 44, 55, 66, 77, 88);
+	vint8 a(s.m);
+	EXPECT_EQ(a.lane<0>(), 11);
+	EXPECT_EQ(a.lane<1>(), 22);
+	EXPECT_EQ(a.lane<2>(), 33);
+	EXPECT_EQ(a.lane<3>(), 44);
+	EXPECT_EQ(a.lane<4>(), 55);
+	EXPECT_EQ(a.lane<5>(), 66);
+	EXPECT_EQ(a.lane<6>(), 77);
+	EXPECT_EQ(a.lane<7>(), 88);
+}
+
+/** @brief Test vint8 lane_id. */
+TEST(vint8, LaneID)
+{
+	vint8 a = vint8::lane_id();
+	EXPECT_EQ(a.lane<0>(), 0);
+	EXPECT_EQ(a.lane<1>(), 1);
+	EXPECT_EQ(a.lane<2>(), 2);
+	EXPECT_EQ(a.lane<3>(), 3);
+	EXPECT_EQ(a.lane<4>(), 4);
+	EXPECT_EQ(a.lane<5>(), 5);
+	EXPECT_EQ(a.lane<6>(), 6);
+	EXPECT_EQ(a.lane<7>(), 7);
+}
+
+/** @brief Test vint8 add. */
+TEST(vint8, vadd)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(2, 3, 4, 5, 2, 3, 4, 5);
+	a = a + b;
+	EXPECT_EQ(a.lane<0>(), 1 + 2);
+	EXPECT_EQ(a.lane<1>(), 2 + 3);
+	EXPECT_EQ(a.lane<2>(), 3 + 4);
+	EXPECT_EQ(a.lane<3>(), 4 + 5);
+	EXPECT_EQ(a.lane<4>(), 1 + 2);
+	EXPECT_EQ(a.lane<5>(), 2 + 3);
+	EXPECT_EQ(a.lane<6>(), 3 + 4);
+	EXPECT_EQ(a.lane<7>(), 4 + 5);
+}
+
+/** @brief Test vint8 sub. */
+TEST(vint8, vsub)
+{
+	vint8 a(1, 2, 4, 4, 1, 2, 4, 4);
+	vint8 b(2, 3, 3, 5, 2, 3, 3, 5);
+	a = a - b;
+	EXPECT_EQ(a.lane<0>(), 1 - 2);
+	EXPECT_EQ(a.lane<1>(), 2 - 3);
+	EXPECT_EQ(a.lane<2>(), 4 - 3);
+	EXPECT_EQ(a.lane<3>(), 4 - 5);
+	EXPECT_EQ(a.lane<4>(), 1 - 2);
+	EXPECT_EQ(a.lane<5>(), 2 - 3);
+	EXPECT_EQ(a.lane<6>(), 4 - 3);
+	EXPECT_EQ(a.lane<7>(), 4 - 5);
+}
+
+/** @brief Test vint8 bitwise invert. */
+TEST(vint8, bit_invert)
+{
+	vint8 a(-1, 0, 1, 2, -1, 0, 1, 2);
+	a = ~a;
+	EXPECT_EQ(a.lane<0>(), ~-1);
+	EXPECT_EQ(a.lane<1>(), ~0);
+	EXPECT_EQ(a.lane<2>(), ~1);
+	EXPECT_EQ(a.lane<3>(), ~2);
+	EXPECT_EQ(a.lane<4>(), ~-1);
+	EXPECT_EQ(a.lane<5>(), ~0);
+	EXPECT_EQ(a.lane<6>(), ~1);
+	EXPECT_EQ(a.lane<7>(), ~2);
+}
+
+/** @brief Test vint8 bitwise or. */
+TEST(vint8, bit_vor)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(2, 3, 4, 5, 2, 3, 4, 5);
+	a = a | b;
+	EXPECT_EQ(a.lane<0>(), 3);
+	EXPECT_EQ(a.lane<1>(), 3);
+	EXPECT_EQ(a.lane<2>(), 7);
+	EXPECT_EQ(a.lane<3>(), 5);
+	EXPECT_EQ(a.lane<4>(), 3);
+	EXPECT_EQ(a.lane<5>(), 3);
+	EXPECT_EQ(a.lane<6>(), 7);
+	EXPECT_EQ(a.lane<7>(), 5);
+}
+
+/** @brief Test vint8 bitwise and. */
+TEST(vint8, bit_vand)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(2, 3, 4, 5, 2, 3, 4, 5);
+	a = a & b;
+	EXPECT_EQ(a.lane<0>(), 0);
+	EXPECT_EQ(a.lane<1>(), 2);
+	EXPECT_EQ(a.lane<2>(), 0);
+	EXPECT_EQ(a.lane<3>(), 4);
+	EXPECT_EQ(a.lane<4>(), 0);
+	EXPECT_EQ(a.lane<5>(), 2);
+	EXPECT_EQ(a.lane<6>(), 0);
+	EXPECT_EQ(a.lane<7>(), 4);
+}
+
+/** @brief Test vint8 bitwise xor. */
+TEST(vint8, bit_vxor)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(2, 3, 4, 5, 2, 3, 4, 5);
+	a = a ^ b;
+	EXPECT_EQ(a.lane<0>(), 3);
+	EXPECT_EQ(a.lane<1>(), 1);
+	EXPECT_EQ(a.lane<2>(), 7);
+	EXPECT_EQ(a.lane<3>(), 1);
+	EXPECT_EQ(a.lane<4>(), 3);
+	EXPECT_EQ(a.lane<5>(), 1);
+	EXPECT_EQ(a.lane<6>(), 7);
+	EXPECT_EQ(a.lane<7>(), 1);
+}
+
+/** @brief Test vint8 ceq. */
+TEST(vint8, ceq)
+{
+	vint8 a1(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b1(0, 1, 2, 3, 0, 1, 2, 3);
+	vmask8 r1 = a1 == b1;
+	EXPECT_EQ(0, mask(r1));
+	EXPECT_EQ(false, any(r1));
+	EXPECT_EQ(false, all(r1));
+
+	vint8 a2(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b2(1, 0, 0, 0, 1, 0, 0, 0);
+	vmask8 r2 = a2 == b2;
+	EXPECT_EQ(0x11, mask(r2));
+	EXPECT_EQ(true, any(r2));
+	EXPECT_EQ(false, all(r2));
+
+	vint8 a3(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b3(1, 0, 3, 0, 1, 0, 3, 0);
+	vmask8 r3 = a3 == b3;
+	EXPECT_EQ(0x55, mask(r3));
+	EXPECT_EQ(true, any(r3));
+	EXPECT_EQ(false, all(r3));
+
+	vint8 a4(1, 2, 3, 4, 1, 2, 3, 4);
+	vmask8 r4 = a4 == a4;
+	EXPECT_EQ(0xFF, mask(r4));
+	EXPECT_EQ(true, any(r4));
+	EXPECT_EQ(true, all(r4));
+}
+
+/** @brief Test vint8 cne. */
+TEST(vint8, cne)
+{
+	vint8 a1(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b1(0, 1, 2, 3, 0, 1, 2, 3);
+	vmask8 r1 = a1 != b1;
+	EXPECT_EQ(0xFF, mask(r1));
+	EXPECT_EQ(true, any(r1));
+	EXPECT_EQ(true, all(r1));
+
+	vint8 a2(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b2(1, 0, 0, 0, 1, 0, 0, 0);
+	vmask8 r2 = a2 != b2;
+	EXPECT_EQ(0xEE, mask(r2));
+	EXPECT_EQ(true, any(r2));
+	EXPECT_EQ(false, all(r2));
+
+	vint8 a3(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b3(1, 0, 3, 0, 1, 0, 3, 0);
+	vmask8 r3 = a3 != b3;
+	EXPECT_EQ(0xAA, mask(r3));
+	EXPECT_EQ(true, any(r3));
+	EXPECT_EQ(false, all(r3));
+
+	vint8 a4(1, 2, 3, 4, 1, 2, 3, 4);
+	vmask8 r4 = a4 != a4;
+	EXPECT_EQ(0, mask(r4));
+	EXPECT_EQ(false, any(r4));
+	EXPECT_EQ(false, all(r4));
+}
+
+/** @brief Test vint8 clt. */
+TEST(vint8, clt)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(0, 3, 3, 5, 0, 3, 3, 5);
+	vmask8 r = a < b;
+	EXPECT_EQ(0xAA, mask(r));
+}
+
+/** @brief Test vint8 cgt. */
+TEST(vint8, cle)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(0, 3, 3, 5, 0, 3, 3, 5);
+	vmask8 r = a > b;
+	EXPECT_EQ(0x11, mask(r));
+}
+
+/** @brief Test vint8 min. */
+TEST(vint8, min)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(0, 3, 3, 5, 0, 3, 3, 5);
+	vint8 r = min(a, b);
+	EXPECT_EQ(r.lane<0>(), 0);
+	EXPECT_EQ(r.lane<1>(), 2);
+	EXPECT_EQ(r.lane<2>(), 3);
+	EXPECT_EQ(r.lane<3>(), 4);
+	EXPECT_EQ(r.lane<4>(), 0);
+	EXPECT_EQ(r.lane<5>(), 2);
+	EXPECT_EQ(r.lane<6>(), 3);
+	EXPECT_EQ(r.lane<7>(), 4);
+}
+
+/** @brief Test vint8 max. */
+TEST(vint8, max)
+{
+	vint8 a(1, 2, 3, 4, 1, 2, 3, 4);
+	vint8 b(0, 3, 3, 5, 0, 3, 3, 5);
+	vint8 r = max(a, b);
+	EXPECT_EQ(r.lane<0>(), 1);
+	EXPECT_EQ(r.lane<1>(), 3);
+	EXPECT_EQ(r.lane<2>(), 3);
+	EXPECT_EQ(r.lane<3>(), 5);
+	EXPECT_EQ(r.lane<4>(), 1);
+	EXPECT_EQ(r.lane<5>(), 3);
+	EXPECT_EQ(r.lane<6>(), 3);
+	EXPECT_EQ(r.lane<7>(), 5);
+}
+
+/** @brief Test vint8 hmin. */
+TEST(vint8, hmin)
+{
+	vint8 a1(1, 2, 1, 2, 1, 2, 1, 2);
+	vint8 r1 = hmin(a1);
+	EXPECT_EQ(r1.lane<0>(), 1);
+	EXPECT_EQ(r1.lane<1>(), 1);
+	EXPECT_EQ(r1.lane<2>(), 1);
+	EXPECT_EQ(r1.lane<3>(), 1);
+	EXPECT_EQ(r1.lane<4>(), 1);
+	EXPECT_EQ(r1.lane<5>(), 1);
+	EXPECT_EQ(r1.lane<6>(), 1);
+	EXPECT_EQ(r1.lane<7>(), 1);
+
+	vint8 a2(1, 2, -1, 5, 1, 2, -1, 5);
+	vint8 r2 = hmin(a2);
+	EXPECT_EQ(r2.lane<0>(), -1);
+	EXPECT_EQ(r2.lane<1>(), -1);
+	EXPECT_EQ(r2.lane<2>(), -1);
+	EXPECT_EQ(r2.lane<3>(), -1);
+	EXPECT_EQ(r2.lane<4>(), -1);
+	EXPECT_EQ(r2.lane<5>(), -1);
+	EXPECT_EQ(r2.lane<6>(), -1);
+	EXPECT_EQ(r2.lane<7>(), -1);
+}
+
+/** @brief Test vint8 storea. */
+TEST(vint8, storea)
+{
+	alignas(16) int out[4];
+	vint8 a(s32_data);
+	storea(a, out);
+	EXPECT_EQ(out[0], 0);
+	EXPECT_EQ(out[1], 1);
+	EXPECT_EQ(out[2], 2);
+	EXPECT_EQ(out[3], 3);
+}
+
+/** @brief Test vint8 store_nbytes. */
+TEST(vint8, store_nbytes)
+{
+	alignas(16) int out;
+	vint8 a(42, 314, 75, 90, 42, 314, 75, 90);
+	store_nbytes(a, (uint8_t*)&out);
+	EXPECT_EQ(out, 42);
+}
+
+/** @brief Test vint8 gatheri. */
+TEST(vint8, gatheri)
+{
+	vint8 indices(0, 4, 3, 2, 7, 4, 3, 2);
+	vint8 r = gatheri(s32_data, indices);
+	EXPECT_EQ(r.lane<0>(), 0);
+	EXPECT_EQ(r.lane<1>(), 4);
+	EXPECT_EQ(r.lane<2>(), 3);
+	EXPECT_EQ(r.lane<3>(), 2);
+	EXPECT_EQ(r.lane<4>(), 7);
+	EXPECT_EQ(r.lane<5>(), 4);
+	EXPECT_EQ(r.lane<6>(), 3);
+	EXPECT_EQ(r.lane<7>(), 2);
+}
+
+/** @brief Test vint8 pack_low_bytes. */
+TEST(vint8, pack_low_bytes)
+{
+	vint8 a(1, 2, 3, 4, 2, 3, 4, 5);
+	vint8 r = pack_low_bytes(a);
+	EXPECT_EQ(r.lane<0>(), (4 << 24) | (3 << 16) | (2  << 8) | (1 << 0));
+	EXPECT_EQ(r.lane<1>(), (5 << 24) | (4 << 16) | (3  << 8) | (2 << 0));
+}
+
+/** @brief Test vint8 select. */
+TEST(vint8, select)
+{
+	vint8 m1(1, 1, 1, 1, 1, 1, 1, 1);
+	vint8 m2(1, 2, 1, 2, 1, 2, 1, 2);
+	vmask8 cond = m1 == m2;
+
+	vint8 a(1, 3, 3, 1, 1, 3, 3, 1);
+	vint8 b(4, 2, 2, 4, 4, 2, 2, 4);
+
+	vint8 r1 = select(a, b, cond);
+	EXPECT_EQ(r1.lane<0>(), 4);
+	EXPECT_EQ(r1.lane<1>(), 3);
+	EXPECT_EQ(r1.lane<2>(), 2);
+	EXPECT_EQ(r1.lane<3>(), 1);
+	EXPECT_EQ(r1.lane<4>(), 4);
+	EXPECT_EQ(r1.lane<5>(), 3);
+	EXPECT_EQ(r1.lane<6>(), 2);
+	EXPECT_EQ(r1.lane<7>(), 1);
+
+	vint8 r2 = select(b, a, cond);
+	EXPECT_EQ(r2.lane<0>(), 1);
+	EXPECT_EQ(r2.lane<1>(), 2);
+	EXPECT_EQ(r2.lane<2>(), 3);
+	EXPECT_EQ(r2.lane<3>(), 4);
+	EXPECT_EQ(r2.lane<4>(), 1);
+	EXPECT_EQ(r2.lane<5>(), 2);
+	EXPECT_EQ(r2.lane<6>(), 3);
+	EXPECT_EQ(r2.lane<7>(), 4);
+}
+
+/** @brief Test vint8 select MSB. */
+TEST(vint8, select_msb)
+{
+	vint8 msb(0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0);
+	vmask8 cond(msb.m);
+
+	vint8 a(1, 3, 3, 1, 1, 3, 3, 1);
+	vint8 b(4, 2, 2, 4, 4, 2, 2, 4);
+
+	vint8 r1 = select(a, b, cond);
+	EXPECT_EQ(r1.lane<0>(), 4);
+	EXPECT_EQ(r1.lane<1>(), 3);
+	EXPECT_EQ(r1.lane<2>(), 2);
+	EXPECT_EQ(r1.lane<3>(), 1);
+	EXPECT_EQ(r1.lane<4>(), 4);
+	EXPECT_EQ(r1.lane<5>(), 3);
+	EXPECT_EQ(r1.lane<6>(), 2);
+	EXPECT_EQ(r1.lane<7>(), 1);
+
+	vint8 r2 = select(b, a, cond);
+	EXPECT_EQ(r2.lane<0>(), 1);
+	EXPECT_EQ(r2.lane<1>(), 2);
+	EXPECT_EQ(r2.lane<2>(), 3);
+	EXPECT_EQ(r2.lane<3>(), 4);
+	EXPECT_EQ(r2.lane<4>(), 1);
+	EXPECT_EQ(r2.lane<5>(), 2);
+	EXPECT_EQ(r2.lane<6>(), 3);
+	EXPECT_EQ(r2.lane<7>(), 4);
+}
+
+// vmask8 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** @brief Test vmask8 or. */
+TEST(vmask8, or)
+{
+	vfloat8 m1a(0, 1, 0, 1, 0, 1, 0, 1);
+	vfloat8 m1b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m1 = m1a == m1b;
+
+	vfloat8 m2a(1, 1, 0, 0, 1, 1, 0, 0);
+	vfloat8 m2b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m2 = m2a == m2b;
+
+	vmask8 r = m1 | m2;
+	EXPECT_EQ(mask(r), 0xBB);
+}
+
+/** @brief Test vmask8 and. */
+TEST(vmask8, and)
+{
+	vfloat8 m1a(0, 1, 0, 1, 0, 1, 0, 1);
+	vfloat8 m1b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m1 = m1a == m1b;
+
+	vfloat8 m2a(1, 1, 0, 0, 1, 1, 0, 0);
+	vfloat8 m2b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m2 = m2a == m2b;
+
+	vmask8 r = m1 & m2;
+	EXPECT_EQ(mask(r), 0x22);
+}
+
+/** @brief Test vmask8 xor. */
+TEST(vmask8, xor)
+{
+	vfloat8 m1a(0, 1, 0, 1, 0, 1, 0, 1);
+	vfloat8 m1b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m1 = m1a == m1b;
+
+	vfloat8 m2a(1, 1, 0, 0, 1, 1, 0, 0);
+	vfloat8 m2b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m2 = m2a == m2b;
+
+	vmask8 r = m1 ^ m2;
+	EXPECT_EQ(mask(r), 0x99);
+}
+
+/** @brief Test vmask8 not. */
+TEST(vmask8, not)
+{
+	vfloat8 m1a(0, 1, 0, 1, 0, 1, 0, 1);
+	vfloat8 m1b(1, 1, 1, 1, 1, 1, 1, 1);
+	vmask8 m1 = m1a == m1b;
+	vmask8 r = ~m1;
+	EXPECT_EQ(mask(r), 0x55);
+}
+
+#endif
 
 }

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -33,11 +33,60 @@
 namespace astcenc
 {
 
+// Misc utility tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+static int round_down(int x)
+{
+	int remainder = x % ASTCENC_SIMD_WIDTH;
+	return x - remainder;
+}
+
+static int round_up(int x)
+{
+	int remainder = x % ASTCENC_SIMD_WIDTH;
+	if (!remainder)
+	{
+		return x;
+	}
+
+	return x - remainder + ASTCENC_SIMD_WIDTH;
+}
+
+/** @brief Test VLA loop limit round down. */
+TEST(misc, RoundDownVLA)
+{
+	// Static ones which are valid for all VLA widths
+	EXPECT_EQ(round_down_to_simd_multiple_vla(0),  0);
+	EXPECT_EQ(round_down_to_simd_multiple_vla(8),  8);
+	EXPECT_EQ(round_down_to_simd_multiple_vla(16), 16);
+
+	// Variable ones which depend on VLA width
+	EXPECT_EQ(round_down_to_simd_multiple_vla(3),   round_down(3));
+	EXPECT_EQ(round_down_to_simd_multiple_vla(5),   round_down(5));
+	EXPECT_EQ(round_down_to_simd_multiple_vla(7),   round_down(7));
+	EXPECT_EQ(round_down_to_simd_multiple_vla(231), round_down(231));
+}
+
+/** @brief Test VLA loop limit round up. */
+TEST(misc, RoundUpVLA)
+{
+	// Static ones which are valid for all VLA widths
+	EXPECT_EQ(round_up_to_simd_multiple_vla(0),  0);
+	EXPECT_EQ(round_up_to_simd_multiple_vla(8),  8);
+	EXPECT_EQ(round_up_to_simd_multiple_vla(16), 16);
+
+	// Variable ones which depend on VLA width
+	EXPECT_EQ(round_up_to_simd_multiple_vla(3),   round_up(3));
+	EXPECT_EQ(round_up_to_simd_multiple_vla(5),   round_up(5));
+	EXPECT_EQ(round_up_to_simd_multiple_vla(7),   round_up(7));
+	EXPECT_EQ(round_up_to_simd_multiple_vla(231), round_up(231));
+}
+
 #if ASTCENC_SIMD_WIDTH == 4
 
 // VLA (4-wide) tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-/** \brief Test VLA change_sign. */
+/** @brief Test VLA change_sign. */
 TEST(vfloat, ChangeSign)
 {
 	vfloat a(-1.0f,  1.0f, -3.12f, 3.12f);
@@ -49,7 +98,7 @@ TEST(vfloat, ChangeSign)
 	EXPECT_EQ(r.lane<3>(),  3.12f);
 }
 
-/** \brief Test VLA atan. */
+/** @brief Test VLA atan. */
 TEST(vfloat, Atan)
 {
 	vfloat a(-0.15f, 0.0f, 0.9f, 2.1f);
@@ -60,7 +109,7 @@ TEST(vfloat, Atan)
 	EXPECT_NEAR(r.lane<3>(),  1.123040f, 0.005f);
 }
 
-/** \brief Test VLA atan2. */
+/** @brief Test VLA atan2. */
 TEST(vfloat, Atan2)
 {
 	vfloat a(-0.15f, 0.0f, 0.9f, 2.1f);
@@ -80,7 +129,7 @@ alignas(16) static const int s32x4_data[5] {      0,    1,    2,    3,    4 };
 
 // VFLOAT4 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-/** \brief Test unaligned vfloat4 data load. */
+/** @brief Test unaligned vfloat4 data load. */
 TEST(vfloat4, UnalignedLoad)
 {
 	vfloat4 a(&(f32x4_data[1]));
@@ -90,7 +139,7 @@ TEST(vfloat4, UnalignedLoad)
 	EXPECT_EQ(a.lane<3>(), 4.0f);
 }
 
-/** \brief Test scalar duplicated vfloat4 load. */
+/** @brief Test scalar duplicated vfloat4 load. */
 TEST(vfloat4, ScalarDupLoad)
 {
 	vfloat4 a(1.1f);
@@ -100,7 +149,7 @@ TEST(vfloat4, ScalarDupLoad)
 	EXPECT_EQ(a.lane<3>(), 1.1f);
 }
 
-/** \brief Test scalar vfloat4 load. */
+/** @brief Test scalar vfloat4 load. */
 TEST(vfloat4, ScalarLoad)
 {
 	vfloat4 a(1.1f, 2.2f, 3.3f, 4.4f);
@@ -110,7 +159,7 @@ TEST(vfloat4, ScalarLoad)
 	EXPECT_EQ(a.lane<3>(), 4.4f);
 }
 
-/** \brief Test copy vfloat4 load. */
+/** @brief Test copy vfloat4 load. */
 TEST(vfloat4, CopyLoad)
 {
 	vfloat4 s(1.1f, 2.2f, 3.3f, 4.4f);
@@ -121,7 +170,7 @@ TEST(vfloat4, CopyLoad)
 	EXPECT_EQ(a.lane<3>(), 4.4f);
 }
 
-/** \brief Test vfloat4 scalar lane set. */
+/** @brief Test vfloat4 scalar lane set. */
 TEST(vfloat4, SetLane)
 {
 	vfloat4 a(0.0f);
@@ -151,7 +200,7 @@ TEST(vfloat4, SetLane)
 	EXPECT_EQ(a.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 zero. */
+/** @brief Test vfloat4 zero. */
 TEST(vfloat4, Zero)
 {
 	vfloat4 a = vfloat4::zero();
@@ -161,7 +210,7 @@ TEST(vfloat4, Zero)
 	EXPECT_EQ(a.lane<3>(), 0.0f);
 }
 
-/** \brief Test vfloat4 load1. */
+/** @brief Test vfloat4 load1. */
 TEST(vfloat4, Load1)
 {
 	float s = 3.14f;
@@ -172,7 +221,7 @@ TEST(vfloat4, Load1)
 	EXPECT_EQ(a.lane<3>(), 3.14f);
 }
 
-/** \brief Test vfloat4 loada. */
+/** @brief Test vfloat4 loada. */
 TEST(vfloat4, Loada)
 {
 	vfloat4 a(&(f32x4_data[0]));
@@ -182,7 +231,7 @@ TEST(vfloat4, Loada)
 	EXPECT_EQ(a.lane<3>(), 3.0f);
 }
 
-/** \brief Test vfloat4 lane_id. */
+/** @brief Test vfloat4 lane_id. */
 TEST(vfloat4, LaneID)
 {
 	vfloat4 a = vfloat4::lane_id();
@@ -192,7 +241,7 @@ TEST(vfloat4, LaneID)
 	EXPECT_EQ(a.lane<3>(), 3.0f);
 }
 
-/** \brief Test vfloat4 add. */
+/** @brief Test vfloat4 add. */
 TEST(vfloat4, vadd)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -204,7 +253,7 @@ TEST(vfloat4, vadd)
 	EXPECT_EQ(a.lane<3>(), 4.0f + 0.4f);
 }
 
-/** \brief Test vfloat4 sub. */
+/** @brief Test vfloat4 sub. */
 TEST(vfloat4, vsub)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -216,7 +265,7 @@ TEST(vfloat4, vsub)
 	EXPECT_EQ(a.lane<3>(), 4.0f - 0.4f);
 }
 
-/** \brief Test vfloat4 mul. */
+/** @brief Test vfloat4 mul. */
 TEST(vfloat4, vmul)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -228,7 +277,7 @@ TEST(vfloat4, vmul)
 	EXPECT_EQ(a.lane<3>(), 4.0f * 0.4f);
 }
 
-/** \brief Test vfloat4 mul. */
+/** @brief Test vfloat4 mul. */
 TEST(vfloat4, vsmul)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -240,7 +289,7 @@ TEST(vfloat4, vsmul)
 	EXPECT_EQ(a.lane<3>(), 4.0f * 3.14f);
 }
 
-/** \brief Test vfloat4 mul. */
+/** @brief Test vfloat4 mul. */
 TEST(vfloat4, svmul)
 {
 	float a = 3.14f;
@@ -252,7 +301,7 @@ TEST(vfloat4, svmul)
 	EXPECT_EQ(b.lane<3>(), 3.14f * 4.0f);
 }
 
-/** \brief Test vfloat4 div. */
+/** @brief Test vfloat4 div. */
 TEST(vfloat4, vdiv)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -264,7 +313,7 @@ TEST(vfloat4, vdiv)
 	EXPECT_EQ(a.lane<3>(), 4.0f / 0.4f);
 }
 
-/** \brief Test vfloat4 ceq. */
+/** @brief Test vfloat4 ceq. */
 TEST(vfloat4, ceq)
 {
 	vfloat4 a1(1.0f, 2.0f, 3.0f, 4.0f);
@@ -295,7 +344,7 @@ TEST(vfloat4, ceq)
 	EXPECT_EQ(true, all(r4));
 }
 
-/** \brief Test vfloat4 cne. */
+/** @brief Test vfloat4 cne. */
 TEST(vfloat4, cne)
 {
 	vfloat4 a1(1.0f, 2.0f, 3.0f, 4.0f);
@@ -326,7 +375,7 @@ TEST(vfloat4, cne)
 	EXPECT_EQ(false, all(r4));
 }
 
-/** \brief Test vfloat4 clt. */
+/** @brief Test vfloat4 clt. */
 TEST(vfloat4, clt)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -335,7 +384,7 @@ TEST(vfloat4, clt)
 	EXPECT_EQ(0xA, mask(r));
 }
 
-/** \brief Test vfloat4 cle. */
+/** @brief Test vfloat4 cle. */
 TEST(vfloat4, cle)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -344,7 +393,7 @@ TEST(vfloat4, cle)
 	EXPECT_EQ(0xE, mask(r));
 }
 
-/** \brief Test vfloat4 cgt. */
+/** @brief Test vfloat4 cgt. */
 TEST(vfloat4, cgt)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -353,7 +402,7 @@ TEST(vfloat4, cgt)
 	EXPECT_EQ(0x1, mask(r));
 }
 
-/** \brief Test vfloat4 cge. */
+/** @brief Test vfloat4 cge. */
 TEST(vfloat4, cge)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -362,7 +411,7 @@ TEST(vfloat4, cge)
 	EXPECT_EQ(0x5, mask(r));
 }
 
-/** \brief Test vfloat4 min. */
+/** @brief Test vfloat4 min. */
 TEST(vfloat4, min)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -374,7 +423,7 @@ TEST(vfloat4, min)
 	EXPECT_EQ(r.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 max. */
+/** @brief Test vfloat4 max. */
 TEST(vfloat4, max)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -386,7 +435,7 @@ TEST(vfloat4, max)
 	EXPECT_EQ(r.lane<3>(), 4.1f);
 }
 
-/** \brief Test vfloat4 clamp. */
+/** @brief Test vfloat4 clamp. */
 TEST(vfloat4, clamp)
 {
 	vfloat4 a1(1.0f, 2.0f, 3.0f, 4.0f);
@@ -404,7 +453,7 @@ TEST(vfloat4, clamp)
 	EXPECT_EQ(r2.lane<3>(), 3.0f);
 }
 
-/** \brief Test vfloat4 clampz. */
+/** @brief Test vfloat4 clampz. */
 TEST(vfloat4, clampz)
 {
 	vfloat4 a1(-1.0f, 0.0f, 0.1f, 4.0f);
@@ -422,7 +471,7 @@ TEST(vfloat4, clampz)
 	EXPECT_EQ(r2.lane<3>(), 3.0f);
 }
 
-/** \brief Test vfloat4 clampz. */
+/** @brief Test vfloat4 clampz. */
 TEST(vfloat4, clampzo)
 {
 	vfloat4 a1(-1.0f, 0.0f, 0.1f, 4.0f);
@@ -440,7 +489,7 @@ TEST(vfloat4, clampzo)
 	EXPECT_EQ(r2.lane<3>(), 1.0f);
 }
 
-/** \brief Test vfloat4 abs. */
+/** @brief Test vfloat4 abs. */
 TEST(vfloat4, abs)
 {
 	vfloat4 a(-1.0f, 0.0f, 0.1f, 4.0f);
@@ -451,7 +500,7 @@ TEST(vfloat4, abs)
 	EXPECT_EQ(r.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 round. */
+/** @brief Test vfloat4 round. */
 TEST(vfloat4, round)
 {
 	vfloat4 a(1.1f, 1.5f, 1.6f, 4.0f);
@@ -462,7 +511,7 @@ TEST(vfloat4, round)
 	EXPECT_EQ(r.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 hmin. */
+/** @brief Test vfloat4 hmin. */
 TEST(vfloat4, hmin)
 {
 	vfloat4 a1(1.1f, 1.5f, 1.6f, 4.0f);
@@ -480,7 +529,7 @@ TEST(vfloat4, hmin)
 	EXPECT_EQ(r2.lane<3>(), 0.2f);
 }
 
-/** \brief Test vfloat4 sqrt. */
+/** @brief Test vfloat4 sqrt. */
 TEST(vfloat4, sqrt)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
@@ -491,7 +540,7 @@ TEST(vfloat4, sqrt)
 	EXPECT_EQ(r.lane<3>(), std::sqrt(4.0f));
 }
 
-/** \brief Test vfloat4 select. */
+/** @brief Test vfloat4 select. */
 TEST(vfloat4, select)
 {
 	vfloat4 m1(1.0f, 1.0f, 1.0f, 1.0f);
@@ -516,7 +565,7 @@ TEST(vfloat4, select)
 	EXPECT_EQ(r2.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 select MSB only. */
+/** @brief Test vfloat4 select MSB only. */
 TEST(vfloat4, select_msb)
 {
 	vint4 msb(0x80000000u, 0, 0x80000000u, 0);
@@ -540,7 +589,7 @@ TEST(vfloat4, select_msb)
 	EXPECT_EQ(r2.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 gatherf. */
+/** @brief Test vfloat4 gatherf. */
 TEST(vfloat4, gatherf)
 {
 	vint4 indices(0, 4, 3, 2);
@@ -551,7 +600,7 @@ TEST(vfloat4, gatherf)
 	EXPECT_EQ(r.lane<3>(), 2.0f);
 }
 
-/** \brief Test vfloat4 store. */
+/** @brief Test vfloat4 store. */
 TEST(vfloat4, store)
 {
 	alignas(16) float out[5];
@@ -563,7 +612,7 @@ TEST(vfloat4, store)
 	EXPECT_EQ(out[4], 3.0f);
 }
 
-/** \brief Test vfloat4 storea. */
+/** @brief Test vfloat4 storea. */
 TEST(vfloat4, storea)
 {
 	alignas(16) float out[4];
@@ -575,7 +624,7 @@ TEST(vfloat4, storea)
 	EXPECT_EQ(out[3], 3.0f);
 }
 
-/** \brief Test vfloat4 dot. */
+/** @brief Test vfloat4 dot. */
 TEST(vfloat4, dot)
 {
 	vfloat4 a(1.0f, 2.0f, 4.0f, 8.0f);
@@ -587,7 +636,7 @@ TEST(vfloat4, dot)
 	EXPECT_EQ(r.lane<3>(), 4.0f);
 }
 
-/** \brief Test vfloat4 float_to_int. */
+/** @brief Test vfloat4 float_to_int. */
 TEST(vfloat4, float_to_int)
 {
 	vfloat4 a(1.1f, 1.5f, 1.6f, 4.0f);
@@ -598,7 +647,7 @@ TEST(vfloat4, float_to_int)
 	EXPECT_EQ(r.lane<3>(), 4);
 }
 
-/** \brief Test vfloat4 round. */
+/** @brief Test vfloat4 round. */
 TEST(vfloat4, float_to_int_rtn)
 {
 	vfloat4 a(1.1f, 1.5f, 1.6f, 4.0f);
@@ -612,7 +661,7 @@ TEST(vfloat4, float_to_int_rtn)
 
 // VINT4 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-/** \brief Test unaligned vint4 data load. */
+/** @brief Test unaligned vint4 data load. */
 TEST(vint4, UnalignedLoad)
 {
 	vint4 a(&(s32x4_data[1]));
@@ -622,7 +671,7 @@ TEST(vint4, UnalignedLoad)
 	EXPECT_EQ(a.lane<3>(), 4);
 }
 
-/** \brief Test scalar duplicated vint4 load. */
+/** @brief Test scalar duplicated vint4 load. */
 TEST(vint4, ScalarDupLoad)
 {
 	vint4 a(42);
@@ -632,7 +681,7 @@ TEST(vint4, ScalarDupLoad)
 	EXPECT_EQ(a.lane<3>(), 42);
 }
 
-/** \brief Test scalar vint4 load. */
+/** @brief Test scalar vint4 load. */
 TEST(vint4, ScalarLoad)
 {
 	vint4 a(11, 22, 33, 44);
@@ -642,7 +691,7 @@ TEST(vint4, ScalarLoad)
 	EXPECT_EQ(a.lane<3>(), 44);
 }
 
-/** \brief Test copy vint4 load. */
+/** @brief Test copy vint4 load. */
 TEST(vint4, CopyLoad)
 {
 	vint4 s(11, 22, 33, 44);
@@ -653,7 +702,7 @@ TEST(vint4, CopyLoad)
 	EXPECT_EQ(a.lane<3>(), 44);
 }
 
-/** \brief Test vint4 lane_id. */
+/** @brief Test vint4 lane_id. */
 TEST(vint4, LaneID)
 {
 	vint4 a = vint4::lane_id();
@@ -663,7 +712,7 @@ TEST(vint4, LaneID)
 	EXPECT_EQ(a.lane<3>(), 3);
 }
 
-/** \brief Test vint4 add. */
+/** @brief Test vint4 add. */
 TEST(vint4, vadd)
 {
 	vint4 a(1, 2, 3, 4);
@@ -675,7 +724,7 @@ TEST(vint4, vadd)
 	EXPECT_EQ(a.lane<3>(), 4 + 5);
 }
 
-/** \brief Test vint4 sub. */
+/** @brief Test vint4 sub. */
 TEST(vint4, vsub)
 {
 	vint4 a(1, 2, 4, 4);
@@ -687,7 +736,7 @@ TEST(vint4, vsub)
 	EXPECT_EQ(a.lane<3>(), 4 - 5);
 }
 
-/** \brief Test vint4 bitwise invert. */
+/** @brief Test vint4 bitwise invert. */
 TEST(vint4, bit_invert)
 {
 	vint4 a(-1, 0, 1, 2);
@@ -698,7 +747,7 @@ TEST(vint4, bit_invert)
 	EXPECT_EQ(a.lane<3>(), ~2);
 }
 
-/** \brief Test vint4 bitwise or. */
+/** @brief Test vint4 bitwise or. */
 TEST(vint4, bit_vor)
 {
 	vint4 a(1, 2, 3, 4);
@@ -710,7 +759,7 @@ TEST(vint4, bit_vor)
 	EXPECT_EQ(a.lane<3>(), 5);
 }
 
-/** \brief Test vint4 bitwise and. */
+/** @brief Test vint4 bitwise and. */
 TEST(vint4, bit_vand)
 {
 	vint4 a(1, 2, 3, 4);
@@ -722,7 +771,7 @@ TEST(vint4, bit_vand)
 	EXPECT_EQ(a.lane<3>(), 4);
 }
 
-/** \brief Test vint4 bitwise xor. */
+/** @brief Test vint4 bitwise xor. */
 TEST(vint4, bit_vxor)
 {
 	vint4 a(1, 2, 3, 4);
@@ -734,7 +783,7 @@ TEST(vint4, bit_vxor)
 	EXPECT_EQ(a.lane<3>(), 1);
 }
 
-/** \brief Test vint4 ceq. */
+/** @brief Test vint4 ceq. */
 TEST(vint4, ceq)
 {
 	vint4 a1(1, 2, 3, 4);
@@ -765,7 +814,7 @@ TEST(vint4, ceq)
 	EXPECT_EQ(true, all(r4));
 }
 
-/** \brief Test vint4 cne. */
+/** @brief Test vint4 cne. */
 TEST(vint4, cne)
 {
 	vint4 a1(1, 2, 3, 4);
@@ -796,7 +845,7 @@ TEST(vint4, cne)
 	EXPECT_EQ(false, all(r4));
 }
 
-/** \brief Test vint4 clt. */
+/** @brief Test vint4 clt. */
 TEST(vint4, clt)
 {
 	vint4 a(1, 2, 3, 4);
@@ -805,7 +854,7 @@ TEST(vint4, clt)
 	EXPECT_EQ(0xA, mask(r));
 }
 
-/** \brief Test vint4 cgt. */
+/** @brief Test vint4 cgt. */
 TEST(vint4, cle)
 {
 	vint4 a(1, 2, 3, 4);
@@ -814,7 +863,7 @@ TEST(vint4, cle)
 	EXPECT_EQ(0x1, mask(r));
 }
 
-/** \brief Test vint4 min. */
+/** @brief Test vint4 min. */
 TEST(vint4, min)
 {
 	vint4 a(1, 2, 3, 4);
@@ -826,7 +875,7 @@ TEST(vint4, min)
 	EXPECT_EQ(r.lane<3>(), 4);
 }
 
-/** \brief Test vint4 max. */
+/** @brief Test vint4 max. */
 TEST(vint4, max)
 {
 	vint4 a(1, 2, 3, 4);
@@ -838,7 +887,7 @@ TEST(vint4, max)
 	EXPECT_EQ(r.lane<3>(), 5);
 }
 
-/** \brief Test vint4 hmin. */
+/** @brief Test vint4 hmin. */
 TEST(vint4, hmin)
 {
 	vint4 a1(1, 2, 1, 2);
@@ -856,7 +905,7 @@ TEST(vint4, hmin)
 	EXPECT_EQ(r2.lane<3>(), -1);
 }
 
-/** \brief Test vint4 storea. */
+/** @brief Test vint4 storea. */
 TEST(vint4, storea)
 {
 	alignas(16) int out[4];
@@ -868,7 +917,7 @@ TEST(vint4, storea)
 	EXPECT_EQ(out[3], 3);
 }
 
-/** \brief Test vint4 store_nbytes. */
+/** @brief Test vint4 store_nbytes. */
 TEST(vint4, store_nbytes)
 {
 	alignas(16) int out;
@@ -877,7 +926,7 @@ TEST(vint4, store_nbytes)
 	EXPECT_EQ(out, 42);
 }
 
-/** \brief Test vint4 gatheri. */
+/** @brief Test vint4 gatheri. */
 TEST(vint4, gatheri)
 {
 	vint4 indices(0, 4, 3, 2);
@@ -888,7 +937,7 @@ TEST(vint4, gatheri)
 	EXPECT_EQ(r.lane<3>(), 2);
 }
 
-/** \brief Test vint4 pack_low_bytes. */
+/** @brief Test vint4 pack_low_bytes. */
 TEST(vint4, pack_low_bytes)
 {
 	vint4 a(1, 2, 3, 4);
@@ -896,7 +945,7 @@ TEST(vint4, pack_low_bytes)
 	EXPECT_EQ(r.lane<0>(), (4 << 24) | (3 << 16) | (2  << 8) | (1 << 0));
 }
 
-/** \brief Test vint4 select. */
+/** @brief Test vint4 select. */
 TEST(vint4, select)
 {
 	vint4 m1(1, 1, 1, 1);
@@ -919,7 +968,7 @@ TEST(vint4, select)
 	EXPECT_EQ(r2.lane<3>(), 4);
 }
 
-/** \brief Test vint4 select MSB. */
+/** @brief Test vint4 select MSB. */
 TEST(vint4, select_msb)
 {
 	vint4 msb(0x80000000u, 0, 0x80000000u, 0);
@@ -942,7 +991,7 @@ TEST(vint4, select_msb)
 }
 
 // VMASK4 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/** \brief Test vmask4 or. */
+/** @brief Test vmask4 or. */
 TEST(vmask4, or)
 {
 	vfloat4 m1a(0, 1, 0, 1);
@@ -957,7 +1006,7 @@ TEST(vmask4, or)
 	EXPECT_EQ(mask(r), 0xB);
 }
 
-/** \brief Test vmask4 and. */
+/** @brief Test vmask4 and. */
 TEST(vmask4, and)
 {
 	vfloat4 m1a(0, 1, 0, 1);
@@ -972,7 +1021,7 @@ TEST(vmask4, and)
 	EXPECT_EQ(mask(r), 0x2);
 }
 
-/** \brief Test vmask4 xor. */
+/** @brief Test vmask4 xor. */
 TEST(vmask4, xor)
 {
 	vfloat4 m1a(0, 1, 0, 1);
@@ -987,7 +1036,7 @@ TEST(vmask4, xor)
 	EXPECT_EQ(mask(r), 0x9);
 }
 
-/** \brief Test vmask4 not. */
+/** @brief Test vmask4 not. */
 TEST(vmask4, not)
 {
 	vfloat4 m1a(0, 1, 0, 1);

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -658,6 +658,15 @@ TEST(vfloat4, hmin)
 	EXPECT_EQ(r2.lane<3>(), 0.2f);
 }
 
+/** @brief Test vfloat4 hadd. */
+TEST(vfloat4, hadd)
+{
+	vfloat4 a1(1.1f, 1.5f, 1.6f, 4.0f);
+	float sum = 1.1f + 1.5f + 1.6f + 4.0f;
+	float r = hadd(a1);
+	EXPECT_NEAR(r, sum, 0.005f);
+}
+
 /** @brief Test vfloat4 sqrt. */
 TEST(vfloat4, sqrt)
 {
@@ -829,6 +838,38 @@ TEST(vint4, CopyLoad)
 	EXPECT_EQ(a.lane<1>(), 22);
 	EXPECT_EQ(a.lane<2>(), 33);
 	EXPECT_EQ(a.lane<3>(), 44);
+}
+
+
+/** @brief Test vint4 zero. */
+TEST(vint4, Zero)
+{
+	vint4 a = vint4::zero();
+	EXPECT_EQ(a.lane<0>(), 0);
+	EXPECT_EQ(a.lane<1>(), 0);
+	EXPECT_EQ(a.lane<2>(), 0);
+	EXPECT_EQ(a.lane<3>(), 0);
+}
+
+/** @brief Test vint4 load1. */
+TEST(vint4, Load1)
+{
+	int s = 42;
+	vint4 a = vint4::load1(&s);
+	EXPECT_EQ(a.lane<0>(), 42);
+	EXPECT_EQ(a.lane<1>(), 42);
+	EXPECT_EQ(a.lane<2>(), 42);
+	EXPECT_EQ(a.lane<3>(), 42);
+}
+
+/** @brief Test vint4 loada. */
+TEST(vint4, Loada)
+{
+	vint4 a(&(s32_data[0]));
+	EXPECT_EQ(a.lane<0>(), 0);
+	EXPECT_EQ(a.lane<1>(), 1);
+	EXPECT_EQ(a.lane<2>(), 2);
+	EXPECT_EQ(a.lane<3>(), 3);
 }
 
 /** @brief Test vint4 lane_id. */
@@ -1653,6 +1694,15 @@ TEST(vfloat8, hmin)
 	EXPECT_EQ(r2.lane<7>(), 0.2f);
 }
 
+/** @brief Test vfloat8 hadd. */
+TEST(vfloat8, hadd)
+{
+	vfloat8 a1(1.1f, 1.5f, 1.6f, 4.0f, 1.1f, 1.5f, 1.6f, 4.0f);
+	float sum = 1.1f + 1.5f + 1.6f + 4.0f + 1.1f + 1.5f + 1.6f + 4.0f;
+	float r = hadd(a1);
+	EXPECT_NEAR(r, sum, 0.005f);
+}
+
 /** @brief Test vfloat8 sqrt. */
 TEST(vfloat8, sqrt)
 {
@@ -1853,6 +1903,49 @@ TEST(vint8, CopyLoad)
 	EXPECT_EQ(a.lane<5>(), 66);
 	EXPECT_EQ(a.lane<6>(), 77);
 	EXPECT_EQ(a.lane<7>(), 88);
+}
+
+/** @brief Test vint8 zero. */
+TEST(vint8, Zero)
+{
+	vint8 a = vint8::zero();
+	EXPECT_EQ(a.lane<0>(), 0);
+	EXPECT_EQ(a.lane<1>(), 0);
+	EXPECT_EQ(a.lane<2>(), 0);
+	EXPECT_EQ(a.lane<3>(), 0);
+	EXPECT_EQ(a.lane<4>(), 0);
+	EXPECT_EQ(a.lane<5>(), 0);
+	EXPECT_EQ(a.lane<6>(), 0);
+	EXPECT_EQ(a.lane<7>(), 0);
+}
+
+/** @brief Test vint8 load1. */
+TEST(vint8, Load1)
+{
+	int s = 42;
+	vint8 a = vint8::load1(&s);
+	EXPECT_EQ(a.lane<0>(), 42);
+	EXPECT_EQ(a.lane<1>(), 42);
+	EXPECT_EQ(a.lane<2>(), 42);
+	EXPECT_EQ(a.lane<3>(), 42);
+	EXPECT_EQ(a.lane<4>(), 42);
+	EXPECT_EQ(a.lane<5>(), 42);
+	EXPECT_EQ(a.lane<6>(), 42);
+	EXPECT_EQ(a.lane<7>(), 42);
+}
+
+/** @brief Test vint8 loada. */
+TEST(vint8, Loada)
+{
+	vint8 a(&(s32_data[0]));
+	EXPECT_EQ(a.lane<0>(), 0);
+	EXPECT_EQ(a.lane<1>(), 1);
+	EXPECT_EQ(a.lane<2>(), 2);
+	EXPECT_EQ(a.lane<3>(), 3);
+	EXPECT_EQ(a.lane<4>(), 4);
+	EXPECT_EQ(a.lane<5>(), 5);
+	EXPECT_EQ(a.lane<6>(), 6);
+	EXPECT_EQ(a.lane<7>(), 7);
 }
 
 /** @brief Test vint8 lane_id. */

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -82,7 +82,79 @@ TEST(misc, RoundUpVLA)
 	EXPECT_EQ(round_up_to_simd_multiple_vla(231), round_up(231));
 }
 
-#if ASTCENC_SIMD_WIDTH == 4
+#if ASTCENC_SIMD_WIDTH == 1
+
+// VLA (1-wide) tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/** @brief Test VLA change_sign. */
+TEST(vfloat, ChangeSign)
+{
+	vfloat a0(-1.0f);
+	vfloat b0(-1.0f);
+	vfloat r0 = change_sign(a0, b0);
+	EXPECT_EQ(r0.lane<0>(), 1.0f);
+
+	vfloat a1( 1.0f);
+	vfloat b1(-1.0f);
+	vfloat r1 = change_sign(a1, b1);
+	EXPECT_EQ(r1.lane<0>(), -1.0f);
+
+	vfloat a2(-3.12f);
+	vfloat b2( 3.12f);
+	vfloat r2 = change_sign(a2, b2);
+	EXPECT_EQ(r2.lane<0>(), -3.12f);
+
+	vfloat a3( 3.12f);
+	vfloat b3( 3.12f);
+	vfloat r3 = change_sign(a3, b3);
+	EXPECT_EQ(r3.lane<0>(), 3.12f);
+}
+
+/** @brief Test VLA atan. */
+TEST(vfloat, Atan)
+{
+	vfloat a0(-0.15f);
+	vfloat r0 = atan(a0);
+	EXPECT_NEAR(r0.lane<0>(), -0.149061f, 0.005f);
+
+	vfloat a1(0.0f);
+	vfloat r1 = atan(a1);
+	EXPECT_NEAR(r1.lane<0>(),  0.000000f, 0.005f);
+
+	vfloat a2(0.9f);
+	vfloat r2 = atan(a2);
+	EXPECT_NEAR(r2.lane<0>(),  0.733616f, 0.005f);
+
+	vfloat a3(2.1f);
+	vfloat r3 = atan(a3);
+	EXPECT_NEAR(r3.lane<0>(),  1.123040f, 0.005f);
+}
+
+/** @brief Test VLA atan2. */
+TEST(vfloat, Atan2)
+{
+	vfloat a0(-0.15f);
+	vfloat b0( 1.15f);
+	vfloat r0 = atan2(a0, b0);
+	EXPECT_NEAR(r0.lane<0>(), -0.129816f, 0.005f);
+
+	vfloat a1( 0.0f);
+	vfloat b1(-3.0f);
+	vfloat r1 = atan2(a1, b1);
+	EXPECT_NEAR(r1.lane<0>(),  3.141592f, 0.005f);
+
+	vfloat a2( 0.9f);
+	vfloat b2(-0.9f);
+	vfloat r2 = atan2(a2, b2);
+	EXPECT_NEAR(r2.lane<0>(),  2.360342f, 0.005f);
+
+	vfloat a3( 2.1f);
+	vfloat b3( 1.1f);
+	vfloat r3 = atan2(a3, b3);
+	EXPECT_NEAR(r3.lane<0>(),  1.084357f, 0.005f);
+}
+
+#elif ASTCENC_SIMD_WIDTH == 4
 
 // VLA (4-wide) tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -119,6 +191,57 @@ TEST(vfloat, Atan2)
 	EXPECT_NEAR(r.lane<1>(),  3.141592f, 0.005f);
 	EXPECT_NEAR(r.lane<2>(),  2.360342f, 0.005f);
 	EXPECT_NEAR(r.lane<3>(),  1.084357f, 0.005f);
+}
+
+#elif ASTCENC_SIMD_WIDTH == 8
+
+// VLA (8-wide) tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/** @brief Test VLA change_sign. */
+TEST(vfloat, ChangeSign)
+{
+	vfloat a(-1.0f,  1.0f, -3.12f, 3.12f, -1.0f,  1.0f, -3.12f, 3.12f);
+	vfloat b(-1.0f, -1.0f,  3.12f, 3.12f, -1.0f, -1.0f,  3.12f, 3.12f);
+	vfloat r = change_sign(a, b);
+	EXPECT_EQ(r.lane<0>(),  1.0f);
+	EXPECT_EQ(r.lane<1>(), -1.0f);
+	EXPECT_EQ(r.lane<2>(), -3.12f);
+	EXPECT_EQ(r.lane<3>(),  3.12f);
+	EXPECT_EQ(r.lane<4>(),  1.0f);
+	EXPECT_EQ(r.lane<5>(), -1.0f);
+	EXPECT_EQ(r.lane<6>(), -3.12f);
+	EXPECT_EQ(r.lane<7>(),  3.12f);
+}
+
+/** @brief Test VLA atan. */
+TEST(vfloat, Atan)
+{
+	vfloat a(-0.15f, 0.0f, 0.9f, 2.1f, -0.15f, 0.0f, 0.9f, 2.1f);
+	vfloat r = atan(a);
+	EXPECT_NEAR(r.lane<0>(), -0.149061f, 0.005f);
+	EXPECT_NEAR(r.lane<1>(),  0.000000f, 0.005f);
+	EXPECT_NEAR(r.lane<2>(),  0.733616f, 0.005f);
+	EXPECT_NEAR(r.lane<3>(),  1.123040f, 0.005f);
+	EXPECT_NEAR(r.lane<4>(), -0.149061f, 0.005f);
+	EXPECT_NEAR(r.lane<5>(),  0.000000f, 0.005f);
+	EXPECT_NEAR(r.lane<6>(),  0.733616f, 0.005f);
+	EXPECT_NEAR(r.lane<7>(),  1.123040f, 0.005f);
+}
+
+/** @brief Test VLA atan2. */
+TEST(vfloat, Atan2)
+{
+	vfloat a(-0.15f, 0.0f, 0.9f, 2.1f, -0.15f, 0.0f, 0.9f, 2.1f);
+	vfloat b(1.15f, -3.0f, -0.9f, 1.1f, 1.15f, -3.0f, -0.9f, 1.1f);
+	vfloat r = atan2(a, b);
+	EXPECT_NEAR(r.lane<0>(), -0.129816f, 0.005f);
+	EXPECT_NEAR(r.lane<1>(),  3.141592f, 0.005f);
+	EXPECT_NEAR(r.lane<2>(),  2.360342f, 0.005f);
+	EXPECT_NEAR(r.lane<3>(),  1.084357f, 0.005f);
+	EXPECT_NEAR(r.lane<4>(), -0.129816f, 0.005f);
+	EXPECT_NEAR(r.lane<5>(),  3.141592f, 0.005f);
+	EXPECT_NEAR(r.lane<6>(),  2.360342f, 0.005f);
+	EXPECT_NEAR(r.lane<7>(),  1.084357f, 0.005f);
 }
 
 #endif

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2020 Arm Limited
+// Copyright 2020-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -706,7 +706,7 @@ TEST(vfloat4, select)
 /** @brief Test vfloat4 select MSB only. */
 TEST(vfloat4, select_msb)
 {
-	vint4 msb(0x80000000u, 0, 0x80000000u, 0);
+	vint4 msb(0x80000000, 0, 0x80000000, 0);
 	vmask4 cond(msb.m);
 
 	vfloat4 a(1.0f, 3.0f, 3.0f, 1.0f);
@@ -1141,7 +1141,7 @@ TEST(vint4, select)
 /** @brief Test vint4 select MSB. */
 TEST(vint4, select_msb)
 {
-	vint4 msb(0x80000000u, 0, 0x80000000u, 0);
+	vint4 msb(0x80000000, 0, 0x80000000, 0);
 	vmask4 cond(msb.m);
 
 	vint4 a(1, 3, 3, 1);
@@ -1754,7 +1754,7 @@ TEST(vfloat8, select)
 /** @brief Test vfloat8 select MSB only. */
 TEST(vfloat8, select_msb)
 {
-	vint8 msb(0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0);
+	vint8 msb(0x80000000, 0, 0x80000000, 0, 0x80000000, 0, 0x80000000, 0);
 	vmask8 cond(msb.m);
 
 	vfloat8 a(1.0f, 3.0f, 3.0f, 1.0f, 1.0f, 3.0f, 3.0f, 1.0f);
@@ -2198,22 +2198,27 @@ TEST(vint8, hmin)
 /** @brief Test vint8 storea. */
 TEST(vint8, storea)
 {
-	alignas(16) int out[4];
+	alignas(32) int out[8];
 	vint8 a(s32_data);
 	storea(a, out);
 	EXPECT_EQ(out[0], 0);
 	EXPECT_EQ(out[1], 1);
 	EXPECT_EQ(out[2], 2);
 	EXPECT_EQ(out[3], 3);
+	EXPECT_EQ(out[4], 4);
+	EXPECT_EQ(out[5], 5);
+	EXPECT_EQ(out[6], 6);
+	EXPECT_EQ(out[7], 7);
 }
 
 /** @brief Test vint8 store_nbytes. */
 TEST(vint8, store_nbytes)
 {
-	alignas(16) int out;
+	alignas(32) int out[2];
 	vint8 a(42, 314, 75, 90, 42, 314, 75, 90);
 	store_nbytes(a, (uint8_t*)&out);
-	EXPECT_EQ(out, 42);
+	EXPECT_EQ(out[0], 42);
+	EXPECT_EQ(out[1], 314);
 }
 
 /** @brief Test vint8 gatheri. */
@@ -2274,7 +2279,7 @@ TEST(vint8, select)
 /** @brief Test vint8 select MSB. */
 TEST(vint8, select_msb)
 {
-	vint8 msb(0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0, 0x80000000u, 0);
+	vint8 msb(0x80000000, 0, 0x80000000, 0, 0x80000000, 0, 0x80000000, 0);
 	vmask8 cond(msb.m);
 
 	vint8 a(1, 3, 3, 1, 1, 3, 3, 1);

--- a/Source/astcenc_averages_and_directions.cpp
+++ b/Source/astcenc_averages_and_directions.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2020 Arm Limited
+// Copyright 2011-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/Source/astcenc_block_sizes2.cpp
+++ b/Source/astcenc_block_sizes2.cpp
@@ -307,15 +307,22 @@ static void initialize_decimation_table_2d(
 		for (int j = 0; j < 4; j++)
 		{
 			dt->texel_weights_int[i][j] = 0;
-			dt->texel_weights_float[j][i] = 0.0f;
-			dt->texel_weights[j][i] = 0;
+			dt->texel_weights_float_4t[j][i] = 0.0f;
+			dt->texel_weights_4t[j][i] = 0;
+			dt->texel_weights_float_t4[i][j] = 0.0f;
+			dt->texel_weights_t4[i][j] = 0;
 		}
 
 		for (int j = 0; j < weightcount_of_texel[i]; j++)
 		{
+			// TODO: Why the uint8_t casts? Can we make these smaller?
 			dt->texel_weights_int[i][j] = (uint8_t)weights_of_texel[i][j];
-			dt->texel_weights_float[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
-			dt->texel_weights[j][i] = (uint8_t)grid_weights_of_texel[i][j];
+
+			dt->texel_weights_float_4t[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights_4t[j][i] = (uint8_t)grid_weights_of_texel[i][j];
+
+			dt->texel_weights_float_t4[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights_t4[i][j] = (uint8_t)grid_weights_of_texel[i][j];
 		}
 	}
 
@@ -336,8 +343,8 @@ static void initialize_decimation_table_2d(
 			int swap_idx = -1;
 			for (int k = 0; k < 4; k++)
 			{
-				int dttw = dt->texel_weights[k][texel];
-				float dttwf = dt->texel_weights_float[k][texel];
+				int dttw = dt->texel_weights_t4[texel][k];
+				float dttwf = dt->texel_weights_float_t4[texel][k];
 				if (dttw == i && dttwf != 0.0f)
 				{
 					swap_idx = k;
@@ -517,15 +524,19 @@ static void initialize_decimation_table_3d(
 		for (int j = 0; j < 4; j++)
 		{
 			dt->texel_weights_int[i][j] = 0;
-			dt->texel_weights_float[j][i] = 0.0f;
-			dt->texel_weights[j][i] = 0;
+			dt->texel_weights_float_4t[j][i] = 0.0f;
+			dt->texel_weights_4t[j][i] = 0;
+			dt->texel_weights_float_t4[i][j] = 0.0f;
+			dt->texel_weights_t4[i][j] = 0;
 		}
 
 		for (int j = 0; j < weightcount_of_texel[i]; j++)
 		{
 			dt->texel_weights_int[i][j] = (uint8_t)weights_of_texel[i][j];
-			dt->texel_weights_float[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
-			dt->texel_weights[j][i] = (uint8_t)grid_weights_of_texel[i][j];
+			dt->texel_weights_float_4t[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights_4t[j][i] = (uint8_t)grid_weights_of_texel[i][j];
+			dt->texel_weights_float_t4[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights_t4[i][j] = (uint8_t)grid_weights_of_texel[i][j];
 		}
 	}
 
@@ -545,8 +556,8 @@ static void initialize_decimation_table_3d(
 			int swap_idx = -1;
 			for (int k = 0; k < 4; k++)
 			{
-				int dttw = dt->texel_weights[k][texel];
-				float dttwf = dt->texel_weights_float[k][texel];
+				int dttw = dt->texel_weights_t4[texel][k];
+				float dttwf = dt->texel_weights_float_t4[texel][k];
 				if (dttw == i && dttwf != 0.0f)
 				{
 					swap_idx = k;

--- a/Source/astcenc_block_sizes2.cpp
+++ b/Source/astcenc_block_sizes2.cpp
@@ -307,15 +307,15 @@ static void initialize_decimation_table_2d(
 		for (int j = 0; j < 4; j++)
 		{
 			dt->texel_weights_int[i][j] = 0;
-			dt->texel_weights_float[i][j] = 0.0f;
-			dt->texel_weights[i][j] = 0;
+			dt->texel_weights_float[j][i] = 0.0f;
+			dt->texel_weights[j][i] = 0;
 		}
 
 		for (int j = 0; j < weightcount_of_texel[i]; j++)
 		{
 			dt->texel_weights_int[i][j] = (uint8_t)weights_of_texel[i][j];
-			dt->texel_weights_float[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
-			dt->texel_weights[i][j] = (uint8_t)grid_weights_of_texel[i][j];
+			dt->texel_weights_float[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights[j][i] = (uint8_t)grid_weights_of_texel[i][j];
 		}
 	}
 
@@ -336,8 +336,8 @@ static void initialize_decimation_table_2d(
 			int swap_idx = -1;
 			for (int k = 0; k < 4; k++)
 			{
-				int dttw = dt->texel_weights[texel][k];
-				float dttwf = dt->texel_weights_float[texel][k];
+				int dttw = dt->texel_weights[k][texel];
+				float dttwf = dt->texel_weights_float[k][texel];
 				if (dttw == i && dttwf != 0.0f)
 				{
 					swap_idx = k;
@@ -517,15 +517,15 @@ static void initialize_decimation_table_3d(
 		for (int j = 0; j < 4; j++)
 		{
 			dt->texel_weights_int[i][j] = 0;
-			dt->texel_weights_float[i][j] = 0.0f;
-			dt->texel_weights[i][j] = 0;
+			dt->texel_weights_float[j][i] = 0.0f;
+			dt->texel_weights[j][i] = 0;
 		}
 
 		for (int j = 0; j < weightcount_of_texel[i]; j++)
 		{
 			dt->texel_weights_int[i][j] = (uint8_t)weights_of_texel[i][j];
-			dt->texel_weights_float[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
-			dt->texel_weights[i][j] = (uint8_t)grid_weights_of_texel[i][j];
+			dt->texel_weights_float[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights[j][i] = (uint8_t)grid_weights_of_texel[i][j];
 		}
 	}
 
@@ -545,8 +545,8 @@ static void initialize_decimation_table_3d(
 			int swap_idx = -1;
 			for (int k = 0; k < 4; k++)
 			{
-				int dttw = dt->texel_weights[texel][k];
-				float dttwf = dt->texel_weights_float[texel][k];
+				int dttw = dt->texel_weights[k][texel];
+				float dttwf = dt->texel_weights_float[k][texel];
 				if (dttw == i && dttwf != 0.0f)
 				{
 					swap_idx = k;
@@ -594,7 +594,7 @@ static int construct_dt_entry_2d(
 
 	bool try_2planes = (2 * weight_count) <= MAX_WEIGHTS_PER_BLOCK;
 
-	decimation_table *dt = new decimation_table;
+	decimation_table *dt = aligned_malloc<decimation_table>(sizeof(decimation_table), ASTCENC_VECALIGN);
 	initialize_decimation_table_2d(x_dim, y_dim, x_weights, y_weights, dt);
 
 	int maxprec_1plane = -1;
@@ -826,7 +826,7 @@ static void construct_block_size_descriptor_3d(
 					continue;
 				}
 
-				decimation_table *dt = new decimation_table;
+				decimation_table *dt = aligned_malloc<decimation_table>(sizeof(decimation_table), ASTCENC_VECALIGN);
 				decimation_mode_index[z_weights * 64 + y_weights * 8 + x_weights] = decimation_mode_count;
 				initialize_decimation_table_3d(xdim, ydim, zdim, x_weights, y_weights, z_weights, dt);
 
@@ -987,6 +987,6 @@ void term_block_size_descriptor(
 {
 	for (int i = 0; i < bsd->decimation_mode_count; i++)
 	{
-		delete bsd->decimation_tables[i];
+		aligned_free<const decimation_table>(bsd->decimation_tables[i]);
 	}
 }

--- a/Source/astcenc_block_sizes2.cpp
+++ b/Source/astcenc_block_sizes2.cpp
@@ -306,23 +306,24 @@ static void initialize_decimation_table_2d(
 		// This allows a branch-free implementation of compute_value_of_texel_flt()
 		for (int j = 0; j < 4; j++)
 		{
-			dt->texel_weights_int[i][j] = 0;
-			dt->texel_weights_float_4t[j][i] = 0.0f;
-			dt->texel_weights_4t[j][i] = 0;
+			dt->texel_weights_int_t4[i][j] = 0;
 			dt->texel_weights_float_t4[i][j] = 0.0f;
 			dt->texel_weights_t4[i][j] = 0;
+
+			dt->texel_weights_float_4t[j][i] = 0.0f;
+			dt->texel_weights_4t[j][i] = 0;
+
 		}
 
 		for (int j = 0; j < weightcount_of_texel[i]; j++)
 		{
 			// TODO: Why the uint8_t casts? Can we make these smaller?
-			dt->texel_weights_int[i][j] = (uint8_t)weights_of_texel[i][j];
+			dt->texel_weights_int_t4[i][j] = (uint8_t)weights_of_texel[i][j];
+			dt->texel_weights_float_t4[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights_t4[i][j] = (uint8_t)grid_weights_of_texel[i][j];
 
 			dt->texel_weights_float_4t[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
 			dt->texel_weights_4t[j][i] = (uint8_t)grid_weights_of_texel[i][j];
-
-			dt->texel_weights_float_t4[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
-			dt->texel_weights_t4[i][j] = (uint8_t)grid_weights_of_texel[i][j];
 		}
 	}
 
@@ -523,20 +524,22 @@ static void initialize_decimation_table_3d(
 		// This allows a branch-free implementation of compute_value_of_texel_flt()
 		for (int j = 0; j < 4; j++)
 		{
-			dt->texel_weights_int[i][j] = 0;
-			dt->texel_weights_float_4t[j][i] = 0.0f;
-			dt->texel_weights_4t[j][i] = 0;
+			dt->texel_weights_int_t4[i][j] = 0;
 			dt->texel_weights_float_t4[i][j] = 0.0f;
 			dt->texel_weights_t4[i][j] = 0;
+
+			dt->texel_weights_float_4t[j][i] = 0.0f;
+			dt->texel_weights_4t[j][i] = 0;
 		}
 
 		for (int j = 0; j < weightcount_of_texel[i]; j++)
 		{
-			dt->texel_weights_int[i][j] = (uint8_t)weights_of_texel[i][j];
-			dt->texel_weights_float_4t[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
-			dt->texel_weights_4t[j][i] = (uint8_t)grid_weights_of_texel[i][j];
+			dt->texel_weights_int_t4[i][j] = (uint8_t)weights_of_texel[i][j];
 			dt->texel_weights_float_t4[i][j] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
 			dt->texel_weights_t4[i][j] = (uint8_t)grid_weights_of_texel[i][j];
+
+			dt->texel_weights_float_4t[j][i] = ((float)weights_of_texel[i][j]) * (1.0f / TEXEL_WEIGHT_SUM);
+			dt->texel_weights_4t[j][i] = (uint8_t)grid_weights_of_texel[i][j];
 		}
 	}
 

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2020 Arm Limited
+// Copyright 2011-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -33,7 +33,7 @@ static int compute_value_of_texel_int(
 	int weights_to_evaluate = it->texel_weight_count[texel_to_get];
 	for (int i = 0; i < weights_to_evaluate; i++)
 	{
-		summed_value += weights[it->texel_weights[texel_to_get][i]] * it->texel_weights_int[texel_to_get][i];
+		summed_value += weights[it->texel_weights[i][texel_to_get]] * it->texel_weights_int[texel_to_get][i];
 	}
 	return summed_value >> 4;
 }

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -33,7 +33,7 @@ static int compute_value_of_texel_int(
 	int weights_to_evaluate = it->texel_weight_count[texel_to_get];
 	for (int i = 0; i < weights_to_evaluate; i++)
 	{
-		summed_value += weights[it->texel_weights[i][texel_to_get]] * it->texel_weights_int[texel_to_get][i];
+		summed_value += weights[it->texel_weights_t4[texel_to_get][i]] * it->texel_weights_int[texel_to_get][i];
 	}
 	return summed_value >> 4;
 }

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -33,7 +33,7 @@ static int compute_value_of_texel_int(
 	int weights_to_evaluate = it->texel_weight_count[texel_to_get];
 	for (int i = 0; i < weights_to_evaluate; i++)
 	{
-		summed_value += weights[it->texel_weights_t4[texel_to_get][i]] * it->texel_weights_int[texel_to_get][i];
+		summed_value += weights[it->texel_weights_t4[texel_to_get][i]] * it->texel_weights_int_t4[texel_to_get][i];
 	}
 	return summed_value >> 4;
 }

--- a/Source/astcenc_ideal_endpoints_and_weights.cpp
+++ b/Source/astcenc_ideal_endpoints_and_weights.cpp
@@ -911,14 +911,13 @@ float compute_error_of_weight_set(
 ) {
 	vfloat verror_summa(0.0f);
 	float error_summa = 0.0f;
-
 	int texel_count = it->texel_count;
 
 	int i = 0;
 
 #if ASTCENC_SIMD_WIDTH > 1
 
-	// Process eight texel coordinates at at time while we can
+	// Process SIMD-width texel coordinates at at time while we can
 	int clipped_texel_count = round_down_to_simd_multiple_vla(texel_count);
 	for (/* */; i < clipped_texel_count; i += ASTCENC_SIMD_WIDTH)
 	{
@@ -964,6 +963,8 @@ float compute_error_of_weight_set(
 	// Loop tail
 	for (/* */; i < texel_count; i++)
 	{
+		// This isn't the ideal access pattern, but the cache lines are probably
+		// already in the cache due to the vector loop above, so go with it ...
 		float current_value = (weights[it->texel_weights_4t[0][i]] * it->texel_weights_float_4t[0][i] +
 		                       weights[it->texel_weights_4t[1][i]] * it->texel_weights_float_4t[1][i]) +
 		                      (weights[it->texel_weights_4t[2][i]] * it->texel_weights_float_4t[2][i] +
@@ -974,6 +975,7 @@ float compute_error_of_weight_set(
 
 		error_summa += error;
 	}
+
 	return error_summa;
 }
 

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -403,8 +403,9 @@ struct decimation_table
 	alignas(ASTCENC_VECALIGN) uint8_t texel_weights_4t[4][MAX_TEXELS_PER_BLOCK];	// the weights that go into a texel calculation
 
 	float texel_weights_float_t4[MAX_TEXELS_PER_BLOCK][4];	// the weight to assign to each weight
-	uint8_t texel_weights_int[MAX_TEXELS_PER_BLOCK][4];	// the weight to assign to each weight
 	uint8_t texel_weights_t4[MAX_TEXELS_PER_BLOCK][4];	// the weights that go into a texel calculation
+
+	uint8_t texel_weights_int_t4[MAX_TEXELS_PER_BLOCK][4];	// the weight to assign to each weight
 
 	uint8_t weight_texel_count[MAX_WEIGHTS_PER_BLOCK];	// the number of texels that a given weight contributes to
 	uint8_t weight_texel[MAX_WEIGHTS_PER_BLOCK][MAX_TEXELS_PER_BLOCK];	// the texels that the weight contributes to

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -396,12 +396,15 @@ struct decimation_table
 	int texel_count;
 	int weight_count;
 	uint8_t texel_weight_count[MAX_TEXELS_PER_BLOCK];	// number of indices that go into the calculation for a texel
+
+	// The 4t and t4 tables are the same data, but transposed to allow optimal
+	// data access patterns depending on how we can unroll loops
+	alignas(ASTCENC_VECALIGN) float texel_weights_float_4t[4][MAX_TEXELS_PER_BLOCK];	// the weight to assign to each weight
+	alignas(ASTCENC_VECALIGN) uint8_t texel_weights_4t[4][MAX_TEXELS_PER_BLOCK];	// the weights that go into a texel calculation
+
+	float texel_weights_float_t4[MAX_TEXELS_PER_BLOCK][4];	// the weight to assign to each weight
 	uint8_t texel_weights_int[MAX_TEXELS_PER_BLOCK][4];	// the weight to assign to each weight
-
-	alignas(ASTCENC_VECALIGN) float texel_weights_float[4][MAX_TEXELS_PER_BLOCK];	// the weight to assign to each weight
-
-	// TODO: Make this (u)int8_t again ...
-	alignas(ASTCENC_VECALIGN) int texel_weights[4][MAX_TEXELS_PER_BLOCK];	// the weights that go into a texel calculation
+	uint8_t texel_weights_t4[MAX_TEXELS_PER_BLOCK][4];	// the weights that go into a texel calculation
 
 	uint8_t weight_texel_count[MAX_WEIGHTS_PER_BLOCK];	// the number of texels that a given weight contributes to
 	uint8_t weight_texel[MAX_WEIGHTS_PER_BLOCK][MAX_TEXELS_PER_BLOCK];	// the texels that the weight contributes to
@@ -410,7 +413,7 @@ struct decimation_table
 
 	// folded data structures:
 	//  * texel_weights_texel[i][j] = texel_weights[weight_texel[i][j]];
-	//  * texel_weights_float_texel[i][j] = texel_weights_float[weight_texel[i][j]
+	//  * texel_weights_float_texel[i][j] = texel_weights_float[weight_texel[i][j]]
 	uint8_t texel_weights_texel[MAX_WEIGHTS_PER_BLOCK][MAX_TEXELS_PER_BLOCK][4];
 	float texel_weights_float_texel[MAX_WEIGHTS_PER_BLOCK][MAX_TEXELS_PER_BLOCK][4];
 };

--- a/Source/astcenc_pick_best_endpoint_format.cpp
+++ b/Source/astcenc_pick_best_endpoint_format.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2020 Arm Limited
+// Copyright 2011-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -828,7 +828,7 @@ void determine_optimal_set_of_endpoint_formats_to_use(
 	// have to ensure that the "overstep" of the last iteration in the vectorized
 	// loop will contain data that will never be picked as best candidate
 	const int packed_mode_count = bsd->block_mode_count;
-	const int packed_mode_count_simd_up = (packed_mode_count + ASTCENC_SIMD_WIDTH - 1) / ASTCENC_SIMD_WIDTH * ASTCENC_SIMD_WIDTH;
+	const int packed_mode_count_simd_up = round_up_to_simd_multiple_vla(packed_mode_count);
 	for (int i = packed_mode_count; i < packed_mode_count_simd_up; ++i)
 	{
 		errors_of_best_combination[i] = 1e30f;

--- a/Source/astcenc_vecmathlib.h
+++ b/Source/astcenc_vecmathlib.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2019-2020 Arm Limited
+// Copyright 2019-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -120,6 +120,35 @@
 	constexpr auto loada = vfloat1::loada;
 	constexpr auto load1 = vfloat1::load1;
 #endif
+
+/**
+ * @brief Round a count down to the largest multiple of the SIMD width.
+ *
+ * Assumption that the vector width is a power of two ...
+ *
+ * @param count   The unrounded value.
+ *
+ * @return The rounded value.
+ */
+ASTCENC_SIMD_INLINE int round_down_to_simd_multiple_vla(int count)
+{
+	return count & ~(ASTCENC_SIMD_WIDTH - 1);
+}
+
+/**
+ * @brief Round a count up to the largest multiple of the SIMD width.
+ *
+ * Assumption that the vector width is a power of two ...
+ *
+ * @param count   The unrounded value.
+ *
+ * @return The rounded value.
+ */
+ASTCENC_SIMD_INLINE int round_up_to_simd_multiple_vla(int count)
+{
+	int multiples = (count + ASTCENC_SIMD_WIDTH - 1) / ASTCENC_SIMD_WIDTH;
+	return multiples * ASTCENC_SIMD_WIDTH;
+}
 
 /**
  * @brief Return @c a with lanes negated if the @c b lane is negative.

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -159,7 +159,7 @@ struct vint8
 	ASTCENC_SIMD_INLINE vint8() {}
 
 	/**
-	 * @brief Construct from 4 values loaded from an unaligned address.
+	 * @brief Construct from 8 values loaded from an unaligned address.
 	 *
 	 * Consider using loada() which is better with vectors if data is aligned
 	 * to vector length.
@@ -167,6 +167,14 @@ struct vint8
 	ASTCENC_SIMD_INLINE explicit vint8(const int *p)
 	{
 		m = _mm256_loadu_si256((const __m256i*)p);
+	}
+
+	/**
+	 * @brief Construct from 8 uint8_t loaded from an unaligned address.
+	 */
+	ASTCENC_SIMD_INLINE explicit vint8(const uint8_t *p)
+	{
+		m = _mm256_cvtepu8_epi32(_mm_loadu_si64(p));
 	}
 
 	/**

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -72,6 +72,18 @@ struct vfloat8
 	}
 
 	/**
+	 * @brief Construct from 8 scalar values.
+	 *
+	 * The value of @c a is stored to lane 0 (LSB) in the SIMD register.
+	 */
+	ASTCENC_SIMD_INLINE explicit vfloat8(
+		float a, float b, float c, float d,
+		float e, float f, float g, float h)
+	{
+		m = _mm256_set_ps(h, g, f, e, d, c, b, a);
+	}
+
+	/**
 	 * @brief Construct from an existing SIMD register.
 	 */
 	ASTCENC_SIMD_INLINE explicit vfloat8(__m256 a) {
@@ -165,6 +177,18 @@ struct vint8
 	ASTCENC_SIMD_INLINE explicit vint8(int a)
 	{
 		m = _mm256_set1_epi32(a);
+	}
+
+	/**
+	 * @brief Construct from 8 scalar values.
+	 *
+	 * The value of @c a is stored to lane 0 (LSB) in the SIMD register.
+	 */
+	ASTCENC_SIMD_INLINE explicit vint8(
+		float a, float b, float c, float d,
+		float e, float f, float g, float h)
+	{
+		m = _mm256_set_epi32(h, g, f, e, d, c, b, a);
 	}
 
 	/**

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -185,8 +185,8 @@ struct vint8
 	 * The value of @c a is stored to lane 0 (LSB) in the SIMD register.
 	 */
 	ASTCENC_SIMD_INLINE explicit vint8(
-		float a, float b, float c, float d,
-		float e, float f, float g, float h)
+		int a, int b, int c, int d,
+		int e, int f, int g, int h)
 	{
 		m = _mm256_set_epi32(h, g, f, e, d, c, b, a);
 	}

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -755,6 +755,14 @@ ASTCENC_SIMD_INLINE float hadd(vfloat8 a)
 }
 
 /**
+ * @brief Return the sqrt of the lanes in the vector.
+ */
+ASTCENC_SIMD_INLINE vfloat8 sqrt(vfloat8 a)
+{
+	return vfloat8(_mm256_sqrt_ps(a.m));
+}
+
+/**
  * @brief Return lanes from @c b if MSB of @c cond is set, else @c a.
  */
 ASTCENC_SIMD_INLINE vfloat8 select(vfloat8 a, vfloat8 b, vmask8 cond)
@@ -772,6 +780,14 @@ ASTCENC_SIMD_INLINE vfloat8 gatherf(const float* base, vint8 indices)
 
 /**
  * @brief Store a vector to an unaligned memory address.
+ */
+ASTCENC_SIMD_INLINE void store(vfloat8 a, float* p)
+{
+	_mm256_storeu_ps(p, a.m);
+}
+
+/**
+ * @brief Store a vector to a 32B aligned memory address.
  */
 ASTCENC_SIMD_INLINE void storea(vfloat8 a, float* p)
 {

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2019-2020 Arm Limited
+// Copyright 2019-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -685,6 +685,15 @@ ASTCENC_SIMD_INLINE vfloat4 round(vfloat4 a)
 ASTCENC_SIMD_INLINE vfloat4 hmin(vfloat4 a)
 {
 	return vfloat4(vminvq_f32(a.m));
+}
+
+/**
+ * @brief Return the horizontal sum of a vector.
+ */
+ASTCENC_SIMD_INLINE float hadd(vfloat4 a)
+{
+	float32x2_t r = vadd_f32(vget_high_f32(a.m), vget_low_f32(a.m));
+	return vget_lane_f32(vpadd_f32(t, t), 0);
 }
 
 /**

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -213,6 +213,30 @@ struct vint4
 	}
 
 	/**
+	 * @brief Factory that returns a vector of zeros.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 zero()
+	{
+		return vint4(0);
+	}
+
+	/**
+	 * @brief Factory that returns a replicated scalar loaded from memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 load1(const int* p)
+	{
+		return vint4(*p);
+	}
+
+	/**
+	 * @brief Factory that returns a vector loaded from 16B aligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 loada(const int* p)
+	{
+		return vint4(*p);
+	}
+
+	/**
 	 * @brief Factory that returns a vector containing the lane IDs.
 	 */
 	static ASTCENC_SIMD_INLINE vint4 lane_id()
@@ -692,7 +716,7 @@ ASTCENC_SIMD_INLINE vfloat4 hmin(vfloat4 a)
  */
 ASTCENC_SIMD_INLINE float hadd(vfloat4 a)
 {
-	float32x2_t r = vadd_f32(vget_high_f32(a.m), vget_low_f32(a.m));
+	float32x2_t t = vadd_f32(vget_high_f32(a.m), vget_low_f32(a.m));
 	return vget_lane_f32(vpadd_f32(t, t), 0);
 }
 

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -176,6 +176,17 @@ struct vint4
 	}
 
 	/**
+	 * @brief Construct from 4 uint8_t loaded from an unaligned address.
+	 */
+	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
+	{
+		uint32x4_t t8;
+		vld1_lane_u32(p, t8, 0);
+		uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
+		m = vreinterpret_s32_u32(vmovl_u16(t16));
+	}
+
+	/**
 	 * @brief Construct from 1 scalar value replicated across all lanes.
 	 *
 	 * Consider using vfloat4::zero() for constexpr zeros.

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -180,10 +180,10 @@ struct vint4
 	 */
 	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
 	{
-		uint32x4_t t8;
-		vld1_lane_u32(p, t8, 0);
+		uint32x2_t t8 {};
+		t8 = vld1_lane_u32(p, t8, 0);
 		uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
-		m = vreinterpret_s32_u32(vmovl_u16(t16));
+		m = vreinterpretq_s32_u32(vmovl_u16(t16));
 	}
 
 	/**

--- a/Source/astcenc_vecmathlib_none_1.h
+++ b/Source/astcenc_vecmathlib_none_1.h
@@ -149,6 +149,14 @@ struct vint1
 	}
 
 	/**
+	 * @brief Construct from 1 uint8_t loaded from an unaligned address.
+	 */
+	ASTCENC_SIMD_INLINE explicit vint1(const uint8_t *p)
+	{
+		m = *p;
+	}
+
+	/**
 	 * @brief Construct from 1 scalar value replicated across all lanes.
 	 *
 	 * Consider using vint1::zero() for constexpr zeros.

--- a/Source/astcenc_vecmathlib_none_1.h
+++ b/Source/astcenc_vecmathlib_none_1.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2019-2020 Arm Limited
+// Copyright 2019-2021 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -167,6 +167,30 @@ struct vint1
 	}
 
 	/**
+	 * @brief Factory that returns a vector of zeros.
+	 */
+	static ASTCENC_SIMD_INLINE vint1 zero()
+	{
+		return vint1(0);
+	}
+
+	/**
+	 * @brief Factory that returns a replicated scalar loaded from memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint1 load1(const int* p)
+	{
+		return vint1(*p);
+	}
+
+	/**
+	 * @brief Factory that returns a vector loaded from 4B aligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint1 loada(const int* p)
+	{
+		return vint1(*p);
+	}
+
+	/**
 	 * @brief Factory that returns a vector containing the lane IDs.
 	 */
 	static ASTCENC_SIMD_INLINE vint1 lane_id()
@@ -192,9 +216,9 @@ struct vmask1
 	/**
 	 * @brief Construct from an existing mask value.
 	 */
-	ASTCENC_SIMD_INLINE explicit vmask1(int v)
+	ASTCENC_SIMD_INLINE explicit vmask1(int a)
 	{
-		m = v;
+		m = a;
 	}
 
 	/**
@@ -368,9 +392,9 @@ ASTCENC_SIMD_INLINE vint1 max(vint1 a, vint1 b)
 /**
  * @brief Return the horizontal minimum of a single vector.
  */
-ASTCENC_SIMD_INLINE vint1 hmin(vint1 v)
+ASTCENC_SIMD_INLINE vint1 hmin(vint1 a)
 {
-	return v;
+	return a;
 }
 
 /**
@@ -590,6 +614,14 @@ ASTCENC_SIMD_INLINE vfloat1 hmin(vfloat1 a)
 }
 
 /**
+ * @brief Return the horizontal sum of a vector.
+ */
+ASTCENC_SIMD_INLINE float hadd(vfloat1 a)
+{
+	return a.m;
+}
+
+/**
  * @brief Return lanes from @c b if MSB of @c cond is set, else @c a.
  */
 ASTCENC_SIMD_INLINE vfloat1 select(vfloat1 a, vfloat1 b, vmask1 cond)
@@ -608,17 +640,17 @@ ASTCENC_SIMD_INLINE vfloat1 gatherf(const float* base, vint1 indices)
 /**
  * @brief Store a vector to an aligned memory address.
  */
-ASTCENC_SIMD_INLINE void storea(vfloat1 v, float* ptr)
+ASTCENC_SIMD_INLINE void storea(vfloat1 a, float* ptr)
 {
-	*ptr = v.m;
+	*ptr = a.m;
 }
 
 /**
  * @brief Return a integer value for a float vector, using truncation.
  */
-ASTCENC_SIMD_INLINE vint1 float_to_int(vfloat1 v)
+ASTCENC_SIMD_INLINE vint1 float_to_int(vfloat1 a)
 {
-	return vint1(v.m);
+	return vint1(a.m);
 }
 
 /**
@@ -628,10 +660,10 @@ ASTCENC_SIMD_INLINE vint1 float_to_int(vfloat1 v)
  * some bit hackery based on knowledge they are IEEE 754 layout, and then
  * convert them back again. This is the first half of that flip.
  */
-ASTCENC_SIMD_INLINE vint1 float_as_int(vfloat1 v)
+ASTCENC_SIMD_INLINE vint1 float_as_int(vfloat1 a)
 {
 	vint1 r;
-	memcpy(&r.m, &v.m, 4);
+	memcpy(&r.m, &a.m, 4);
 	return r;
 }
 
@@ -642,10 +674,10 @@ ASTCENC_SIMD_INLINE vint1 float_as_int(vfloat1 v)
  * some bit hackery based on knowledge they are IEEE 754 layout, and then
  * convert them back again. This is the second half of that flip.
  */
-ASTCENC_SIMD_INLINE vfloat1 int_as_float(vint1 v)
+ASTCENC_SIMD_INLINE vfloat1 int_as_float(vint1 a)
 {
 	vfloat1 r;
-	memcpy(&r.m, &v.m, 4);
+	memcpy(&r.m, &a.m, 4);
 	return r;
 }
 

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -179,6 +179,17 @@ struct vint4
 	}
 
 	/**
+	 * @brief Construct from 4 uint8_t loaded from an unaligned address.
+	 */
+	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
+	{
+		m[0] = p[0];
+		m[1] = p[1];
+		m[2] = p[2];
+		m[3] = p[3];
+	}
+
+	/**
 	 * @brief Construct from 4 scalar values.
 	 *
 	 * The value of @c a is stored to lane 0 (LSB) in the SIMD register.

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -219,6 +219,30 @@ struct vint4
 	}
 
 	/**
+	 * @brief Factory that returns a vector of zeros.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 zero()
+	{
+		return vint4(_mm_setzero_si128());
+	}
+
+	/**
+	 * @brief Factory that returns a replicated scalar loaded from memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 load1(const int* p)
+	{
+		return vint4(*p);
+	}
+
+	/**
+	 * @brief Factory that returns a vector loaded from 16B aligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 loada(const int* p)
+	{
+		return vint4(_mm_load_si128((const __m128i*)p));
+	}
+
+	/**
 	 * @brief Factory that returns a vector containing the lane IDs.
 	 */
 	static ASTCENC_SIMD_INLINE vint4 lane_id()
@@ -728,6 +752,20 @@ ASTCENC_SIMD_INLINE vfloat4 hmin(vfloat4 a)
 	a = min(a, vfloat4(_mm_shuffle_ps(a.m, a.m, _MM_SHUFFLE(0, 0, 3, 2))));
 	a = min(a, vfloat4(_mm_shuffle_ps(a.m, a.m, _MM_SHUFFLE(0, 0, 0, 1))));
 	return vfloat4(_mm_shuffle_ps(a.m, a.m, _MM_SHUFFLE(0, 0, 0, 0)));
+}
+
+/**
+ * @brief Return the horizontal sum of a vector.
+ */
+ASTCENC_SIMD_INLINE float hadd(vfloat4 a)
+{
+	// Add top and bottom halves, lane 1/0
+	__m128 t = _mm_add_ps(a.m, _mm_movehl_ps(a.m, a.m));
+
+	// Add top and bottom halves, lane 0 (_mm_hadd_ps exists but slow)
+	t = _mm_add_ss(t, _mm_shuffle_ps(t, t, 0x55));
+
+	return _mm_cvtss_f32(t);
 }
 
 /**

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -183,6 +183,21 @@ struct vint4
 	}
 
 	/**
+	 * @brief Construct from 4 uint8_t loaded from an unaligned address.
+	 */
+	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
+	{
+		__m128 t = _mm_loadu_si32(p);
+
+#if ASTCENC_SSE >= 41
+		m = _mm_cvtepu8_epi32(t);
+#else
+		t = _mm_unpacklo_epi8(t, _mm_setzero_si128());
+		m = _mm_unpacklo_epi16(t, _mm_setzero_si128());
+#endif
+	}
+
+	/**
 	 * @brief Construct from 1 scalar value replicated across all lanes.
 	 *
 	 * Consider using vfloat4::zero() for constexpr zeros.

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -187,7 +187,7 @@ struct vint4
 	 */
 	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
 	{
-		__m128 t = _mm_loadu_si32(p);
+		__m128i t = _mm_loadu_si32(p);
 
 #if ASTCENC_SSE >= 41
 		m = _mm_cvtepu8_epi32(t);

--- a/jenkins/nightly.Jenkinsfile
+++ b/jenkins/nightly.Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                 sh '''
                   mkdir build_rel
                   cd build_rel
-                  cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DISA_AVX2=ON -DISA_SSE41=ON -DISA_SSE2=ON -DISA_NONE=ON -DUNITEST=ON ..
+                  cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DISA_AVX2=ON -DISA_SSE41=ON -DISA_SSE2=ON -DISA_NONE=ON -DUNITTEST=ON ..
                   make install package -j4
                 '''
               }


### PR DESCRIPTION
This PR vectorizes the implementation of the compute_error_for_weight_set() function using the vector-length agnostic SIMD support. It is bit-exact with the original implementation, so no image diffs are expected.

To make this vectorizable it needs to switch some structures from AOS to SOA, but we can't use these everywhere, so we duplicate some data tables in the decimation table and store both array orderings. 

- 5-7% faster for -thorough
- 2-4% faster for -medium
- 1-2% faster for -fast
- Neutral for -fastest
