### PR TITLE
Add diagnostic tracing tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Test/Images/Scratch*
 
 # Test output
 TestOutput
+/*.json
 /*.log
 /*.txt
 /*.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020 Arm Limited
+#  Copyright 2020-2021 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -91,6 +91,13 @@ if(${DECOMPRESSOR})
     message("  -- Decompress-only backend - ON")
 else()
     message("  -- Decompress-only backend - OFF")
+endif()
+
+option(DIAGNOSTICS "Enable builds for diagnostic trace")
+if(${DIAGNOSTICS})
+    message("  -- Diagnostic tracing - ON")
+else()
+    message("  -- Diagnostic tracing - OFF")
 endif()
 
 option(UNITTEST "Enable builds for unit tests")

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -180,7 +180,11 @@ enum astcenc_error {
 	/** @brief The call failed due to the context not supporting the operation. */
 	ASTCENC_ERR_BAD_CONTEXT,
 	/** @brief The call failed due to unimplemented functionality. */
-	ASTCENC_ERR_NOT_IMPLEMENTED
+	ASTCENC_ERR_NOT_IMPLEMENTED,
+#if defined(ASTCENC_DIAGNOSTICS)
+	/** @brief The call failed due to an issue with diagnostic tracing. */
+	ASTCENC_ERR_DTRACE_FAILURE,
+#endif
 };
 
 /**
@@ -463,6 +467,16 @@ struct astcenc_config {
 	 * This option is ineffective for normal maps.
 	 */
 	float tune_two_plane_early_out_limit;
