### PR TITLE
Remove aarch32|aarch32hf build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,19 @@ if(NOT ${ANY_ISA})
     message(FATAL_ERROR "At least one backend ISA must be enabled")
 endif()
 
+
+# Project configuration
+
+# Must be done after project() but before compiler settings
+# or it gets overriden (this contradicts the official docs)
+if(${ARCH} MATCHES "aarch64")
+    set(CMAKE_OSX_ARCHITECTURES "arm64")
+
+elseif(${ARCH} MATCHES "x86_64")
+    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ function(printopt optName optVal optArch tgtArch)
     endif()
 endfunction()
 
-set(VALID_ARCH aarch64 aarch32 aarch32hf x64)
+set(VALID_ARCH aarch64 x64)
 set(ARCH x64 CACHE STRING "Target architecture")
 set_property(CACHE ARCH PROPERTY STRINGS ${VALID_ARCH})
 
@@ -66,8 +66,8 @@ if(${ISA_SSE2} AND ${ARCH} MATCHES "x64")
 endif()
 
 option(ISA_NEON "Enable builds for NEON SIMD")
-printopt("NEON" ${ISA_NEON} "aarch32|aarch32hf|aarch64" ${ARCH})
-if(${ISA_NEON} AND ${ARCH} MATCHES "aarch32|aarch32hf|aarch64")
+printopt("NEON" ${ISA_NEON} "aarch64" ${ARCH})
+if(${ISA_NEON} AND ${ARCH} MATCHES "aarch64")
     set(ANY_ISA 1)
 endif()
 
@@ -116,45 +116,6 @@ endif()
 
 if(NOT ${ANY_ISA})
     message(FATAL_ERROR "At least one backend ISA must be enabled")
-endif()
-
-
-# Project configuration
-
-# Must be done after project() but before compiler settings
-# or it gets overriden (this contradicts the official docs)
-if(${ARCH} MATCHES "aarch64")
-    set(CMAKE_OSX_ARCHITECTURES "arm64")
-
-elseif(${ARCH} MATCHES "aarch32|aarch32hf")
-    # Deliberately use Armv7 for Clang - its most compatible with the current
-    # code; we provide some fallbacks for a few missing v8 intrinsics.
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-
-        set(CMAKE_OSX_ARCHITECTURES "armv7")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv7-a")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon-vfpv4")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
-        set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-
-    # For GCC we directly target Armv8-A A32, and provide some emulated
-    # fallback intrinsics for functionality that exists for A64 but not A32.
-    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon-fp-armv8")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfp16-format=ieee")
-
-        if(${ARCH} STREQUAL "aarch32")  # arm-linux-gnueabi-g++
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=softfp")
-        elseif(${ARCH} STREQUAL "aarch32hf")  # arm-linux-gnueabihf-g++
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=hard")
-        endif()
-
-        # Workaround for Source/tinyexr.h:11025
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-type-limits")
-    endif()
-else()
-    set(CMAKE_OSX_ARCHITECTURES "x86_64")
 endif()
 
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ if(${ARCH} MATCHES "aarch64")
 elseif(${ARCH} MATCHES "x86_64")
     set(CMAKE_OSX_ARCHITECTURES "x86_64")
 
+else()
+    message(FATAL_ERROR "Unsupported architecture")
+
 endif()
 
 set(CMAKE_CXX_STANDARD 14)

--- a/Docs/Building.md
+++ b/Docs/Building.md
@@ -120,29 +120,6 @@ To enable this binary variant add `-DISA_NONE=ON` to the CMake command line
 when configuring. It is NOT recommended to use this for production; it is
 significantly slower than the vectorized SIMD builds.
 
-### 32-bit Armv8 builds
-
-The build system includes support for building for Armv8 32-bit binaries on
-Linux, using GCC 9.3 or higher, or Clang 9 or higher. The `aarch32` build uses
-the soft-float ABI and `aarch32hf` uses the hard-float ABI.
-
-We tested these builds using the following cross-compilers on Ubuntu 20.04:
-
-* `aarch32`: arm-linux-gnueabi-g++-9 (v 9.3.0)
-* `aarch32hf`:  arm-linux-gnueabihf-g++-9 (v 9.3.0)
-
-```shell
-# Arm aarch32 using the soft-float ABI
-export CXX=arm-linux-gnueabi-g++-9
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./ \
-    -DARCH=aarch32 -DISA_NEON=ON ..
-
-# Arm aarch32 using the hard-float ABI
-export CXX=arm-linux-gnueabihf-g++-9
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./ \
-    -DARCH=aarch32hf -DISA_NEON=ON ..
-```
-
 ### Build Types
 
 We support and test the following `CMAKE_BUILD_TYPE` options.


### PR DESCRIPTION
To answer the [comment](https://github.com/ARM-software/astc-encoder/pull/266/files#r656484179) removing arm32 bit build support. This also removes setting CMAKE_OSX_ARCHITECTURES explicitely to not mess with universal builds.