### PR TITLE
Fixed an invalid assert when ASTCENC_DECOMPRESS_ONLY is used

### DIFF
--- a/Source/astcenc_block_sizes.cpp
+++ b/Source/astcenc_block_sizes.cpp
@@ -950,10 +950,10 @@ static void construct_block_size_descriptor_2d(
 	bsd.always_block_mode_count = always_block_mode_count;
 	bsd.always_decimation_mode_count = always_decimation_mode_count;
 
+#if !defined(ASTCENC_DECOMPRESS_ONLY)
 	assert(bsd.always_block_mode_count > 0);
 	assert(bsd.always_decimation_mode_count > 0);
 
-#if !defined(ASTCENC_DECOMPRESS_ONLY)
 	delete[] percentiles;
 #endif
 


### PR DESCRIPTION
It seems that these asserts would always fire with the ASTCENC_DECOMPRESS_ONLY flag.