+
+#if defined(ASTCENC_DIAGNOSTICS)
+	/**
+	 * @brief The path to save the diagnostic trace data to.
+	 *
+	 * This option is not part of the public API, and requires special builds
+	 * of the library.
+	 */
+	const char* trace_file_path;
+#endif
 };
 
 /**

--- a/Source/astcenc_block_sizes2.cpp
+++ b/Source/astcenc_block_sizes2.cpp
@@ -368,6 +368,9 @@ static void initialize_decimation_table_2d(
 
 	dt->texel_count = texels_per_block;
 	dt->weight_count = weights_per_block;
+	dt->weight_x = x_weights;
+	dt->weight_y = y_weights;
+	dt->weight_z = 1;
 }
 
 static void initialize_decimation_table_3d(
@@ -582,6 +585,9 @@ static void initialize_decimation_table_3d(
 
 	dt->texel_count = texels_per_block;
 	dt->weight_count = weights_per_block;
+	dt->weight_x = x_weights;
+	dt->weight_y = y_weights;
+	dt->weight_z = z_weights;
 }
 
 /**

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1225,8 +1225,6 @@ static float prepare_block_statistics(
 	if (astc::isnan(ga_cov)) ga_cov = 1.0f;
 	if (astc::isnan(ba_cov)) ba_cov = 1.0f;
 
-
-
 	float lowest_correlation = astc::min(fabsf(rg_cov), fabsf(rb_cov));
 	lowest_correlation       = astc::min(lowest_correlation, fabsf(ra_cov));
 	lowest_correlation       = astc::min(lowest_correlation, fabsf(gb_cov));
@@ -1234,20 +1232,20 @@ static float prepare_block_statistics(
 	lowest_correlation       = astc::min(lowest_correlation, fabsf(ba_cov));
 
 	// Diagnostic trace points
-	trace_add_data("r_min", blk->data_min.lane<0>());
-	trace_add_data("r_max", blk->data_max.lane<0>());
-	trace_add_data("g_min", blk->data_min.lane<1>());
-	trace_add_data("g_max", blk->data_max.lane<1>());
-	trace_add_data("b_min", blk->data_min.lane<2>());
-	trace_add_data("b_max", blk->data_max.lane<2>());
-	trace_add_data("a_min", blk->data_min.lane<3>());
-	trace_add_data("a_max", blk->data_max.lane<3>());
-	trace_add_data("rg_cov", fabsf(rg_cov));
-	trace_add_data("rb_cov", fabsf(rb_cov));
-	trace_add_data("ra_cov", fabsf(ra_cov));
-	trace_add_data("gb_cov", fabsf(gb_cov));
-	trace_add_data("ga_cov", fabsf(ga_cov));
-	trace_add_data("ba_cov", fabsf(ba_cov));
+	trace_add_data("min_r", blk->data_min.lane<0>());
+	trace_add_data("max_r", blk->data_max.lane<0>());
+	trace_add_data("min_g", blk->data_min.lane<1>());
+	trace_add_data("max_g", blk->data_max.lane<1>());
+	trace_add_data("min_b", blk->data_min.lane<2>());
+	trace_add_data("max_b", blk->data_max.lane<2>());
+	trace_add_data("min_a", blk->data_min.lane<3>());
+	trace_add_data("max_a", blk->data_max.lane<3>());
+	trace_add_data("cov_rg", fabsf(rg_cov));
+	trace_add_data("cov_rb", fabsf(rb_cov));
+	trace_add_data("cov_ra", fabsf(ra_cov));
+	trace_add_data("cov_gb", fabsf(gb_cov));
+	trace_add_data("cov_ga", fabsf(ga_cov));
+	trace_add_data("cov_ba", fabsf(ba_cov));
 
 	return lowest_correlation;
 }

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1266,9 +1266,9 @@ void compress_block(
 	float lowest_correl;
 
 	TRACE_NODE(node0, "block");
-	trace_add_data("x_pos", blk->xpos);
-	trace_add_data("y_pos", blk->ypos);
-	trace_add_data("z_pos", blk->zpos);
+	trace_add_data("pos_x", blk->xpos);
+	trace_add_data("pos_y", blk->ypos);
+	trace_add_data("pos_z", blk->zpos);
 
 #if defined(ASTCENC_DIAGNOSTICS)
 	// Do this early in diagnostic builds so we can dump uniform metrics

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1270,9 +1270,12 @@ void compress_block(
 				continue;
 			}
 
+			TRACE_NODE(node2, "trial");
+
 			float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
 			errorval *= errorval_mult[i];
-			trace_add_data("trial_errorval", errorval);
+
+			trace_add_data("final_errorval", errorval);
 
 			best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 
@@ -1339,8 +1342,11 @@ void compress_block(
 				continue;
 			}
 
+			TRACE_NODE(node2, "trial");
+
 			float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
-			trace_add_data("trial_errorval", errorval);
+
+			trace_add_data("final_errorval", errorval);
 
 			best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 
@@ -1395,8 +1401,11 @@ void compress_block(
 					continue;
 				}
 
+				TRACE_NODE(node2, "trial");
+
 				float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
-				trace_add_data("trial_errorval", errorval);
+
+				trace_add_data("final_errorval", errorval);
 
 				best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 
@@ -1469,8 +1478,11 @@ void compress_block(
 				continue;
 			}
 
+			TRACE_NODE(node2, "trial");
+
 			float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
-			trace_add_data("trial_errorval", errorval);
+
+			trace_add_data("final_errorval", errorval);
 
 			best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1375,12 +1375,8 @@ void compress_block(
 				continue;
 			}
 
-			TRACE_NODE(node2, "trial");
-
 			float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
 			errorval *= errorval_mult[i];
-
-			trace_add_data("final_errorval", errorval);
 
 			best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 
@@ -1447,11 +1443,7 @@ void compress_block(
 				continue;
 			}
 
-			TRACE_NODE(node2, "trial");
-
 			float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
-
-			trace_add_data("final_errorval", errorval);
 
 			best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 
@@ -1507,11 +1499,7 @@ void compress_block(
 					continue;
 				}
 
-				TRACE_NODE(node2, "trial");
-
 				float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
-
-				trace_add_data("final_errorval", errorval);
 
 				best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 
@@ -1585,11 +1573,7 @@ void compress_block(
 				continue;
 			}
 
-			TRACE_NODE(node2, "trial");
-
 			float errorval = compute_symbolic_block_difference(decode_mode, bsd, tempblocks + j, blk, ewb);
-
-			trace_add_data("final_errorval", errorval);
 
 			best_errorval_in_mode = astc::min(errorval, best_errorval_in_mode);
 

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -215,7 +215,8 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 	int tune_candidate_limit,
 	int max_refinement_iters,
 	const block_size_descriptor* bsd,
-	int partition_count, int partition_index,
+	int partition_count,
+	int partition_index,
 	const imageblock* blk,
 	const error_weight_block* ewb,
 	symbolic_compressed_block* scb,
@@ -402,6 +403,11 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 		int weight_quantization_mode = qw_bm.quantization_mode;
 		const decimation_table *it = ixtab2[decimation_mode];
 		u8_weight_src = u8_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * qw_packed_index;
+
+		trace_add_data("weight_x", it->weight_x);
+		trace_add_data("weight_y", it->weight_y);
+		trace_add_data("weight_z", it->weight_z);
+		trace_add_data("weight_quant", weight_quantization_mode);
 
 		weights_to_copy = it->weight_count;
 
@@ -1482,6 +1488,7 @@ void compress_block(
 		{
 			TRACE_NODE(node1, "pass");
 			trace_add_data("partition_count", partition_count);
+			trace_add_data("partition_index", partition_indices_1plane[i]);
 			trace_add_data("plane_count", 1);
 			trace_add_data("search_mode", i);
 
@@ -1555,6 +1562,7 @@ void compress_block(
 
 		TRACE_NODE(node1, "pass");
 		trace_add_data("partition_count", partition_count);
+		trace_add_data("partition_index", partition_index_2planes & (PARTITION_COUNT - 1));
 		trace_add_data("plane_count", 2);
 		trace_add_data("plane_channel", partition_index_2planes >> PARTITION_BITS);
 

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1159,6 +1159,7 @@ void compress_block(
 	astcenc_profile decode_mode = ctx.config.profile;
 	error_weight_block *ewb = &tmpbuf->ewb;
 	const block_size_descriptor* bsd = ctx.bsd;
+	float lowest_correl;
 
 	TRACE_NODE(node0, "block");
 	trace_add_data("x_pos", blk->xpos);
@@ -1169,7 +1170,7 @@ void compress_block(
 	// Do this early in diagnostic builds so we can dump uniform metrics
 	// for every block, do it later in release builds to avoid wasting time!
 	float error_weight_sum = prepare_error_weight_block(ctx, input_image, bsd, blk, ewb);
-	float lowest_correl = prepare_block_statistics(bsd->texel_count, blk, ewb);
+	lowest_correl = prepare_block_statistics(bsd->texel_count, blk, ewb);
 #endif
 
 	if (all(blk->data_min == blk->data_max))
@@ -1219,7 +1220,6 @@ void compress_block(
 	}
 
 #if !defined(ASTCENC_DIAGNOSTICS)
-	error_weight_block *ewb = &tmpbuf->ewb;
 	float error_weight_sum = prepare_error_weight_block(ctx, input_image, bsd, blk, ewb);
 #endif
 
@@ -1293,7 +1293,7 @@ void compress_block(
 	}
 
 #if !defined(ASTCENC_DIAGNOSTICS)
-	float lowest_correl = prepare_block_statistics(bsd->texel_count, blk, ewb);
+	lowest_correl = prepare_block_statistics(bsd->texel_count, blk, ewb);
 #endif
 
 	// next, test the four possible 1-partition, 2-planes modes

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -221,7 +221,9 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 	symbolic_compressed_block* scb,
 	compress_fixed_partition_buffers* tmpbuf
 ) {
-	static const int free_bits_for_partition_count[5] = { 0, 115 - 4, 111 - 4 - PARTITION_BITS, 108 - 4 - PARTITION_BITS, 105 - 4 - PARTITION_BITS };
+	static const int free_bits_for_partition_count[5] = {
+		0, 115 - 4, 111 - 4 - PARTITION_BITS, 108 - 4 - PARTITION_BITS, 105 - 4 - PARTITION_BITS
+	};
 
 	const partition_info *pi = get_partition_table(bsd, partition_count);
 	pi += partition_index;
@@ -250,7 +252,12 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 			continue;
 		}
 		eix[i] = *ei;
-		compute_ideal_weights_for_decimation_table(&(eix[i]), ixtab2[i], decimated_quantized_weights + i * MAX_WEIGHTS_PER_BLOCK, decimated_weights + i * MAX_WEIGHTS_PER_BLOCK);
+
+		compute_ideal_weights_for_decimation_table(
+		    &(eix[i]),
+		    ixtab2[i],
+		    decimated_quantized_weights + i * MAX_WEIGHTS_PER_BLOCK,
+		    decimated_weights + i * MAX_WEIGHTS_PER_BLOCK);
 	}
 
 	// compute maximum colors for the endpoints and ideal weights.
@@ -301,7 +308,10 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 	float weight_low_value[MAX_WEIGHT_MODES];
 	float weight_high_value[MAX_WEIGHT_MODES];
 
-	compute_angular_endpoints_1plane(only_always, bsd, decimated_quantized_weights, decimated_weights, weight_low_value, weight_high_value);
+	compute_angular_endpoints_1plane(
+	    only_always, bsd,
+	    decimated_quantized_weights, decimated_weights,
+	    weight_low_value, weight_high_value);
 
 	// for each mode (which specifies a decimation and a quantization):
 	// * compute number of bits needed for the quantized weights.
@@ -327,8 +337,9 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 		int decimation_mode = bm.decimation_mode;
 
 		// compute weight bitcount for the mode
-		int bits_used_by_weights = compute_ise_bitcount(ixtab2[decimation_mode]->weight_count,
-														(quantization_method) bm.quantization_mode);
+		int bits_used_by_weights = compute_ise_bitcount(
+		    ixtab2[decimation_mode]->weight_count,
+		    (quantization_method)bm.quantization_mode);
 		int bitcount = free_bits_for_partition_count[partition_count] - bits_used_by_weights;
 		if (bitcount <= 0 || bits_used_by_weights < 24 || bits_used_by_weights > 96)
 		{
@@ -338,15 +349,19 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 		qwt_bitcounts[i] = bitcount;
 
 		// then, generate the optimized set of weights for the weight mode.
-		compute_ideal_quantized_weights_for_decimation_table(ixtab2[decimation_mode],
-															 weight_low_value[i], weight_high_value[i],
-															 decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * decimation_mode,
-															 flt_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * i,
-															 u8_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * i,
-															 bm.quantization_mode);
+		compute_ideal_quantized_weights_for_decimation_table(
+		    ixtab2[decimation_mode],
+		    weight_low_value[i], weight_high_value[i],
+		    decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * decimation_mode,
+		    flt_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * i,
+		    u8_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * i,
+		    bm.quantization_mode);
 
 		// then, compute weight-errors for the weight mode.
-		qwt_errors[i] = compute_error_of_weight_set(&(eix[decimation_mode]), ixtab2[decimation_mode], flt_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * i);
+		qwt_errors[i] = compute_error_of_weight_set(
+		                    &(eix[decimation_mode]),
+		                    ixtab2[decimation_mode],
+		                    flt_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * i);
 	}
 
 	// for each weighting mode, determine the optimal combination of color endpoint encodings
@@ -393,18 +408,26 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 		// recompute the ideal color endpoints before storing them.
 		float4 rgbs_colors[4];
 		float4 rgbo_colors[4];
+
 		for (int l = 0; l < max_refinement_iters; l++)
 		{
-			recompute_ideal_colors_1plane(weight_quantization_mode, &(eix[decimation_mode].ep), rgbs_colors, rgbo_colors, u8_weight_src, pi, it, blk, ewb);
+			recompute_ideal_colors_1plane(
+			    weight_quantization_mode, &(eix[decimation_mode].ep),
+			    rgbs_colors, rgbo_colors, u8_weight_src, pi, it, blk, ewb);
 
 			// quantize the chosen color
 
 			// store the colors for the block
 			for (int j = 0; j < partition_count; j++)
 			{
-				scb->color_formats[j] = pack_color_endpoints(eix[decimation_mode].ep.endpt0[j],
-															 eix[decimation_mode].ep.endpt1[j],
-															 rgbs_colors[j], rgbo_colors[j], partition_format_specifiers[i][j], scb->color_values[j], color_quantization_level[i]);
+				scb->color_formats[j] = pack_color_endpoints(
+				    eix[decimation_mode].ep.endpt0[j],
+				    eix[decimation_mode].ep.endpt1[j],
+				    rgbs_colors[j],
+				    rgbo_colors[j],
+				    partition_format_specifiers[i][j],
+				    scb->color_values[j],
+				    color_quantization_level[i]);
 			}
 
 			// if all the color endpoint modes are the same, we get a few more
@@ -414,19 +437,26 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 			scb->color_formats_matched = 0;
 
 			if ((partition_count >= 2 && scb->color_formats[0] == scb->color_formats[1]
-				&& color_quantization_level[i] != color_quantization_level_mod[i])
-				&& (partition_count == 2 || (scb->color_formats[0] == scb->color_formats[2] && (partition_count == 3 || (scb->color_formats[0] == scb->color_formats[3])))))
+			    && color_quantization_level[i] != color_quantization_level_mod[i])
+			    && (partition_count == 2 || (scb->color_formats[0] == scb->color_formats[2]
+			    && (partition_count == 3 || (scb->color_formats[0] == scb->color_formats[3])))))
 			{
 				int colorvals[4][12];
 				int color_formats_mod[4] = { 0 };
 				for (int j = 0; j < partition_count; j++)
 				{
-					color_formats_mod[j] = pack_color_endpoints(eix[decimation_mode].ep.endpt0[j],
-																eix[decimation_mode].ep.endpt1[j],
-																rgbs_colors[j], rgbo_colors[j], partition_format_specifiers[i][j], colorvals[j], color_quantization_level_mod[i]);
+					color_formats_mod[j] = pack_color_endpoints(
+					    eix[decimation_mode].ep.endpt0[j],
+					    eix[decimation_mode].ep.endpt1[j],
+					    rgbs_colors[j],
+					    rgbo_colors[j],
+					    partition_format_specifiers[i][j],
+					    colorvals[j],
+					    color_quantization_level_mod[i]);
 				}
 				if (color_formats_mod[0] == color_formats_mod[1]
-					&& (partition_count == 2 || (color_formats_mod[0] == color_formats_mod[2] && (partition_count == 3 || (color_formats_mod[0] == color_formats_mod[3])))))
+				    && (partition_count == 2 || (color_formats_mod[0] == color_formats_mod[2]
+				    && (partition_count == 3 || (color_formats_mod[0] == color_formats_mod[3])))))
 				{
 					scb->color_formats_matched = 1;
 					for (int j = 0; j < 4; j++)
@@ -508,8 +538,9 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 	symbolic_compressed_block* scb,
 	compress_fixed_partition_buffers* tmpbuf
 ) {
-	static const int free_bits_for_partition_count[5] =
-		{ 0, 113 - 4, 109 - 4 - PARTITION_BITS, 106 - 4 - PARTITION_BITS, 103 - 4 - PARTITION_BITS };
+	static const int free_bits_for_partition_count[5] = {
+		0, 113 - 4, 109 - 4 - PARTITION_BITS, 106 - 4 - PARTITION_BITS, 103 - 4 - PARTITION_BITS
+	};
 
 	const partition_info *pi = get_partition_table(bsd, partition_count);
 	pi += partition_index;
@@ -540,8 +571,18 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 
 		eix1[i] = *ei1;
 		eix2[i] = *ei2;
-		compute_ideal_weights_for_decimation_table(&(eix1[i]), ixtab2[i], decimated_quantized_weights + (2 * i) * MAX_WEIGHTS_PER_BLOCK, decimated_weights + (2 * i) * MAX_WEIGHTS_PER_BLOCK);
-		compute_ideal_weights_for_decimation_table(&(eix2[i]), ixtab2[i], decimated_quantized_weights + (2 * i + 1) * MAX_WEIGHTS_PER_BLOCK, decimated_weights + (2 * i + 1) * MAX_WEIGHTS_PER_BLOCK);
+
+		compute_ideal_weights_for_decimation_table(
+		    &(eix1[i]),
+		    ixtab2[i],
+		    decimated_quantized_weights + (2 * i) * MAX_WEIGHTS_PER_BLOCK,
+		    decimated_weights + (2 * i) * MAX_WEIGHTS_PER_BLOCK);
+
+		compute_ideal_weights_for_decimation_table(
+		    &(eix2[i]),
+		    ixtab2[i],
+		    decimated_quantized_weights + (2 * i + 1) * MAX_WEIGHTS_PER_BLOCK,
+		    decimated_weights + (2 * i + 1) * MAX_WEIGHTS_PER_BLOCK);
 	}
 
 	// compute maximum colors for the endpoints and ideal weights.
@@ -644,7 +685,11 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 	float weight_low_value2[MAX_WEIGHT_MODES];
 	float weight_high_value2[MAX_WEIGHT_MODES];
 
-	compute_angular_endpoints_2planes(only_always, bsd, decimated_quantized_weights, decimated_weights, weight_low_value1, weight_high_value1, weight_low_value2, weight_high_value2);
+	compute_angular_endpoints_2planes(
+	    only_always, bsd,
+	    decimated_quantized_weights, decimated_weights,
+	    weight_low_value1, weight_high_value1,
+	    weight_low_value2, weight_high_value2);
 
 	// for each mode (which specifies a decimation and a quantization):
 	// * generate an optimized set of quantized weights.
@@ -675,8 +720,9 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 		}
 
 		// compute weight bitcount for the mode
-		int bits_used_by_weights = compute_ise_bitcount(2 * ixtab2[decimation_mode]->weight_count,
-														(quantization_method) bm.quantization_mode);
+		int bits_used_by_weights = compute_ise_bitcount(
+			2 * ixtab2[decimation_mode]->weight_count,
+			(quantization_method)bm.quantization_mode);
 		int bitcount = free_bits_for_partition_count[partition_count] - bits_used_by_weights;
 		if (bitcount <= 0 || bits_used_by_weights < 24 || bits_used_by_weights > 96)
 		{
@@ -708,6 +754,7 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 		                    &(eix1[decimation_mode]),
 		                    ixtab2[decimation_mode],
 		                    flt_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * (2 * i))
+
 		              + compute_error_of_weight_set(
 		                    &(eix2[decimation_mode]),
 		                    ixtab2[decimation_mode],
@@ -782,23 +829,27 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 			scb->color_formats_matched = 0;
 
 			if ((partition_count >= 2 && scb->color_formats[0] == scb->color_formats[1]
-				&& color_quantization_level[i] != color_quantization_level_mod[i])
-				&& (partition_count == 2 || (scb->color_formats[0] == scb->color_formats[2] && (partition_count == 3 || (scb->color_formats[0] == scb->color_formats[3])))))
+			    && color_quantization_level[i] != color_quantization_level_mod[i])
+			    && (partition_count == 2 || (scb->color_formats[0] == scb->color_formats[2]
+			    && (partition_count == 3 || (scb->color_formats[0] == scb->color_formats[3])))))
 			{
 				int colorvals[4][12];
 				int color_formats_mod[4] = { 0 };
 				for (int j = 0; j < partition_count; j++)
 				{
 					color_formats_mod[j] = pack_color_endpoints(
-					                           epm.endpt0[j], epm.endpt1[j],
-					                           rgbs_colors[j], rgbo_colors[j],
-					                           partition_format_specifiers[i][j],
-					                           colorvals[j],
-					                           color_quantization_level_mod[i]);
+					    epm.endpt0[j],
+					    epm.endpt1[j],
+					    rgbs_colors[j],
+					    rgbo_colors[j],
+					    partition_format_specifiers[i][j],
+					    colorvals[j],
+					    color_quantization_level_mod[i]);
 				}
 
 				if (color_formats_mod[0] == color_formats_mod[1]
-					&& (partition_count == 2 || (color_formats_mod[0] == color_formats_mod[2] && (partition_count == 3 || (color_formats_mod[0] == color_formats_mod[3])))))
+				    && (partition_count == 2 || (color_formats_mod[0] == color_formats_mod[2]
+				    && (partition_count == 3 || (color_formats_mod[0] == color_formats_mod[3])))))
 				{
 					scb->color_formats_matched = 1;
 					for (int j = 0; j < 4; j++)
@@ -856,7 +907,6 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 			scb->weights[j] = u8_weight1_src[j];
 			scb->weights[j + PLANE2_WEIGHTS_OFFSET] = u8_weight2_src[j];
 		}
-
 
 		#if defined(ASTCENC_DIAGNOSTICS)
 		{

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -403,13 +403,12 @@ static void compress_symbolic_block_fixed_partition_1_plane(
 		int weight_quantization_mode = qw_bm.quantization_mode;
 		const decimation_table *it = ixtab2[decimation_mode];
 		u8_weight_src = u8_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * qw_packed_index;
+		weights_to_copy = it->weight_count;
 
 		trace_add_data("weight_x", it->weight_x);
 		trace_add_data("weight_y", it->weight_y);
 		trace_add_data("weight_z", it->weight_z);
 		trace_add_data("weight_quant", weight_quantization_mode);
-
-		weights_to_copy = it->weight_count;
 
 		// recompute the ideal color endpoints before storing them.
 		float4 rgbs_colors[4];
@@ -807,8 +806,12 @@ static void compress_symbolic_block_fixed_partition_2_planes(
 
 		u8_weight1_src = u8_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * (2 * qw_packed_index);
 		u8_weight2_src = u8_quantized_decimated_quantized_weights + MAX_WEIGHTS_PER_BLOCK * (2 * qw_packed_index + 1);
-
 		weights_to_copy = it->weight_count;
+
+		trace_add_data("weight_x", it->weight_x);
+		trace_add_data("weight_y", it->weight_y);
+		trace_add_data("weight_z", it->weight_z);
+		trace_add_data("weight_quant", weight_quantization_mode);
 
 		// recompute the ideal color endpoints before storing them.
 		merge_endpoints(&(eix1[decimation_mode].ep), &(eix2[decimation_mode].ep), separate_component, &epm);
@@ -1318,6 +1321,8 @@ void compress_block(
 			scb.constant_color[2] = astc::flt2int_rtn(blue * 65535.0f);
 			scb.constant_color[3] = astc::flt2int_rtn(alpha * 65535.0f);
 		}
+
+		trace_add_data("exit", "quality hit");
 
 		symbolic_to_physical(*bsd, scb, pcb);
 		return;

--- a/Source/astcenc_diagnostic_trace.cpp
+++ b/Source/astcenc_diagnostic_trace.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// ----------------------------------------------------------------------------
+// Copyright 2021 Arm Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief Functions for the library entrypoint.
+ */
+
+#if defined(ASTCENC_DIAGNOSTICS)
+
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+
+#include "astcenc_diagnostic_trace.h"
+
+
+/** @brief The global trace logger. */
+static TraceLog* g_TraceLog;
+
+TraceLog::TraceLog(const char* file_name): m_file(file_name)
+{
+	assert(!g_TraceLog);
+	g_TraceLog = this;
+}
+
+TraceLog::~TraceLog()
+{
+	assert(g_TraceLog == this);
+	g_TraceLog = nullptr;
+}
+
+TraceNode::TraceNode(const char* format, ...)
+{
+	constexpr size_t bufsz = 256;
+	char buffer[bufsz];
+
+	va_list args;
+	va_start (args, format);
+	vsnprintf (buffer, bufsz, format, args);
+	va_end (args);
+
+	// Guarantee there is a nul termintor
+	buffer[bufsz - 1] = 0;
+
+	printf("%s\n", buffer);
+}
+
+TraceNode::~TraceNode()
+{
+
+}
+
+void trace_add_data(const char* key, const char* format, ...)
+{
+	constexpr size_t bufsz = 256;
+	char buffer[bufsz];
+
+	va_list args;
+	va_start (args, format);
+	vsnprintf (buffer, bufsz, format, args);
+	va_end (args);
+
+	// Guarantee there is a nul termintor
+	buffer[bufsz - 1] = 0;
+
+	printf("%s => %s\n", key, buffer);
+}
+
+void trace_add_data(const char* key, float value)
+{
+	printf("%s => %g\n", key, (double)value);
+}
+
+void trace_add_data(const char* key, int value)
+{
+	printf("%s => %d\n", key, value);
+}
+
+void trace_add_data(const char* key, unsigned int value)
+{
+	printf("%s => %u\n", key, value);
+}
+
+#endif

