### PR TITLE
QE-2641: Update Coverity client and licence

### DIFF
--- a/jenkins/build-image.sh
+++ b/jenkins/build-image.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-DOCKER_REGISTRY=mobile-studio--docker.eu-west-1.artifactory.aws.arm.com
+ARTIFACTORY_URL=eu-west-1.artifactory.aws.arm.com
+DOCKER_REGISTRY=mobile-studio--docker.${ARTIFACTORY_URL}
 IMAGE_NAME=astcenc
-IMAGE_VERSION=3.0.0
+IMAGE_VERSION=3.1.0
 
 # Check Artifactory credentials are set
 if [[ -z "${ARTIFACTORY_CREDENTIALS}" ]]
@@ -17,11 +18,8 @@ rm -fr tmp
 mkdir -p tmp
 
 echo "Get static analysis tools"
-curl --user ${ARTIFACTORY_CREDENTIALS} https://eu-west-1.artifactory.aws.arm.com/artifactory/mobile-studio.tools/coverity201909.tar.xz --output tmp/coverity.tar.xz
-pushd tmp
-  tar xf coverity.tar.xz
-  rm coverity.tar.xz
-popd
+curl --user ${ARTIFACTORY_CREDENTIALS} https://${ARTIFACTORY_URL}/artifactory/mobile-studio.tools/coverity/cov-analysis-linux64-2020.12.sh --output tmp/coverity_install.sh
+curl --user ${ARTIFACTORY_CREDENTIALS} https://${ARTIFACTORY_URL}/artifactory/mobile-studio.tools/coverity/license.dat --output tmp/coverity_license.dat
 
 echo "Building image"
 docker build -f jenkins/build.Dockerfile \

--- a/jenkins/build.Dockerfile
+++ b/jenkins/build.Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:18.04
 
 RUN useradd -u 1000 -U -m -c Jenkins jenkins
 
-RUN apt update && apt-get install -y \
+RUN apt update && apt -y upgrade \
+  && apt install -y \
     software-properties-common \
     clang \
     clang++-9 \
@@ -18,15 +19,18 @@ RUN apt update && apt-get install -y \
     python3-pil \
     ca-certificates \
     gnupg \
-    wget
+    wget \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install python modules
 RUN pip3 install requests
 
 # Install Coverity static analysis tools
-COPY cov-analysis-linux64-2019.09 /coverity/
-RUN chmod -R a+rw /coverity
-ENV PATH="/coverity/bin:$PATH"
+COPY coverity_* /tmp/
+RUN chmod 555 /tmp/coverity_install.sh && \
+  /tmp/coverity_install.sh -q --license.region=6 --license.agreement=agree --license.cov.path=/tmp/coverity_license.dat -dir /usr/local/cov-analysis && \
+  rm /tmp/coverity_*
+ENV PATH="/usr/local/cov-analysis/bin:$PATH"
 
 # Install up-to-date CMake, as standard Ubuntu 18.04 package is too old
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \

--- a/jenkins/nightly.Jenkinsfile
+++ b/jenkins/nightly.Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                     - name: artifactory-ms-docker
                   containers:
                     - name: astcenc
-                      image: mobile-studio--docker.eu-west-1.artifactory.aws.arm.com/astcenc:3.0.0
+                      image: mobile-studio--docker.eu-west-1.artifactory.aws.arm.com/astcenc:3.1.0
                       command:
                         - sleep
                       args:

--- a/jenkins/release.Jenkinsfile
+++ b/jenkins/release.Jenkinsfile
@@ -43,7 +43,7 @@ spec:
     - name: artifactory-ms-docker
   containers:
     - name: astcenc
-      image: mobile-studio--docker.eu-west-1.artifactory.aws.arm.com/astcenc:3.0.0
+      image: mobile-studio--docker.eu-west-1.artifactory.aws.arm.com/astcenc:3.1.0
       command:
         - sleep
       args:


### PR DESCRIPTION
Updates to Docker build image:
- Updated Coverity client and licence to match server.
- Added `apt upgrade` to ensure latest package versions in image