### PR TITLE
Fixed uninitialized memory access

### DIFF
--- a/Source/astcenc_block_sizes2.cpp
+++ b/Source/astcenc_block_sizes2.cpp
@@ -802,6 +802,11 @@ static void construct_block_size_descriptor_2d(
 			bsd.block_modes[packed_idx].percentile_hit = true;
 			bsd.decimation_modes[decimation_mode].percentile_hit = true;
 		}
+		else
+		{
+			bsd.block_modes[packed_idx].percentile_always = false;
+			bsd.block_modes[packed_idx].percentile_hit = false;
+		}
 #endif
 
 		bsd.block_modes[packed_idx].decimation_mode = decimation_mode;


### PR DESCRIPTION
Check block_mode_packed_index before other block mode properties, since they are never set if the block mode is invalid.

This is the code in `construct_block_size_descriptor_2d()` that causes the memory to be uninitialized:

```
// Skip modes that are invalid, too large, or not selected by heuristic
if (!valid || !selected || (x_weights > x_dim) || (y_weights > y_dim))
{
	bsd.block_mode_packed_index[i] = -1;
	continue;
}
```