--- a/Source/astcenc_diagnostic_trace.cpp
+++ b/Source/astcenc_diagnostic_trace.cpp
@@ -33,7 +33,8 @@ static TraceLog* g_TraceLog = nullptr;
 /** @brief The JSON indentation level. */
 static const int g_trace_indent = 2;
 
-TraceLog::TraceLog(const char* file_name):
+TraceLog::TraceLog(
+	const char* file_name):
 	m_file(file_name, std::ofstream::out | std::ofstream::binary)
 {
 	assert(!g_TraceLog);
@@ -63,8 +64,10 @@ TraceLog::~TraceLog()
 	g_TraceLog = nullptr;
 }
 
-TraceNode::TraceNode(const char* format, ...)
-{
+TraceNode::TraceNode(
+	const char* format,
+	...
+) {
 	// Format the name string
 	constexpr size_t bufsz = 256;
 	char buffer[bufsz];
@@ -161,8 +164,11 @@ TraceNode::~TraceNode()
 	out << out_indents << "]";
 }
 
-void trace_add_data(const char* key, const char* format, ...)
-{
+void trace_add_data(
+	const char* key,
+	const char* format,
+	...
+) {
 	constexpr size_t bufsz = 256;
 	char buffer[bufsz];
 
@@ -180,20 +186,26 @@ void trace_add_data(const char* key, const char* format, ...)
 	node->add_attrib("str", key, value);
 }
 
-void trace_add_data(const char* key, float value)
-{
+void trace_add_data(
+	const char* key,
+	float value
+) {
 	TraceNode* node = g_TraceLog->get_current_leaf();
 	node->add_attrib("float", key, std::to_string(value));
 }
 
-void trace_add_data(const char* key, int value)
-{
+void trace_add_data(
+	const char* key,
+	int value
+) {
 	TraceNode* node = g_TraceLog->get_current_leaf();
 	node->add_attrib("int", key, std::to_string(value));
 }
 
-void trace_add_data(const char* key, unsigned int value)
-{
+void trace_add_data(
+	const char* key,
+	unsigned int value
+) {
 	TraceNode* node = g_TraceLog->get_current_leaf();
 	node->add_attrib("int", key, std::to_string(value));
 }

--- a/Source/astcenc_diagnostic_trace.cpp
+++ b/Source/astcenc_diagnostic_trace.cpp
@@ -132,7 +132,7 @@ void TraceNode::add_attrib(
 	out << '\n';
 	out << std::string(indent, ' ') << "[ "
 	                                << "\"" << key << "\", "
-	                                << value << "]";
+	                                << value << " ]";
 }
 
 TraceNode::~TraceNode()

--- a/Source/astcenc_diagnostic_trace.cpp
+++ b/Source/astcenc_diagnostic_trace.cpp
@@ -88,7 +88,8 @@ TraceNode::TraceNode(
 	bool comma = parent && parent->m_attrib_count;
 	auto& out = g_TraceLog->m_file;
 
-	if (parent) {
+	if (parent)
+	{
 		parent->m_attrib_count++;
 	}
 
@@ -97,7 +98,10 @@ TraceNode::TraceNode(
 		out << ',';
 	}
 
-	out << '\n';
+	if (depth)
+	{
+		out << '\n';
+	}
 
 	int out_indent = (depth * 2) * g_trace_indent;
 	int in_indent = (depth * 2 + 1) * g_trace_indent;

--- a/Source/astcenc_diagnostic_trace.h
+++ b/Source/astcenc_diagnostic_trace.h
@@ -69,7 +69,7 @@
 #ifndef ASTCENC_DIAGNOSTIC_TRACE_INCLUDED
 #define ASTCENC_DIAGNOSTIC_TRACE_INCLUDED
 
-#if defined(ASTCENC_DIAGNOSTICS) || 1
+#if defined(ASTCENC_DIAGNOSTICS)
 
 #include <iostream>
 #include <fstream>

--- a/Source/astcenc_diagnostic_trace.h
+++ b/Source/astcenc_diagnostic_trace.h
@@ -17,49 +17,201 @@
 
 /**
  * @brief This module provides a set of diagnostic tracing utilities.
+ *
+ * Overview
+ * ========
+ *
+ * The built-in diagnostic trace tool generates a hierarchical JSON tree
+ * structure. The tree hierarchy contains three levels:
+ *
+ *    - block
+ *        - pass
+ *           - candidate
+ *
+ * One block node exists for each compressed block in the image. One pass node
+ * exists for each major pass (N partition, M planes, O channel) applied to a
+ * block. One candidate node exists for each encoding candidate trialed for a
+ * pass.
+ *
+ * Each node contains both the hierarchy but also a number of attributes which
+ * explain the behavior. For example, the block node contains the block
+ * coordinates in the image, the pass explains the pass configuration, and the
+ * candidate will explain the candidate encoding such as weight decimation,
+ * refinement error, etc.
+ *
+ * Trace Nodes are designed as scope-managed C++ objects with stack-like
+ * push/pop behavior. Constructing a trace node on the stack will automatically
+ * add it to the current node as a child, and then make it the current node.
+ * Destroying the current node will pop the stack and set the parent to the
+ * current node. This provides a robust mechanism for ensuring reliable
+ * nesting in the tree structure.
+ *
+ * A set of utility macros are provided to add attribute annotations to the
+ * current trace node.
+ *
+ * Usage
+ * =====
+ *
+ * Create Trace Nodes on the stack using the TRACE_NODE() macro. This will
+ * compile-out completely in builds with diagnostics disabled.
+ *
+ * Add annotations to the current trace node using the trace_add_data() macro.
+ * This will similarly compile out completely in builds with diagnostics
+ * disabled.
+ *
+ * If you need to add additional code to support diagnostics-only behavior wrap
+ * it in preprocessor guards:
+ *
+ *     #if defined(ASTCENC_DIAGNOSTICS)
+ *     #endif
  */
 
 #ifndef ASTCENC_DIAGNOSTIC_TRACE_INCLUDED
 #define ASTCENC_DIAGNOSTIC_TRACE_INCLUDED
 
-#if defined(ASTCENC_DIAGNOSTICS)
+#if defined(ASTCENC_DIAGNOSTICS) || 1
 
 #include <iostream>
 #include <fstream>
 #include <vector>
 
+/**
+ * @brief Class representing a single node in the trace hierarchy.
+ */
 class TraceNode
 {
 public:
+	/**
+	 * @brief Construct a new node.
+	 *
+	 * Constructing a node will push to the the top of the stack, automatically
+	 * making it a child of the current node, and then setting it to become the
+	 * current node.
+	 *
+	 * @param format   The format template for the node name.
+	 * @param ...      The format parameters.
+	 */
 	TraceNode(const char* format, ...);
+
+	/**
+	 * @brief Add an attribute to this node.
+	 *
+	 * Note that no quoting is applied to the @c value, so if quoting is
+	 * needed it must be done by the caller.
+	 *
+	 * @param type    The type of the attribute.
+	 * @param key     The key of the attribute.
+	 * @param value   The value of the attribute.
+	 */
 	void add_attrib(std::string type, std::string key, std::string value);
+
+	/**
+	 * @brief Destroy this node.
+	 *
+	 * Destroying a node will pop it from the top of the stack, making its
+	 * parent the current node. It is invalid behavior to destroy a node that
+	 * is not the current node; usage must conform to stack push-pop semantics.
+	 */
 	~TraceNode();
+
+	/**
+	 * @brief The number of attributes and child nodes in this node.
+	 */
 	unsigned int m_attrib_count { 0 };
 };
 
-
+/**
+ * @brief Class representing the trace log file being written.
+ */
 class TraceLog
 {
 public:
+	/**
+	 * @brief Create a new trace log.
+	 *
+	 * The trace log is global; there can be only one at a time.
+	 *
+	 * @param file_name   The name of the file to write.
+	 */
 	TraceLog(const char* file_name);
+
+	/**
+	 * @brief Detroy the trace log.
+	 *
+	 * Trace logs MUST be cleanly destroyed to ensure the file gets written.
+	 */
 	~TraceLog();
 
+	/**
+	 * @brief Get the current child node.
+	 *
+	 * @return The current leaf node.
+	 */
 	TraceNode* get_current_leaf();
+
+	/**
+	 * @brief Get the stack depth of the current child node.
+	 *
+	 * @return The current leaf node stack depth.
+	 */
 	int get_depth();
 
+	/**
+	 * @brief The file stream to write to.
+	 */
  	std::ofstream m_file;
+
+	/**
+	 * @brief The stack of nodes (newest at the back).
+	 */
 	std::vector<TraceNode*> m_stack;
+
+private:
+	/**
+	 * @brief The root node in the JSON file.
+	 */
 	TraceNode* m_root;
 };
 
+/**
+ * @brief Utility macro to create a trace node on the stack.
+ *
+ * @param name     The variable name to use.
+ * @param ...      The name template and format parameters.
+ */
 #define TRACE_NODE(name, ...) TraceNode name(__VA_ARGS__);
 
+/**
+ * @brief Add a string annotation to the current node.
+ *
+ * @param key      The name of the attribute.
+ * @param format   The format template for the attribute value.
+ * @param ...      The format parameters.
+ */
 void trace_add_data(const char* key, const char* format, ...);
 
+/**
+ * @brief Add a float annotation to the current node.
+ *
+ * @param key     The name of the attribute.
+ * @param value   The value of the attribute.
+ */
 void trace_add_data(const char* key, float value);
 
+/**
+ * @brief Add an integer annotation to the current node.
+ *
+ * @param key     The name of the attribute.
+ * @param value   The value of the attribute.
+ */
 void trace_add_data(const char* key, int value);
 
+/**
+ * @brief Add an unsigned integer annotation to the current node.
+ *
+ * @param key     The name of the attribute.
+ * @param value   The value of the attribute.
+ */
 void trace_add_data(const char* key, unsigned int value);
 
 #else

--- a/Source/astcenc_diagnostic_trace.h
+++ b/Source/astcenc_diagnostic_trace.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// ----------------------------------------------------------------------------
+// Copyright 2021 Arm Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief This module provides a set of diagnostic tracing utilities.
+ */
+
+#ifndef ASTCENC_DIAGNOSTIC_TRACE_INCLUDED
+#define ASTCENC_DIAGNOSTIC_TRACE_INCLUDED
+
+#if defined(ASTCENC_DIAGNOSTICS)
+
+#include <iostream>
+#include <fstream>
+
+class TraceLog
+{
+public:
+	TraceLog(const char* file_name);
+	~TraceLog();
+private:
+ 	std::ofstream m_file;
+};
+
+class TraceNode
+{
+public:
+	TraceNode(const char* format, ...);
+	~TraceNode();
+private:
+};
+
+#define TRACE_NODE(name, ...) TraceNode name(__VA_ARGS__);
+
+void trace_add_data(const char* key, const char* format, ...);
+
+void trace_add_data(const char* key, float value);
+
+void trace_add_data(const char* key, int value);
+
+void trace_add_data(const char* key, unsigned int value);
+
+#else
+
+#define TRACE_NODE(name, ...)
+
+#define trace_add_data(...)
+
+#endif
+
+#endif

--- a/Source/astcenc_diagnostic_trace.h
+++ b/Source/astcenc_diagnostic_trace.h
@@ -26,22 +26,30 @@
 
 #include <iostream>
 #include <fstream>
+#include <vector>
+
+class TraceNode
+{
+public:
+	TraceNode(const char* format, ...);
+	void add_attrib(std::string type, std::string key, std::string value);
+	~TraceNode();
+	unsigned int m_attrib_count { 0 };
+};
+
 
 class TraceLog
 {
 public:
 	TraceLog(const char* file_name);
 	~TraceLog();
-private:
- 	std::ofstream m_file;
-};
 
-class TraceNode
-{
-public:
-	TraceNode(const char* format, ...);
-	~TraceNode();
-private:
+	TraceNode* get_current_leaf();
+	int get_depth();
+
+ 	std::ofstream m_file;
+	std::vector<TraceNode*> m_stack;
+	TraceNode* m_root;
 };
 
 #define TRACE_NODE(name, ...) TraceNode name(__VA_ARGS__);

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -24,6 +24,7 @@
 
 #include "astcenc.h"
 #include "astcenc_internal.h"
+#include "astcenc_diagnostic_trace.h"
 
 // The ASTC codec is written with the assumption that a float threaded through
 // the "if32" union will in fact be stored and reloaded as a 32-bit IEEE-754 single-precision
@@ -484,6 +485,14 @@ astcenc_error astcenc_context_alloc(
 		return ASTCENC_ERR_BAD_PARAM;
 	}
 
+#if defined(ASTCENC_DIAGNOSTICS)
+	// Force single threaded compressor use in diagnostic mode.
+	if (thread_count != 1)
+	{
+		return ASTCENC_ERR_BAD_PARAM;
+	}
+#endif
+
 	ctx = new astcenc_context;
 	ctx->thread_count = thread_count;
 	ctx->config = config;
@@ -537,6 +546,13 @@ astcenc_error astcenc_context_alloc(
 	}
 #endif
 
+#if defined(ASTCENC_DIAGNOSTICS)
+	ctx->trace_log = new TraceLog("astcenc_trace.json");
+	trace_add_data("block_x", config.block_x);
+	trace_add_data("block_y", config.block_y);
+	trace_add_data("block_z", config.block_z);
+#endif
+
 	*context = ctx;
 
 	// TODO: Currently static memory; should move to context memory
@@ -555,6 +571,9 @@ void astcenc_context_free(
 	{
 		aligned_free<compress_symbolic_block_buffers>(ctx->working_buffers);
 		term_block_size_descriptor(ctx->bsd);
+#if defined(ASTCENC_DIAGNOSTICS)
+		delete ctx->trace_log;
+#endif
 		delete ctx->bsd;
 		delete ctx;
 	}

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -547,7 +547,12 @@ astcenc_error astcenc_context_alloc(
 #endif
 
 #if defined(ASTCENC_DIAGNOSTICS)
-	ctx->trace_log = new TraceLog("astcenc_trace.json");
+	ctx->trace_log = new TraceLog(ctx->config.trace_file_path);
+	if(!ctx->trace_log->m_file)
+	{
+		return ASTCENC_ERR_DTRACE_FAILURE;
+	}
+
 	trace_add_data("block_x", config.block_x);
 	trace_add_data("block_y", config.block_y);
 	trace_add_data("block_z", config.block_z);
@@ -849,6 +854,10 @@ const char* astcenc_get_error_string(
 		return "ASTCENC_ERR_BAD_CONTEXT";
 	case ASTCENC_ERR_NOT_IMPLEMENTED:
 		return "ASTCENC_ERR_NOT_IMPLEMENTED";
+#if defined(ASTCENC_DIAGNOSTICS)
+	case ASTCENC_ERR_DTRACE_FAILURE:
+		return "ASTCENC_ERR_DTRACE_FAILURE";
+#endif
 	default:
 		return nullptr;
 	}

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -442,7 +442,6 @@ struct block_mode
 	uint8_t percentile_hit : 1;
 	uint8_t percentile_always : 1;
 	int16_t mode_index;
-
 };
 
 /**

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -400,8 +400,13 @@ struct partition_info
 */
 struct decimation_table
 {
+	// TODO: Make these byte values
 	int texel_count;
 	int weight_count;
+	int weight_x;
+	int weight_y;
+	int weight_z;
+
 	uint8_t texel_weight_count[MAX_TEXELS_PER_BLOCK];	// number of indices that go into the calculation for a texel
 
 	// The 4t and t4 tables are the same data, but transposed to allow optimal

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -1260,6 +1260,10 @@ void physical_to_symbolic(
 uint16_t unorm16_to_sf16(
 	uint16_t p);
 
+#if defined(ASTCENC_DIAGNOSTICS)
+class TraceLog; // See astcenc_diagnostic_trace for details.
+#endif
+
 struct astcenc_context
 {
 	astcenc_config config;
@@ -1287,6 +1291,10 @@ struct astcenc_context
 
 	ParallelManager manage_avg_var;
 	ParallelManager manage_compress;
+#endif
+
+#if defined(ASTCENC_DIAGNOSTICS)
+	TraceLog* trace_log;
 #endif
 };
 

--- a/Source/astcenc_mathlib.h
+++ b/Source/astcenc_mathlib.h
@@ -421,7 +421,7 @@ vtype2<T> operator*(vtype2<T> p, T q) {
 
 // Scalar by vector multiplication operator
 template <typename T>
-vtype2<T> operator*(T p, vtype2<T> q){
+vtype2<T> operator*(T p, vtype2<T> q) {
 	return vtype2<T> { p * q.r, p * q.g };
 }
 
@@ -478,7 +478,7 @@ vtype3<T> operator*(vtype3<T> p, T q) {
 
 // Scalar by vector multiplication operator
 template <typename T>
-vtype3<T> operator*(T p, vtype3<T> q){
+vtype3<T> operator*(T p, vtype3<T> q) {
 	return vtype3<T> { p * q.r, p * q.g, p * q.b };
 }
 
@@ -536,7 +536,7 @@ vtype4<T> operator*(vtype4<T> p, T q) {
 
 // Scalar by vector multiplication operator
 template <typename T>
-vtype4<T> operator*(T p, vtype4<T> q){
+vtype4<T> operator*(T p, vtype4<T> q) {
 	return vtype4<T> { p * q.r, p * q.g, p * q.b, p * q.a };
 }
 

--- a/Source/astcenccli_error_metrics.cpp
+++ b/Source/astcenccli_error_metrics.cpp
@@ -44,7 +44,8 @@ public:
 	/**
 	 * @brief Create a new Kahan accumulator
 	 */
-	kahan_accum4() {
+	kahan_accum4()
+	{
 		sum = float4(0.0f);
 		comp = float4(0.0f);
 	}

--- a/Source/astcenccli_internal.h
+++ b/Source/astcenccli_internal.h
@@ -80,7 +80,6 @@ int store_ncimage(
 int get_output_filename_enforced_bitness(
 	const char* filename);
 
-
 astcenc_image* alloc_image(
 	unsigned int bitness,
 	unsigned int dim_x,

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -908,7 +908,7 @@ int edit_astcenc_config(
 		cli_config.thread_count = get_cpu_count();
 	}
 
-#if defined(ASTCENC_DECOMPRESS_ONLY)
+#if defined(ASTCENC_DECOMPRESS_ONLY) || defined(ASTCENC_DIAGNOSTICS)
 	cli_config.thread_count = 1;
 #else
 	if (operation == ASTCENC_OP_DECOMPRESS)

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -135,7 +135,8 @@ static void compression_workload_runner(
 
 	// This is a racy update, so which error gets returned is a random, but it
 	// will reliably report an error if an error occurs
-	if (error != ASTCENC_SUCCESS) {
+	if (error != ASTCENC_SUCCESS)
+	{
 		work->error = error;
 	}
 }
@@ -896,6 +897,19 @@ int edit_astcenc_config(
 			}
 			argidx++;
 		}
+#if defined(ASTCENC_DIAGNOSTICS)
+		else if (!strcmp(argv[argidx], "-dtrace-out"))
+		{
+			argidx += 2;
+			if (argidx > argc)
+			{
+				printf("ERROR: -dtrace-out switch with no argument\n");
+				return 1;
+			}
+
+			config.trace_file_path = argv[argidx - 1];
+		}
+#endif
 		else // check others as well
 		{
 			printf("ERROR: Argument '%s' not recognized\n", argv[argidx]);
@@ -914,6 +928,14 @@ int edit_astcenc_config(
 	if (operation == ASTCENC_OP_DECOMPRESS)
 	{
 		cli_config.thread_count = 1;
+	}
+#endif
+
+#if defined(ASTCENC_DIAGNOSTICS)
+	if (!config.trace_file_path)
+	{
+		printf("ERROR: Diagnostics builds must set -dtrace-out\n");
+		return 1;
 	}
 #endif
 

--- a/Source/astcenccli_toplevel_help.cpp
+++ b/Source/astcenccli_toplevel_help.cpp
@@ -529,12 +529,14 @@ void astcenc_print_header()
 	printf(astcenc_copyright_string, bits, simdtype, pcnttype);
 }
 
-void astcenc_print_shorthelp() {
+void astcenc_print_shorthelp()
+{
 	astcenc_print_header();
 	printf("%s", astcenc_short_help);
 }
 
-void astcenc_print_longhelp() {
+void astcenc_print_longhelp()
+{
 	astcenc_print_header();
 	printf("%s", astcenc_long_help);
 }

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -30,6 +30,7 @@ target_sources(astc${CODEC}-${ISA_SIMD}
         astcenc_compress_symbolic.cpp
         astcenc_compute_variance.cpp
         astcenc_decompress_symbolic.cpp
+        astcenc_diagnostic_trace.cpp
         astcenc_encoding_choice_error.cpp
         astcenc_entry.cpp
         astcenc_find_best_partitioning.cpp
@@ -70,6 +71,12 @@ if(${DECOMPRESSOR})
     target_compile_definitions(astc${CODEC}-${ISA_SIMD}
         PRIVATE
             ASTCENC_DECOMPRESS_ONLY)
+endif()
+
+if(${DIAGNOSTICS})
+    target_compile_definitions(astc${CODEC}-${ISA_SIMD}
+        PRIVATE
+            ASTCENC_DIAGNOSTICS)
 endif()
 
 target_compile_options(astc${CODEC}-${ISA_SIMD}

--- a/Test/astc_trace_analysis.py
+++ b/Test/astc_trace_analysis.py
@@ -203,10 +203,10 @@ def generate_database(data):
     dbStruct = Trace(bx, by, bz)
 
     for block in get_node(data, "block", True):
-        bx = get_attrib(block, "x_pos")
-        by = get_attrib(block, "y_pos")
-        bz = get_attrib(block, "z_pos")
-        blockStruct = Block(bx, by, bz)
+        px = get_attrib(block, "pos_x")
+        py = get_attrib(block, "pos_y")
+        pz = get_attrib(block, "pos_z")
+        blockStruct = Block(px, py, pz)
         dbStruct.add_block(blockStruct)
 
         for pas in get_node(block, "pass", True):

--- a/Test/astc_trace_analysis.py
+++ b/Test/astc_trace_analysis.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+# Copyright 2021 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# -----------------------------------------------------------------------------
+"""
+The ``astc_trace_analysis`` utility provides a tool to analyze trace files.
+
+WARNING: Trace files are an engineering tool, and not part of the standard
+product, so traces and their associated tools are volatile and may change
+significantly without notice.
+"""
+
+import argparse
+import json
+import sys
+
+QUANT_TABLE = {
+	 0:   2,
+	 1:   3,
+	 2:   4,
+	 3:   5,
+	 4:   6,
+	 5:   8,
+	 6:  10,
+	 7:  12,
+	 8:  16,
+	 9:  20,
+	10:  24,
+	11:  32
+}
+
+
+def rev_enumerate(seq):
+    return zip(reversed(range(len(seq))), reversed(seq))
+
+
+class Trace:
+
+    def __init__(self, block_x, block_y, block_z):
+        self.block_x = block_x
+        self.block_y = block_y
+        self.block_z = block_z
+        self.blocks = []
+
+    def add_block(self, block):
+        self.blocks.append(block)
+
+    def __getitem__(self, i):
+       return self.blocks[i]
+
+    def __delitem__(self, i):
+       del self.blocks[i]
+
+    def __len__(self):
+       return len(self.blocks)
+
+class Block:
+
+    def __init__(self, pos_x, pos_y, pos_z):
+        self.pos_x = pos_x
+        self.pos_y = pos_y
+        self.pos_z = pos_z
+
+        self.passes = []
+        self.qualityHit = None
+
+    def add_pass(self, pas):
+        self.passes.append(pas)
+
+    def __getitem__(self, i):
+       return self.passes[i]
+
+    def __delitem__(self, i):
+       del self.passes[i]
+
+    def __len__(self):
+       return len(self.passes)
+
+class Pass:
+
+    def __init__(self, partitions, planes, target_hit, mode=None, channel=None):
+        self.partitions = partitions
+        self.planes = planes
+        self.plane2_channel = channel
+        self.target_hit = target_hit
+        self.search_mode = mode
+        self.candidates = []
+
+    def add_candidate(self, candidate):
+        self.candidates.append(candidate)
+
+    def __getitem__(self, i):
+       return self.candidates[i]
+
+    def __delitem__(self, i):
+       del self.candidates[i]
+
+    def __len__(self):
+       return len(self.candidates)
+
+
+class Candidate:
+
+    def __init__(self, weight_x, weight_y, weight_z, weight_quant):
+        self.weight_x = weight_x
+        self.weight_y = weight_y
+        self.weight_z = weight_z
+        self.weight_quant = weight_quant
+        self.refinement_errors = []
+
+    def add_refinement(self, errorval):
+        self.refinement_errors.append(errorval)
+
+
+def get_attrib(data, name, multiple=False, hard_fail=True):
+    results = []
+    for attrib in data:
+        if len(attrib) == 2 and attrib[0] == name:
+            results.append(attrib[1])
+
+    if not results:
+        if hard_fail:
+            print(json.dumps(data, indent=2))
+            assert False, "Attribute %s not found" % name
+        return None
+
+    if not multiple:
+        if len(results) > 1:
+            print(json.dumps(data, indent=2))
+            assert False, "Attribute %s found %u times" % (name, len(results))
+        return results[0]
+
+    return results
+
+
+def get_node(data, name, multiple=False, hard_fail=True):
+    results = []
+    for attrib in data:
+        if len(attrib) == 3 and attrib[0] == "node" and attrib[1] == name:
+            results.append(attrib[2])
+
+    if not results:
+        if hard_fail:
+            print(json.dumps(data, indent=2))
+            assert False, "Node %s not found" % name
+        return None
+
+    if not multiple:
+        if len(results) > 1:
+            print(json.dumps(data, indent=2))
+            assert False, "Node %s found %u times" % (name, len(results))
+        return results[0]
+
+    return results
+
+
+def find_best_pass_and_candidate(block):
+    explicit_pass = None
+
+    best_error = 1e30
+    best_pass = None
+    best_candidate = None
+
+    for pas in block:
+        # Special case for constant color blocks - no trial candidates
+        if pas.target_hit and pas.partitions == 0:
+            return (pas, None)
+
+        for candidate in pas:
+            errorval = candidate.refinement_errors[-1]
+            if errorval <= best_error:
+                best_error = errorval
+                best_pass = pas
+                best_candidate = candidate
+
+    # Every other return type must have both best pass and best candidate
+    assert (best_pass and best_candidate)
+    return (best_pass, best_candidate)
+
+
+def generate_database(data):
+    # Skip header
+    assert(data[0] == "node")
+    assert(data[1] == "root")
+    data = data[2]
+
+    bx = get_attrib(data, "block_x")
+    by = get_attrib(data, "block_y")
+    bz = get_attrib(data, "block_z")
+    dbStruct = Trace(bx, by, bz)
+
+    for block in get_node(data, "block", True):
+        bx = get_attrib(block, "x_pos")
+        by = get_attrib(block, "y_pos")
+        bz = get_attrib(block, "z_pos")
+        blockStruct = Block(bx, by, bz)
+        dbStruct.add_block(blockStruct)
+
+        for pas in get_node(block, "pass", True):
+            # Don't copy across passes we skipped due to heuristics
+            skipped = get_attrib(pas, "skip", False, False)
+            if skipped:
+                continue
+
+            prts = get_attrib(pas, "partition_count")
+            plns = get_attrib(pas, "plane_count")
+            chan = get_attrib(pas, "plane_channel", False, plns > 2)
+            mode = get_attrib(pas, "search_mode", False, False)
+            ehit = get_attrib(pas, "exit", False, False) == "quality hit"
+
+            passStruct = Pass(prts, plns, ehit, mode, chan)
+            blockStruct.add_pass(passStruct)
+
+            # Constant color blocks don't have any candidates
+            if prts == 0:
+                continue
+
+            for candidate in get_node(pas, "candidate", True):
+                # Don't copy across candidates we couldn't encode
+                failed = get_attrib(candidate, "failed", False, False)
+                if failed:
+                    continue
+
+                wx = get_attrib(candidate, "weight_x")
+                wy = get_attrib(candidate, "weight_y")
+                wz = get_attrib(candidate, "weight_z")
+                wq = QUANT_TABLE[get_attrib(candidate, "weight_quant")]
+                epre = get_attrib(candidate, "error_prerealign", True)
+                epst = get_attrib(candidate, "error_postrealign")
+
+                candStruct = Candidate(wx, wy, wz, wq)
+                passStruct.add_candidate(candStruct)
+                for value in epre:
+                    candStruct.add_refinement(value)
+                candStruct.add_refinement(epst)
+
+    return dbStruct
+
+
+def filter_database(data):
+
+    for block in data:
+        best_pass, best_candidate = find_best_pass_and_candidate(block)
+
+        for i, pas in rev_enumerate(block):
+            if pas != best_pass:
+                del block[i]
+                continue
+
+            if best_candidate is None:
+                continue
+
+            for j, candidate in rev_enumerate(pas):
+                if candidate != best_candidate:
+                    del pas[j]
+
+
+def parse_command_line():
+    """
+    Parse the command line.
+
+    Returns:
+        Namespace: The parsed command line container.
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("trace", type=argparse.FileType("r"),
+                        help="The trace file to analyze")
+
+    return parser.parse_args()
+
+
+def main():
+    """
+    The main function.
+
+    Returns:
+        int: The process return code.
+    """
+    args = parse_command_line()
+
+    data = json.load(args.trace)
+    db = generate_database(data)
+    filter_database(db)
+
+
+
+    #count_blocks(data)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Test/astc_trace_analysis.py
+++ b/Test/astc_trace_analysis.py
@@ -24,6 +24,7 @@ significantly without notice.
 """
 
 import argparse
+from collections import defaultdict as ddict
 import json
 import sys
 
@@ -42,10 +43,12 @@ QUANT_TABLE = {
 	11:  32
 }
 
-
-def rev_enumerate(seq):
-    return zip(reversed(range(len(seq))), reversed(seq))
-
+CHANNEL_TABLE = {
+	 0: "R",
+	 1: "G",
+	 2: "B",
+	 3: "A"
+}
 
 class Trace:
 
@@ -69,13 +72,38 @@ class Trace:
 
 class Block:
 
-    def __init__(self, pos_x, pos_y, pos_z):
+    def __init__(self, pos_x, pos_y, pos_z, error_target):
         self.pos_x = pos_x
         self.pos_y = pos_y
         self.pos_z = pos_z
 
+        self.raw_min = None
+        self.raw_max = None
+
+        self.ldr_min = None
+        self.ldr_max = None
+
+        self.error_target = error_target
         self.passes = []
         self.qualityHit = None
+
+    def add_minimums(self, r, g, b, a):
+        self.raw_min = (r, g, b, a)
+
+        def ldr(x):
+            cmax = 65535.0
+            return int((r / cmax) * 255.0)
+
+        self.ldr_min = (ldr(r), ldr(g), ldr(b), ldr(a))
+
+    def add_maximums(self, r, g, b, a):
+        self.raw_max = (r, g, b, a)
+
+        def ldr(x):
+            cmax = 65535.0
+            return int((r / cmax) * 255.0)
+
+        self.ldr_max = (ldr(r), ldr(g), ldr(b), ldr(a))
 
     def add_pass(self, pas):
         self.passes.append(pas)
@@ -89,10 +117,12 @@ class Block:
     def __len__(self):
        return len(self.passes)
 
+
 class Pass:
 
-    def __init__(self, partitions, planes, target_hit, mode=None, channel=None):
+    def __init__(self, partitions, partition, planes, target_hit, mode, channel):
         self.partitions = partitions
+        self.partition_index = 0 if partition is None else partition
         self.planes = planes
         self.plane2_channel = channel
         self.target_hit = target_hit
@@ -145,6 +175,31 @@ def get_attrib(data, name, multiple=False, hard_fail=True):
 
     return results
 
+
+def rev_enumerate(seq):
+    return zip(reversed(range(len(seq))), reversed(seq))
+
+def foreach_block(data):
+
+    for block in data:
+        yield block
+
+def foreach_pass(data):
+
+    for block in data:
+        for pas in block:
+            yield (block, pas)
+
+def foreach_candidate(data):
+
+    for block in data:
+        for pas in block:
+            # Special case - None candidates for 0 partition
+            if not len(pas):
+                yield (block, pas, None)
+
+            for candidate in pas:
+                yield (block, pas, candidate)
 
 def get_node(data, name, multiple=False, hard_fail=True):
     results = []
@@ -206,7 +261,22 @@ def generate_database(data):
         px = get_attrib(block, "pos_x")
         py = get_attrib(block, "pos_y")
         pz = get_attrib(block, "pos_z")
-        blockStruct = Block(px, py, pz)
+
+        minr = get_attrib(block, "min_r")
+        ming = get_attrib(block, "min_g")
+        minb = get_attrib(block, "min_b")
+        mina = get_attrib(block, "min_a")
+
+        maxr = get_attrib(block, "max_r")
+        maxg = get_attrib(block, "max_g")
+        maxb = get_attrib(block, "max_b")
+        maxa = get_attrib(block, "max_a")
+
+        et = get_attrib(block, "tune_error_threshold")
+
+        blockStruct = Block(px, py, pz, et)
+        blockStruct.add_minimums(minr, ming, minb, mina)
+        blockStruct.add_maximums(maxr, maxg, maxb, maxa)
         dbStruct.add_block(blockStruct)
 
         for pas in get_node(block, "pass", True):
@@ -216,12 +286,13 @@ def generate_database(data):
                 continue
 
             prts = get_attrib(pas, "partition_count")
+            prti = get_attrib(pas, "partition_index", False, False)
             plns = get_attrib(pas, "plane_count")
             chan = get_attrib(pas, "plane_channel", False, plns > 2)
             mode = get_attrib(pas, "search_mode", False, False)
             ehit = get_attrib(pas, "exit", False, False) == "quality hit"
 
-            passStruct = Pass(prts, plns, ehit, mode, chan)
+            passStruct = Pass(prts, prti, plns, ehit, mode, chan)
             blockStruct.add_pass(passStruct)
 
             # Constant color blocks don't have any candidates
@@ -268,6 +339,179 @@ def filter_database(data):
                     del pas[j]
 
 
+def generate_pass_statistics(data):
+    pass
+
+
+def generate_feature_statistics(data):
+    # -------------------------------------------------------------------------
+    # Config
+    print("Compressor Config")
+    print("=================")
+
+    if data.block_z > 1:
+        dat = (data.block_x, data.block_y, data.block_z)
+        print("  - Block size: %ux%ux%u" % dat)
+    else:
+        dat = (data.block_x, data.block_y)
+        print("  - Block size: %ux%u" % dat)
+
+    print("")
+
+    # -------------------------------------------------------------------------
+    # Block metrics
+    result = ddict(int)
+
+    RANGE_QUANT = 16
+
+    for block in foreach_block(data):
+        ranges = []
+        for i in range(0, 4):
+            ranges.append(block.ldr_max[i] - block.ldr_min[i])
+
+        max_range = max(ranges)
+        max_range = int(max_range / RANGE_QUANT) * RANGE_QUANT
+
+        result[max_range] += 1
+
+    print("Channel Range")
+    print("=============")
+    keys = sorted(result.keys())
+    for key in keys:
+        dat = (key, key + RANGE_QUANT - 1, result[key])
+        print("  - %3u-%3u dynamic range = %6u blocks" % dat)
+
+    print("")
+
+    # -------------------------------------------------------------------------
+    # Partition usage
+    result_totals = ddict(int)
+    results = ddict(lambda: ddict(int))
+
+    for _, pas in foreach_pass(data):
+        result_totals[pas.partitions] += 1
+        results[pas.partitions][pas.partition_index] += 1
+
+    print("Partition Count")
+    print("===============")
+    keys = sorted(result_totals.keys())
+    for key in keys:
+        dat = (key, result_totals[key], len(results[key]))
+        print("  - %u partition(s) = %6u blocks / %4u indicies" % dat)
+
+    print("")
+
+    # -------------------------------------------------------------------------
+    # Plane usage
+    result_count = ddict(lambda: ddict(int))
+    result_channel = ddict(lambda: ddict(int))
+
+    for _, pas in foreach_pass(data):
+        result_count[pas.partitions][pas.planes] += 1
+        if (pas.planes > 1):
+            result_channel[pas.partitions][pas.plane2_channel] += 1
+
+    print("Plane Usage")
+    print("===========")
+    keys = sorted(result_count.keys())
+    for key in keys:
+        keys2 = sorted(result_count[key])
+        for key2 in keys2:
+            val2 = result_count[key][key2]
+            dat = (key, key2, val2)
+            print("  - %u partition(s) %u plane(s) = %6u blocks" % dat)
+            if key2 == 2:
+                keys3 = sorted(result_channel[key])
+                for key3 in keys3:
+                    dat = (CHANNEL_TABLE[key3], result_channel[key][key3])
+                    print("    - %s plane                 = %6u blocks" % dat)
+
+    print("")
+
+    # -------------------------------------------------------------------------
+    # Decimation usage
+    decim_count = ddict(lambda: ddict(int))
+    quant_count = ddict(lambda: ddict(lambda: ddict(int)))
+
+
+    MERGE_ROTATIONS = True
+
+    for _, pas, can in foreach_candidate(data):
+        # Skip constant color blocks
+        if can is None:
+            continue
+
+        wx = can.weight_x
+        wy = can.weight_y
+
+        if MERGE_ROTATIONS and wx < wy:
+            wx, wy = wy, wx
+
+        decim_count[wx][wy] += 1
+        quant_count[wx][wy][can.weight_quant] += 1
+
+    print("Decimation Usage")
+    print("================")
+
+    if MERGE_ROTATIONS:
+        print("  - Note: data merging grid rotations")
+
+    x_keys = sorted(decim_count.keys())
+    for x_key in x_keys:
+        y_keys = sorted(decim_count[x_key])
+
+        for y_key in y_keys:
+            count = decim_count[x_key][y_key]
+            dat = (x_key, y_key, count)
+            print("  - %ux%u weights      = %6u blocks" % dat)
+
+            q_keys = sorted(quant_count[x_key][y_key])
+            for q_key in q_keys:
+                count = quant_count[x_key][y_key][q_key]
+                dat = (q_key, count)
+                print("    - %2u quant range = %6u blocks" % dat)
+
+    print("")
+
+    # -------------------------------------------------------------------------
+    # Refinement usage
+
+    total_count = 0
+    better_count = 0
+    could_have_count = 0
+    success_count = 0
+
+    for block, pas, candidate in foreach_candidate(data):
+        # Ignore zero partition blocks - they don't use refinement
+        if not candidate:
+            continue
+
+        target_error = block.error_target
+        start_error = candidate.refinement_errors[0]
+        end_error = candidate.refinement_errors[-1]
+
+        total_count += 1
+        if end_error <= start_error:
+            better_count += 1
+
+        if end_error <= target_error:
+            success_count += 1
+        else:
+            for refinement in candidate.refinement_errors:
+                if refinement <= target_error:
+                    could_have_count += 1
+                    break
+
+
+    print("Refinement Usage")
+    print("================")
+    print("  - %u refinements(s)" % total_count)
+    print("  - %u refinements(s) improved" % better_count)
+    print("  - %u refinements(s) worsened" % (total_count - better_count))
+    print("  - %u refinements(s) could hit target, but didnt" % could_have_count)
+    print("  - %u refinements(s) hit target" % success_count)
+
+
 def parse_command_line():
     """
     Parse the command line.
@@ -296,9 +540,7 @@ def main():
     db = generate_database(data)
     filter_database(db)
 
-
-
-    #count_blocks(data)
+    generate_feature_statistics(db)
 
     return 0
 


### PR DESCRIPTION
This PR adds support for tracing the compressor execution. 

This is implemented using a special build-variant, which can include additional processing and forces single threaded execution. Each compression will generate a JSON file containing the trace file.  The trace file is relatively raw, due to the need to keep the tracing stateless. A python tool is provided to post-process the trace and allow further analysis of the data.

