### PR TITLE
Implement vec4 support for float16 conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,22 @@ Binaries are provided for 64-bit builds on Windows, macOS, and Linux.
 ## astcenc 2.x binaries
 
 The current builds of the astcenc 2.x series are provided as multiple binaries,
-each tuned for a specific SIMD instruction set. We provide, in order of
-increasing performance:
+each tuned for a specific SIMD instruction set.
+
+For x86-64 we provide, in order of increasing performance:
 
 * `astcenc-sse2` - uses SSE2
 * `astcenc-sse4.1` - uses SSE4.1 and POPCNT
-* `astcenc-avx2` - uses SSE4.2, POPCNT, and AVX2
+* `astcenc-avx2` - uses AVX2, SSE4.2, POPCNT, and F16C
 
-The SSE2 builds will work on all x86-64 host machines, but it is the slowest of
-the three. The other two require extended CPU instruction set support which is
-not universally available.
+For Apple silicon macOS devices we provide:
 
-It is worth noting that the three binaries do not produce identical output
-images; there are minor output differences caused by variations in
-floating-point rounding.
+* `astcenc-neon` - uses NEON
+
+The x86-64 SSE2 builds will work on all x86-64 machines, but it is the slowest
+of the three. The other two require extended CPU instruction set support which
+is not universally available, but each step gains ~15% more performance.
+
 
 ## Repository branches
 

--- a/Source/UnitTest/cmake_core.cmake
+++ b/Source/UnitTest/cmake_core.cmake
@@ -19,7 +19,8 @@ add_executable(test-simd-${ISA_SIMD})
 
 target_sources(test-simd-${ISA_SIMD}
     PRIVATE
-        test_simd.cpp)
+        test_simd.cpp
+        ../astcenc_mathlib_softfloat.cpp)
 
 target_include_directories(test-simd-${ISA_SIMD}
     PRIVATE
@@ -48,7 +49,8 @@ if(${ISA_SIMD} MATCHES "none")
             ASTCENC_NEON=0
             ASTCENC_SSE=0
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=0)
+            ASTCENC_POPCNT=0
+            ASTCENC_F16C=0)
 
     if (${ARCH} MATCHES x64)
         target_compile_options(test-simd-${ISA_SIMD}
@@ -62,7 +64,8 @@ elseif(${ISA_SIMD} MATCHES "neon")
             ASTCENC_NEON=1
             ASTCENC_SSE=0
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=0)
+            ASTCENC_POPCNT=0
+            ASTCENC_F16C=0)
 
 elseif(${ISA_SIMD} MATCHES "sse2")
     target_compile_definitions(test-simd-${ISA_SIMD}
@@ -70,7 +73,8 @@ elseif(${ISA_SIMD} MATCHES "sse2")
             ASTCENC_NEON=0
             ASTCENC_SSE=20
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=0)
+            ASTCENC_POPCNT=0
+            ASTCENC_F16C=0)
 
     target_compile_options(test-simd-${ISA_SIMD}
         PRIVATE
@@ -82,7 +86,8 @@ elseif(${ISA_SIMD} MATCHES "sse4.1")
             ASTCENC_NEON=0
             ASTCENC_SSE=41
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=1)
+            ASTCENC_POPCNT=1
+            ASTCENC_F16C=0)
 
     target_compile_options(test-simd-${ISA_SIMD}
         PRIVATE
@@ -94,11 +99,12 @@ elseif(${ISA_SIMD} MATCHES "avx2")
             ASTCENC_NEON=0
             ASTCENC_SSE=41
             ASTCENC_AVX=2
-            ASTCENC_POPCNT=1)
+            ASTCENC_POPCNT=1
+            ASTCENC_F16C=1)
 
     target_compile_options(test-simd-${ISA_SIMD}
         PRIVATE
-            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mfpmath=sse -mavx2 -mpopcnt>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mfpmath=sse -mavx2 -mpopcnt -mf16c>
             $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>)
 endif()
 

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1014,6 +1014,53 @@ TEST(vfloat4, int_to_float)
 	EXPECT_EQ(r.lane<3>(), 4.0f);
 }
 
