### PR TITLE
Add install specific relative paths to target_include_directories

### DIFF
--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -54,7 +54,8 @@ add_library(${ASTC_TARGET}-static
 
 target_include_directories(${ASTC_TARGET}-static
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR})
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:.>)
 
 if(${CLI})
     add_executable(${ASTC_TARGET}


### PR DESCRIPTION
This PR adds relative paths to install_interface of astcenc library. Details of why this is required are [here](https://stackoverflow.com/questions/25676277/cmake-target-include-directories-prints-an-error-when-i-try-to-add-the-source)