### PR TITLE
Make public API C-only, and exportable

### DIFF
--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -144,6 +144,16 @@
 #include <cstddef>
 #include <cstdint>
 
+#if defined(ASTCENC_DYNAMIC_LIBRARY)
+	#if defined(_MSC_VER)
+		#define ASTCENC_PUBLIC extern "C" __declspec(dllexport)
+	#else
+		#define ASTCENC_PUBLIC extern "C" __attribute__ ((visibility ("default")))
+	#endif
+#else
+	#define ASTCENC_PUBLIC
+#endif
+
 /* ============================================================================
     Data declarations
 ============================================================================ */
@@ -548,14 +558,14 @@ struct astcenc_image {
  * @return ASTCENC_SUCCESS on success, or an error if the inputs are invalid
  * either individually, or in combination.
  */
-astcenc_error astcenc_config_init(
+ASTCENC_PUBLIC astcenc_error astcenc_config_init(
 	astcenc_profile profile,
 	unsigned int block_x,
 	unsigned int block_y,
 	unsigned int block_z,
 	float quality,
 	unsigned int flags,
-	astcenc_config& config);
+	astcenc_config* config);
 
 /**
  * @brief Allocate a new codec context based on a config.
@@ -578,8 +588,8 @@ astcenc_error astcenc_config_init(
  *
  * @return ASTCENC_SUCCESS on success, or an error if context creation failed.
  */
-astcenc_error astcenc_context_alloc(
-	const astcenc_config& config,
+ASTCENC_PUBLIC astcenc_error astcenc_context_alloc(
+	const astcenc_config* config,
 	unsigned int thread_count,
 	astcenc_context** context);
 
@@ -601,9 +611,9 @@ astcenc_error astcenc_context_alloc(
  *
  * @return ASTCENC_SUCCESS on success, or an error if compression failed.
  */
-astcenc_error astcenc_compress_image(
+ASTCENC_PUBLIC astcenc_error astcenc_compress_image(
 	astcenc_context* context,
-	astcenc_image& image,
+	astcenc_image* image,
 	astcenc_swizzle swizzle,
 	uint8_t* data_out,
 	size_t data_len,
@@ -621,7 +631,7 @@ astcenc_error astcenc_compress_image(
  *
  * @return ASTCENC_SUCCESS on success, or an error if reset failed.
  */
-astcenc_error astcenc_compress_reset(
+ASTCENC_PUBLIC astcenc_error astcenc_compress_reset(
 	astcenc_context* context);
 
 /**
@@ -635,11 +645,11 @@ astcenc_error astcenc_compress_reset(
  *
  * @return ASTCENC_SUCCESS on success, or an error if decompression failed.
  */
-astcenc_error astcenc_decompress_image(
+ASTCENC_PUBLIC astcenc_error astcenc_decompress_image(
 	astcenc_context* context,
 	const uint8_t* data,
 	size_t data_len,
-	astcenc_image& image_out,
+	astcenc_image* image_out,
 	astcenc_swizzle swizzle);
 
 /**
@@ -647,7 +657,7 @@ astcenc_error astcenc_decompress_image(
  *
  * @param context   The codec context.
  */
-void astcenc_context_free(
+ASTCENC_PUBLIC void astcenc_context_free(
 	astcenc_context* context);
 
 /**
@@ -657,7 +667,7 @@ void astcenc_context_free(
  *
  * @return A human readable nul-terminated string.
  */
-const char* astcenc_get_error_string(
+ASTCENC_PUBLIC const char* astcenc_get_error_string(
 	astcenc_error status);
 
 #endif

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -152,7 +152,7 @@ static void compression_workload_runner(
 
 	compression_workload* work = static_cast<compression_workload*>(payload);
 	astcenc_error error = astcenc_compress_image(
-	                       work->context, *work->image, work->swizzle,
+	                       work->context, work->image, work->swizzle,
 	                       work->data_out, work->data_len, thread_id);
 
 	// This is a racy update, so which error gets returned is a random, but it
@@ -527,7 +527,7 @@ static int init_astcenc_config(
 #endif
 
 	astcenc_error status = astcenc_config_init(profile, block_x, block_y, block_z,
-	                                           quality, flags, config);
+	                                           quality, flags, &config);
 	if (status == ASTCENC_ERR_BAD_BLOCK_SIZE)
 	{
 		printf("ERROR: Block size '%s' is invalid\n", argv[4]);
@@ -1388,7 +1388,7 @@ int main(
 	astcenc_error    codec_status;
 	astcenc_context* codec_context;
 
-	codec_status = astcenc_context_alloc(config, cli_config.thread_count, &codec_context);
+	codec_status = astcenc_context_alloc(&config, cli_config.thread_count, &codec_context);
 	if (codec_status != ASTCENC_SUCCESS)
 	{
 		printf("ERROR: Codec context alloc failed: %s\n", astcenc_get_error_string(codec_status));
@@ -1499,7 +1499,7 @@ int main(
 		else
 		{
 			work.error = astcenc_compress_image(
-			    work.context, *work.image, work.swizzle,
+			    work.context, work.image, work.swizzle,
 			    work.data_out, work.data_len, 0);
 		}
 
@@ -1534,7 +1534,7 @@ int main(
 		    out_bitness, image_comp.dim_x, image_comp.dim_y, image_comp.dim_z);
 
 		codec_status = astcenc_decompress_image(codec_context, image_comp.data, image_comp.data_len,
-		                                        *image_decomp_out, cli_config.swz_decode);
+		                                        image_decomp_out, cli_config.swz_decode);
 		if (codec_status != ASTCENC_SUCCESS)
 		{
 			printf("ERROR: Codec decompress failed: %s\n", astcenc_get_error_string(codec_status));


### PR DESCRIPTION
This PR makes two changes to allow a stable C API to exported from a dynamic library without name mangling. 

- Public API has been changed to be pure C (no references).  
- Public API entry points include support for API export annotation. 