+/** @brief Test vfloat4 float to fp16 conversion. */
+TEST(vfloat4, float_to_float16)
+{
+	vfloat4 a(1.5, 234.5, 345345.0, qnan);
+	vint4 r = float_to_float16(a);
+
+	// Normal numbers
+	EXPECT_EQ(r.lane<0>(), 0x3E00);
+	EXPECT_EQ(r.lane<1>(), 0x5B54);
+
+	// Large numbers convert to infinity
+	EXPECT_EQ(r.lane<2>(), 0x7C00);
+
+	// NaN must convert to any valid NaN encoding
+	EXPECT_EQ((r.lane<3>() >> 10) & 0x1F, 0x1F); // Exponent must be all 1s
+	EXPECT_NE(r.lane<3>() & (0x3FF), 0);         // Mantissa must be non-zero
+}
+
+/** @brief Test float to fp16 conversion. */
+TEST(sfloat, float_to_float16)
+{
+	int r = float_to_float16(234.5);
+	EXPECT_EQ(r, 0x5B54);
+}
+
+/** @brief Test vfloat4 fp16 to float conversion. */
+TEST(vfloat4, float16_to_float)
+{	vint4 a(0x3E00, 0x5B54, 0x7C00, 0xFFFF);
+	vfloat4 r = float16_to_float(a);
+
+	// Normal numbers
+	EXPECT_EQ(r.lane<0>(), 1.5);
+	EXPECT_EQ(r.lane<1>(), 234.5);
+
+	// Infinities must be preserved
+	EXPECT_NE(std::isinf(r.lane<2>()), 0);
+
+	// NaNs must be preserved
+	EXPECT_NE(std::isnan(r.lane<3>()), 0);
+}
+
+/** @brief Test fp16 to float conversion. */
+TEST(sfloat, float16_to_float)
+{
+	float r = float16_to_float(0x5B54);
+	EXPECT_EQ(r, 234.5);
+}
 
 // VINT4 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1308,27 +1308,22 @@ void compress_block(
 
 		// detected a constant-color block. Encode as FP16 if using HDR
 		scb.error_block = 0;
+		scb.partition_count = 0;
 
 		if ((decode_mode == ASTCENC_PRF_HDR) ||
 		    (decode_mode == ASTCENC_PRF_HDR_RGB_LDR_A))
 		{
 			scb.block_mode = -1;
-			scb.partition_count = 0;
-			vfloat4 orig_color = blk->origin_texel;
-			scb.constant_color[0] = float_to_sf16(orig_color.lane<0>(), SF_NEARESTEVEN);
-			scb.constant_color[1] = float_to_sf16(orig_color.lane<1>(), SF_NEARESTEVEN);
-			scb.constant_color[2] = float_to_sf16(orig_color.lane<2>(), SF_NEARESTEVEN);
-			scb.constant_color[3] = float_to_sf16(orig_color.lane<3>(), SF_NEARESTEVEN);
+			vint4 color_f16 = float_to_float16(blk->origin_texel);
+			store(color_f16, scb.constant_color);
 		}
 		else
 		{
 			// Encode as UNORM16 if NOT using HDR.
 			scb.block_mode = -2;
-			scb.partition_count = 0;
-
-			vfloat4 color_u16f = clamp(0.0f, 1.0f, blk->origin_texel) * 65535.0f;
-			vint4 color_u16i = float_to_int_rtn(color_u16f);
-			store(color_u16i, scb.constant_color);
+			vfloat4 color_f32 = clamp(0.0f, 1.0f, blk->origin_texel) * 65535.0f;
+			vint4 color_u16 = float_to_int_rtn(color_f32);
+			store(color_u16, scb.constant_color);
 		}
 
 		trace_add_data("exit", "quality hit");

