### PR TITLE
Allow astc-encoder to be built as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@
 #  ----------------------------------------------------------------------------
 
 # CMake configuration
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 cmake_policy(SET CMP0069 NEW)  # LTO support
-cmake_policy(SET CMP0091 NEW)  # MSVC runtime support
+#cmake_policy(SET CMP0091 NEW)  # MSVC runtime support
 
 project(astcenc VERSION 2.3.0)
 


### PR DESCRIPTION
Currently the CMake build does not support building the API as a static library.

I'm not sure what the right approach is here. I had to hack together static library support for Granite integration.