--- a/Source/astcenc_compute_variance.cpp
+++ b/Source/astcenc_compute_variance.cpp
@@ -245,15 +245,8 @@ static void compute_pixel_region_variance(
 					data[2] = data16[(4 * img->dim_x * y_src) + (4 * x_src + 2)];
 					data[3] = data16[(4 * img->dim_x * y_src) + (4 * x_src + 3)];
 
-					uint16_t r = data[swz.r];
-					uint16_t g = data[swz.g];
-					uint16_t b = data[swz.b];
-					uint16_t a = data[swz.a];
-
-					vfloat4 d = vfloat4(sf16_to_float(r),
-					                    sf16_to_float(g),
-					                    sf16_to_float(b),
-					                    sf16_to_float(a));
+					vint4 di(data[swz.r], data[swz.g], data[swz.b], data[swz.a]);
+					vfloat4 d = float16_to_float(di);
 
 					if (!are_powers_1)
 					{

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -64,6 +64,13 @@ static astcenc_error validate_cpu_isa()
 		}
 	#endif
 
+	#if ASTCENC_F16C >= 1
+		if (!cpu_supports_f16c())
+		{
+			return ASTCENC_ERR_BAD_CPU_ISA;
+		}
+	#endif
+
 	#if ASTCENC_AVX >= 2
 		if (!cpu_supports_avx2())
 		{

--- a/Source/astcenc_image.cpp
+++ b/Source/astcenc_image.cpp
@@ -126,50 +126,59 @@ void imageblock_initialize_deriv(
 	int pixelcount,
 	vfloat4* dptr
 ) {
+	// TODO: For LDR on the current codec we can skip this if no LNS and just
+	// early-out as we use the same LNS settings everywhere ...
 	for (int i = 0; i < pixelcount; i++)
 	{
-		float dr = 65535.0f;
-		float dg = 65535.0f;
-		float db = 65535.0f;
-		float da = 65535.0f;
+		vfloat4 derv_unorm(65535.0f);
+		vfloat4 derv_lns = vfloat4::zero();
 
-		// compute derivatives for RGB first
-		if (pb->rgb_lns[i])
+		// TODO: Pack these into bits and avoid the disjoint fetch
+		int rgb_lns = pb->rgb_lns[i];
+		int a_lns = pb->alpha_lns[i];
+
+		// Compute derivatives if we have any use of LNS
+		if (rgb_lns || a_lns)
 		{
-			vfloat4 fdata = pb->texel3(i);
-			fdata.set_lane<0>(sf16_to_float(lns_to_sf16((uint16_t)fdata.lane<0>())));
-			fdata.set_lane<1>(sf16_to_float(lns_to_sf16((uint16_t)fdata.lane<1>())));
-			fdata.set_lane<2>(sf16_to_float(lns_to_sf16((uint16_t)fdata.lane<2>())));
+			vfloat4 data = pb->texel(i);
 
-			float r = astc::max(fdata.lane<0>(), 6e-5f);
-			float g = astc::max(fdata.lane<1>(), 6e-5f);
-			float b = astc::max(fdata.lane<2>(), 6e-5f);
+			vint4 datai(
+				lns_to_sf16((uint16_t)data.lane<0>()),
+				lns_to_sf16((uint16_t)data.lane<1>()),
+				lns_to_sf16((uint16_t)data.lane<2>()),
+				lns_to_sf16((uint16_t)data.lane<3>())
+			);
 
-			float rderiv = (float_to_lns(r * 1.05f) - float_to_lns(r)) / (r * 0.05f);
-			float gderiv = (float_to_lns(g * 1.05f) - float_to_lns(g)) / (g * 0.05f);
-			float bderiv = (float_to_lns(b * 1.05f) - float_to_lns(b)) / (b * 0.05f);
+			vfloat4 dataf = float16_to_float(datai);
+			dataf = max(dataf, 6e-5f);
 
-			// the derivative may not actually take values smaller than 1/32 or larger than 2^25;
-			// if it does, we clamp it.
-			dr = astc::clamp(rderiv, 1.0f / 32.0f, 33554432.0f);
-			dg = astc::clamp(gderiv, 1.0f / 32.0f, 33554432.0f);
-			db = astc::clamp(bderiv, 1.0f / 32.0f, 33554432.0f);
+			vfloat4 data_lns1 = dataf * 1.05;
+			data_lns1 = vfloat4(
+				float_to_lns(data_lns1.lane<0>()),
+				float_to_lns(data_lns1.lane<1>()),
+				float_to_lns(data_lns1.lane<2>()),
+				float_to_lns(data_lns1.lane<3>())
+			);
+
+			vfloat4 data_lns2 = dataf;
+			data_lns2 = vfloat4(
+				float_to_lns(data_lns2.lane<0>()),
+				float_to_lns(data_lns2.lane<1>()),
+				float_to_lns(data_lns2.lane<2>()),
+				float_to_lns(data_lns2.lane<3>())
+			);
+
+			vfloat4 divisor_lns = dataf * 0.05f;
+
+			// Clamp derivatives between 1/32 and 2^25
+			float lo = 1.0f / 32.0f;
+			float hi = 33554432.0f;
+			derv_lns = clamp(lo, hi, (data_lns1 - data_lns2) / divisor_lns);
 		}
 
-		// then compute derivatives for Alpha
-		if (pb->alpha_lns[i])
-		{
-			float fdata = pb->data_a[i];
-			fdata = sf16_to_float(lns_to_sf16((uint16_t)fdata));
-
-			float a = astc::max(fdata, 6e-5f);
-			float aderiv = (float_to_lns(a * 1.05f) - float_to_lns(a)) / (a * 0.05f);
-			// the derivative may not actually take values smaller than 1/32 or larger than 2^25;
-			// if it does, we clamp it.
-			da = astc::clamp(aderiv, 1.0f / 32.0f, 33554432.0f);
-		}
-
-		*dptr = vfloat4(dr, dg, db, da);
+		vint4 use_lns(rgb_lns, rgb_lns, rgb_lns, a_lns);
+		vmask4 lns_mask = use_lns != vint4::zero();
+		*dptr = select(derv_unorm, derv_lns, lns_mask);
 		dptr++;
 	}
 }
@@ -210,7 +219,6 @@ static void imageblock_initialize_work_from_orig(
 		{
 			data.set_lane<3>(data.lane<3>() * 65535.0f);
 		}
-
 		// Compute block metadata
 		data_min = min(data_min, data);
 		data_max = max(data_max, data);
@@ -413,10 +421,11 @@ void fetch_imageblock(
 						a = data[swz.a];
 					}
 
-					pb->data_r[idx] = astc::max(sf16_to_float(r), 1e-8f);
-					pb->data_g[idx] = astc::max(sf16_to_float(g), 1e-8f);
-					pb->data_b[idx] = astc::max(sf16_to_float(b), 1e-8f);
-					pb->data_a[idx] = astc::max(sf16_to_float(a), 1e-8f);
+					vfloat4 dataf = max(float16_to_float(vint4(r, g, b, a)), 1e-8);
+					pb->data_r[idx] = dataf.lane<0>();
+					pb->data_g[idx] = dataf.lane<1>();
+					pb->data_b[idx] = dataf.lane<2>();
+					pb->data_a[idx] = dataf.lane<3>();
 					idx++;
 				}
 			}
@@ -600,14 +609,11 @@ void write_imageblock(
 
 					if (xi >= 0 && yi >= 0 && zi >= 0 && xi < xsize && yi < ysize && zi < zsize)
 					{
-						int ri, gi, bi, ai;
+						vint4 color;
 
 						if (*nptr)
 						{
-							ri = 0xFFFF;
-							gi = 0xFFFF;
-							bi = 0xFFFF;
-							ai = 0xFFFF;
+							color = vint4(0xFFFF);
 						}
 						else if (needs_swz)
 						{
@@ -628,23 +634,19 @@ void write_imageblock(
 								data[ASTCENC_SWZ_Z] = (astc::sqrt(zN) * 0.5f) + 0.5f;
 							}
 
-							ri = float_to_sf16(data[swz.r], SF_NEARESTEVEN);
-							gi = float_to_sf16(data[swz.g], SF_NEARESTEVEN);
-							bi = float_to_sf16(data[swz.b], SF_NEARESTEVEN);
-							ai = float_to_sf16(data[swz.a], SF_NEARESTEVEN);
+							vfloat4 colorf(data[swz.r], data[swz.g], data[swz.b], data[swz.a]);
+							color = float_to_float16(colorf);
 						}
 						else
 						{
-							ri = float_to_sf16(pb->data_r[idx], SF_NEARESTEVEN);
-							gi = float_to_sf16(pb->data_g[idx], SF_NEARESTEVEN);
-							bi = float_to_sf16(pb->data_b[idx], SF_NEARESTEVEN);
-							ai = float_to_sf16(pb->data_a[idx], SF_NEARESTEVEN);
+							vfloat4 colorf = pb->texel(idx);
+							color = float_to_float16(colorf);
 						}
 
-						data16[(4 * xsize * yi) + (4 * xi    )] = ri;
-						data16[(4 * xsize * yi) + (4 * xi + 1)] = gi;
-						data16[(4 * xsize * yi) + (4 * xi + 2)] = bi;
-						data16[(4 * xsize * yi) + (4 * xi + 3)] = ai;
+						data16[(4 * xsize * yi) + (4 * xi    )] = (uint16_t)color.lane<0>();
+						data16[(4 * xsize * yi) + (4 * xi + 1)] = (uint16_t)color.lane<1>();
+						data16[(4 * xsize * yi) + (4 * xi + 2)] = (uint16_t)color.lane<2>();
+						data16[(4 * xsize * yi) + (4 * xi + 3)] = (uint16_t)color.lane<3>();
 					}
 					idx++;
 					nptr++;

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -1324,19 +1324,25 @@ struct astcenc_context
   Platform-specific functions
 ============================================================================ */
 /**
- * @brief Run-time detection if the host CPU supports SSE 4.1.
- * @return Zero if not supported, positive value if it is.
- */
-int cpu_supports_sse41();
-
-/**
- * @brief Run-time detection if the host CPU supports popcnt.
+ * @brief Run-time detection if the host CPU supports the POPCNT extension.
  * @return Zero if not supported, positive value if it is.
  */
 int cpu_supports_popcnt();
 
 /**
- * @brief Run-time detection if the host CPU supports avx2.
+ * @brief Run-time detection if the host CPU supports F16C extension.
+ * @return Zero if not supported, positive value if it is.
+ */
+int cpu_supports_f16c();
+
+/**
+ * @brief Run-time detection if the host CPU supports SSE 4.1 extension.
+ * @return Zero if not supported, positive value if it is.
+ */
+int cpu_supports_sse41();
+
+/**
+ * @brief Run-time detection if the host CPU supports AVX 2 extension.
  * @return Zero if not supported, positive value if it is.
  */
 int cpu_supports_avx2();

--- a/Source/astcenc_mathlib.h
+++ b/Source/astcenc_mathlib.h
@@ -27,6 +27,22 @@
 #include <cstdint>
 #include <cmath>
 
+#ifndef ASTCENC_POPCNT
+  #if defined(__POPCNT__)
+    #define ASTCENC_POPCNT 1
+  #else
+    #define ASTCENC_POPCNT 0
+  #endif
+#endif
+
+#ifndef ASTCENC_F16C
+  #if defined(__F16C__)
+    #define ASTCENC_F16C 1
+  #else
+    #define ASTCENC_F16C 0
+  #endif
+#endif
+
 #ifndef ASTCENC_SSE
   #if defined(__SSE4_2__)
     #define ASTCENC_SSE 42
@@ -38,14 +54,6 @@
     #define ASTCENC_SSE 20
   #else
     #define ASTCENC_SSE 0
-  #endif
-#endif
-
-#ifndef ASTCENC_POPCNT
-  #if defined(__POPCNT__)
-    #define ASTCENC_POPCNT 1
-  #else
-    #define ASTCENC_POPCNT 0
   #endif
 #endif
 

--- a/Source/astcenc_mathlib.h
+++ b/Source/astcenc_mathlib.h
@@ -305,21 +305,6 @@ static inline float clamp255f(float v)
 }
 
 /**
- * @brief Clamp a float value between 0.0f and 65504.0f.
- *
- * NaNs are turned into 0.0f.
- *
- * @param v   The value to clamp
- *
- * @return The clamped value
- */
-static inline float clamp64Kf(float v)
-{
-	return astc::clamp(v, 0.0f, 65504.0f);
-}
-
-
-/**
  * @brief SP float round-to-nearest.
  *
  * @param v   The value to round.
@@ -550,32 +535,9 @@ static inline float2 normalize(float2 p) { return p * astc::rsqrt(dot(p, p)); }
 ============================================================================ */
 uint32_t clz32(uint32_t p);
 
-/*	sized soft-float types. These are mapped to the sized integer
-    types of C99, instead of C's floating-point types; this is because
-    the library needs to maintain exact, bit-level control on all
-    operations on these data types. */
-typedef uint16_t sf16;
-typedef uint32_t sf32;
-
-/* the five rounding modes that IEEE-754r defines */
-typedef enum
-{
-	SF_UP = 0,				/* round towards positive infinity */
-	SF_DOWN = 1,			/* round towards negative infinity */
-	SF_TOZERO = 2,			/* round towards zero */
-	SF_NEARESTEVEN = 3,		/* round toward nearest value; if mid-between, round to even value */
-	SF_NEARESTAWAY = 4		/* round toward nearest value; if mid-between, round away from zero */
-} roundmode;
-
 /* narrowing float->float conversions */
-sf16 sf32_to_sf16(sf32, roundmode);
-
-/* widening float->float conversions */
-sf32 sf16_to_sf32(sf16);
-
-sf16 float_to_sf16(float, roundmode);
-
-float sf16_to_float(sf16);
+uint16_t float_to_sf16(float val);
+float sf16_to_float(uint16_t val);
 
 /*********************************
   Vector library

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -1002,6 +1002,54 @@ ASTCENC_SIMD_INLINE vfloat4 int_to_float(vint4 a)
 }
 
 /**
+ * @brief Return a float16 value for a float vector, using round-to-nearest.
+ */
+ASTCENC_SIMD_INLINE vint4 float_to_float16(vfloat4 a)
+{
+	// Generate float16 value
+	float16x4_t f16 = vcvt_f16_f32(a.m);
+
+	// Convert each 16-bit float pattern to a 32-bit pattern
+	uint16x4_t u16 = vreinterpret_u16_f16(f16)
+	uint32x4_t u32 = movl_u16(u16);
+	return vint4(vreinterpret_s32_u32(u32));
+}
+
+/**
+ * @brief Return a float16 value for a float scalar, using round-to-nearest.
+ */
+static inline uint16_t float_to_float16(float a)
+{
+	vfloat4 av(a);
+	return float_to_float16(av).lane<0>();
+}
+
+/**
+ * @brief Return a float value for a float16 vector.
+ *
+ * TODO: Use the NEON fp16 support.
+ */
+ASTCENC_SIMD_INLINE vfloat4 float16_to_float(vint4 a)
+{
+	// Convert each 32-bit float pattern to a 16-bit pattern
+	uint32x4_t u32 = vreinterpret_u32_s32(a.m);
+	uint16x4_t u16 = movn_u32(u32);
+	float16x4_t f16 = vreinterpret_f16_u16(u16);
+
+	// Generate float16 value
+	return vfloat4(vcvt_f32_f16(f16));
+}
+
+/**
+ * @brief Return a float value for a float16 scalar.
+ */
+ASTCENC_SIMD_INLINE float float16_to_float(uint16_t a)
+{
+	vint4 av(a);
+	return float16_to_float(av).lane<0>();
+}
+
+/**
  * @brief Return a float value as an integer bit pattern (i.e. no conversion).
  *
  * It is a common trick to convert floats into integer bit patterns, perform

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -1010,9 +1010,9 @@ ASTCENC_SIMD_INLINE vint4 float_to_float16(vfloat4 a)
 	float16x4_t f16 = vcvt_f16_f32(a.m);
 
 	// Convert each 16-bit float pattern to a 32-bit pattern
-	uint16x4_t u16 = vreinterpret_u16_f16(f16)
-	uint32x4_t u32 = movl_u16(u16);
-	return vint4(vreinterpret_s32_u32(u32));
+	uint16x4_t u16 = vreinterpret_u16_f16(f16);
+	uint32x4_t u32 = vmovl_u16(u16);
+	return vint4(vreinterpretq_s32_u32(u32));
 }
 
 /**
@@ -1026,14 +1026,12 @@ static inline uint16_t float_to_float16(float a)
 
 /**
  * @brief Return a float value for a float16 vector.
- *
- * TODO: Use the NEON fp16 support.
  */
 ASTCENC_SIMD_INLINE vfloat4 float16_to_float(vint4 a)
 {
 	// Convert each 32-bit float pattern to a 16-bit pattern
-	uint32x4_t u32 = vreinterpret_u32_s32(a.m);
-	uint16x4_t u16 = movn_u32(u32);
+	uint32x4_t u32 = vreinterpretq_u32_s32(a.m);
+	uint16x4_t u16 = vmovn_u32(u32);
 	float16x4_t f16 = vreinterpret_f16_u16(u16);
 
 	// Generate float16 value

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -1120,6 +1120,46 @@ ASTCENC_SIMD_INLINE vfloat4 int_to_float(vint4 a)
 }
 
 /**
+ * @brief Return a float16 value for a float vector, using round-to-nearest.
+ */
+ASTCENC_SIMD_INLINE vint4 float_to_float16(vfloat4 a)
+{
+	return vint4(
+		float_to_sf16(a.lane<0>()),
+		float_to_sf16(a.lane<1>()),
+		float_to_sf16(a.lane<2>()),
+		float_to_sf16(a.lane<3>()));
+}
+
+/**
+ * @brief Return a float16 value for a float scalar, using round-to-nearest.
+ */
+static inline uint16_t float_to_float16(float a)
+{
+	return float_to_sf16(a);
+}
+
+/**
+ * @brief Return a float value for a float16 vector.
+ */
+ASTCENC_SIMD_INLINE vfloat4 float16_to_float(vint4 a)
+{
+	return vfloat4(
+		sf16_to_float(a.lane<0>()),
+		sf16_to_float(a.lane<1>()),
+		sf16_to_float(a.lane<2>()),
+		sf16_to_float(a.lane<3>()));
+}
+
+/**
+ * @brief Return a float value for a float16 scalar.
+ */
+ASTCENC_SIMD_INLINE float float16_to_float(uint16_t a)
+{
+	return sf16_to_float(a);
+}
+
+/**
  * @brief Return a float value as an integer bit pattern (i.e. no conversion).
  *
  * It is a common trick to convert floats into integer bit patterns, perform

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1071,6 +1071,27 @@ ASTCENC_SIMD_INLINE vfloat4 int_to_float(vint4 a)
 }
 
 /**
+ * @brief Return a float16 value for a float vector, using round-to-nearest.
+ */
+ASTCENC_SIMD_INLINE vint4 float_to_float16(vfloat4 a)
+{
+	__m128i packedf16 = _mm_cvtps_ph(a.m, _MM_FROUND_NO_EXC);
+	__m128i f16 = _mm_cvtepu16_epi32(packedf16);
+	return vint4(f16);
+}
+
+/**
+ * @brief Return a float value for a float16 vector.
+ */
+ASTCENC_SIMD_INLINE vfloat4 float16_to_float(vint4 a)
+{
+
+	__m128i packed = _mm_packs_epi32(a.m, a.m);
+	__m128 f32 = _mm_cvtph_ps(packed);
+	return vfloat4(f32);
+}
+
+/**
  * @brief Return a float value as an integer bit pattern (i.e. no conversion).
  *
  * It is a common trick to convert floats into integer bit patterns, perform
@@ -1104,5 +1125,7 @@ ASTCENC_SIMD_INLINE void print(vfloat4 a)
 	printf("v4_f32:\n  %0.4f %0.4f %0.4f %0.4f\n",
 	       (double)v[0], (double)v[1], (double)v[2], (double)v[3]);
 }
+
+
 
 #endif // #ifndef ASTC_VECMATHLIB_SSE_4_H_INCLUDED

--- a/Source/astcenccli_error_metrics.cpp
+++ b/Source/astcenccli_error_metrics.cpp
@@ -168,59 +168,79 @@ void compute_error_metrics(
 				if (img1->data_type == ASTCENC_TYPE_U8)
 				{
 					uint8_t* data8 = static_cast<uint8_t*>(img1->data[z]);
+
 					color1 = vfloat4(
-					    data8[(4 * xsize1 * y) + (4 * x    )] * (1.0f / 255.0f),
-					    data8[(4 * xsize1 * y) + (4 * x + 1)] * (1.0f / 255.0f),
-					    data8[(4 * xsize1 * y) + (4 * x + 2)] * (1.0f / 255.0f),
-					    data8[(4 * xsize1 * y) + (4 * x + 3)] * (1.0f / 255.0f));
+					    data8[(4 * xsize1 * y) + (4 * x    )],
+					    data8[(4 * xsize1 * y) + (4 * x + 1)],
+					    data8[(4 * xsize1 * y) + (4 * x + 2)],
+					    data8[(4 * xsize1 * y) + (4 * x + 3)]);
+
+					color1 = color1 * (1.0f / 255.0f);
 				}
 				else if (img1->data_type == ASTCENC_TYPE_F16)
 				{
 					uint16_t* data16 = static_cast<uint16_t*>(img1->data[z]);
-					color1 = vfloat4(
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x    )])),
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x + 1)])),
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x + 2)])),
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize1 * y) + (4 * x + 3)])));
+
+					vint4 color1i = vint4(
+					    data16[(4 * xsize1 * y) + (4 * x    )],
+					    data16[(4 * xsize1 * y) + (4 * x + 1)],
+					    data16[(4 * xsize1 * y) + (4 * x + 2)],
+					    data16[(4 * xsize1 * y) + (4 * x + 3)]);
+
+					color1 = float16_to_float(color1i);
+					color1 = clamp(0, 65504.0f, color1);
 				}
 				else // if (img1->data_type == ASTCENC_TYPE_F32)
 				{
 					assert(img1->data_type == ASTCENC_TYPE_F32);
 					float* data32 = static_cast<float*>(img1->data[z]);
+
 					color1 = vfloat4(
-					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x    )]),
-					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x + 1)]),
-					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x + 2)]),
-					    astc::clamp64Kf(data32[(4 * xsize1 * y) + (4 * x + 3)]));
+					    data32[(4 * xsize1 * y) + (4 * x    )],
+					    data32[(4 * xsize1 * y) + (4 * x + 1)],
+					    data32[(4 * xsize1 * y) + (4 * x + 2)],
+					    data32[(4 * xsize1 * y) + (4 * x + 3)]);
+
+					color1 = clamp(0, 65504.0f, color1);
 				}
 
 				if (img2->data_type == ASTCENC_TYPE_U8)
 				{
 					uint8_t* data8 = static_cast<uint8_t*>(img2->data[z]);
+
 					color2 = vfloat4(
-					    data8[(4 * xsize2 * y) + (4 * x    )] * (1.0f / 255.0f),
-					    data8[(4 * xsize2 * y) + (4 * x + 1)] * (1.0f / 255.0f),
-					    data8[(4 * xsize2 * y) + (4 * x + 2)] * (1.0f / 255.0f),
-					    data8[(4 * xsize2 * y) + (4 * x + 3)] * (1.0f / 255.0f));
+					    data8[(4 * xsize2 * y) + (4 * x    )],
+					    data8[(4 * xsize2 * y) + (4 * x + 1)],
+					    data8[(4 * xsize2 * y) + (4 * x + 2)],
+					    data8[(4 * xsize2 * y) + (4 * x + 3)]);
+
+					color2 = color2 * (1.0f / 255.0f);
 				}
 				else if (img2->data_type == ASTCENC_TYPE_F16)
 				{
 					uint16_t* data16 = static_cast<uint16_t*>(img2->data[z]);
-					color2 = vfloat4(
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x    )])),
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x + 1)])),
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x + 2)])),
-					    astc::clamp64Kf(sf16_to_float(data16[(4 * xsize2 * y) + (4 * x + 3)])));
+
+					vint4 color2i = vint4(
+					    data16[(4 * xsize2 * y) + (4 * x    )],
+					    data16[(4 * xsize2 * y) + (4 * x + 1)],
+					    data16[(4 * xsize2 * y) + (4 * x + 2)],
+					    data16[(4 * xsize2 * y) + (4 * x + 3)]);
+
+					color2 = float16_to_float(color2i);
+					color2 = clamp(0, 65504.0f, color2);;
 				}
 				else // if (img2->data_type == ASTCENC_TYPE_F32)
 				{
 					assert(img2->data_type == ASTCENC_TYPE_F32);
-					float* data16 = static_cast<float*>(img2->data[z]);
-					color2 = vfloat4(
-					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x    )]),
-					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x + 1)]),
-					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x + 2)]),
-					    astc::clamp64Kf(data16[(4 * xsize2 * y) + (4 * x + 3)]));
+					float* data32 = static_cast<float*>(img2->data[z]);
+
+					color1 = vfloat4(
+					    data32[(4 * xsize2 * y) + (4 * x    )],
+					    data32[(4 * xsize2 * y) + (4 * x + 1)],
+					    data32[(4 * xsize2 * y) + (4 * x + 2)],
+					    data32[(4 * xsize2 * y) + (4 * x + 3)]);
+
+					color2 = clamp(0, 65504.0f, color2);
 				}
 
 				rgb_peak = astc::max(color1.lane<0>(), color1.lane<1>(), color1.lane<2>(), rgb_peak);

--- a/Source/astcenccli_image.cpp
+++ b/Source/astcenccli_image.cpp
@@ -203,10 +203,17 @@ astcenc_image* astc_img_from_floatx4_array(
 
 		for (unsigned int x = 0; x < dim_x; x++)
 		{
-			data16[(4 * dim_x * y) + (4 * x    )] = float_to_sf16(src[4 * x    ], SF_NEARESTEVEN);
-			data16[(4 * dim_x * y) + (4 * x + 1)] = float_to_sf16(src[4 * x + 1], SF_NEARESTEVEN);
-			data16[(4 * dim_x * y) + (4 * x + 2)] = float_to_sf16(src[4 * x + 2], SF_NEARESTEVEN);
-			data16[(4 * dim_x * y) + (4 * x + 3)] = float_to_sf16(src[4 * x + 3], SF_NEARESTEVEN);
+			vint4 colorf16 = float_to_float16(vfloat4(
+				src[4 * x    ],
+				src[4 * x + 1],
+				src[4 * x + 2],
+				src[4 * x + 3]
+			));
+
+			data16[(4 * dim_x * y) + (4 * x    )] = (uint16_t)colorf16.lane<0>();
+			data16[(4 * dim_x * y) + (4 * x + 1)] = (uint16_t)colorf16.lane<1>();
+			data16[(4 * dim_x * y) + (4 * x + 2)] = (uint16_t)colorf16.lane<2>();
+			data16[(4 * dim_x * y) + (4 * x + 3)] = (uint16_t)colorf16.lane<3>();
 		}
 #endif
 	}

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -217,8 +217,8 @@ static void copy_scanline(
 ) {
 
 #define id(x) (x)
-#define u16_sf16(x) float_to_sf16(x * (1.0f/65535.0f), SF_NEARESTEVEN)
-#define f32_sf16(x) sf32_to_sf16(x, SF_NEARESTEVEN)
+#define u16_sf16(x) float_to_float16(x * (1.0f/65535.0f))
+#define f32_sf16(x) float16_to_float(x)
 
 #define COPY_R(dsttype, srctype, convfunc, oneval) \
 	do { \

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -154,7 +154,8 @@ if(${ISA_SIMD} MATCHES "none")
             ASTCENC_NEON=0
             ASTCENC_SSE=0
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=0)
+            ASTCENC_POPCNT=0
+            ASTCENC_F16C=0)
 
 elseif(${ISA_SIMD} MATCHES "neon")
     target_compile_definitions(astc${CODEC}-${ISA_SIMD}
@@ -162,7 +163,8 @@ elseif(${ISA_SIMD} MATCHES "neon")
             ASTCENC_NEON=1
             ASTCENC_SSE=0
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=0)
+            ASTCENC_POPCNT=0
+            ASTCENC_F16C=0)
 
 elseif(${ISA_SIMD} MATCHES "sse2")
     target_compile_definitions(astc${CODEC}-${ISA_SIMD}
@@ -170,7 +172,8 @@ elseif(${ISA_SIMD} MATCHES "sse2")
             ASTCENC_NEON=0
             ASTCENC_SSE=20
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=0)
+            ASTCENC_POPCNT=0
+            ASTCENC_F16C=0)
 
 elseif(${ISA_SIMD} MATCHES "sse4.1")
     target_compile_definitions(astc${CODEC}-${ISA_SIMD}
@@ -178,7 +181,8 @@ elseif(${ISA_SIMD} MATCHES "sse4.1")
             ASTCENC_NEON=0
             ASTCENC_SSE=41
             ASTCENC_AVX=0
-            ASTCENC_POPCNT=1)
+            ASTCENC_POPCNT=1
+            ASTCENC_F16C=0)
 
     target_compile_options(astc${CODEC}-${ISA_SIMD}
         PRIVATE
@@ -190,11 +194,12 @@ elseif(${ISA_SIMD} MATCHES "avx2")
             ASTCENC_NEON=0
             ASTCENC_SSE=41
             ASTCENC_AVX=2
-            ASTCENC_POPCNT=1)
+            ASTCENC_POPCNT=1
+            ASTCENC_F16C=1)
 
     target_compile_options(astc${CODEC}-${ISA_SIMD}
         PRIVATE
-            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mavx2 -mpopcnt>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mavx2 -mpopcnt -mf16c>
             $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>)
 endif()
 

--- a/Test/astc_minify_test.sh
+++ b/Test/astc_minify_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./astcenc/astcenc-avx2-good -tl in.png out-good.png 6x6 -medium
+
+./astcenc/astcenc-avx2 -tl in.png out-bad.png 6x6 -medium
+
+./astcenc/astc_test_autoextract 6x6 in.png out-good.png out-bad.png in-min.png


### PR DESCRIPTION
This PR implements the ability to convert floats stored in vfloat4 vectors to fp16 bit patterns stored in vint4 vectors. Scalar versions are also provided as overloaded functions of the same name, for sake of convenience. 

The code has been refactored to take advantage of the vectorization opportunities this gives, in particular using NEON (Arm) and F16C (x86-64) ISA support for float<>fp16 conversion. The F16C support is tied to the AVX2 enable config option, it is not a separate enable. In cases where the soft-float code is not needed, code size reduces by ~5KB.