### PR TITLE
Propagate CMAKE_BUILD_TYPE in example project

### DIFF
--- a/Utils/Example/CMakeLists.txt
+++ b/Utils/Example/CMakeLists.txt
@@ -35,7 +35,7 @@ project(astcencoder_example VERSION 1.0.0)
 ExternalProject_Add(astcencoder
     GIT_REPOSITORY https://github.com/ARM-software/astc-encoder
     GIT_TAG main
-    CMAKE_CACHE_ARGS -DCLI:String=OFF -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+    CMAKE_CACHE_ARGS -DCLI:STRING=OFF -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     INSTALL_COMMAND "")
 
 ExternalProject_Get_property(astcencoder

--- a/Utils/Example/CMakeLists.txt
+++ b/Utils/Example/CMakeLists.txt
@@ -35,7 +35,7 @@ project(astcencoder_example VERSION 1.0.0)
 ExternalProject_Add(astcencoder
     GIT_REPOSITORY https://github.com/ARM-software/astc-encoder
     GIT_TAG main
-    CMAKE_CACHE_ARGS -DCLI:String=OFF
+    CMAKE_CACHE_ARGS -DCLI:String=OFF -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     INSTALL_COMMAND "")
 
 ExternalProject_Get_property(astcencoder


### PR DESCRIPTION
Getting errors when trying to build `Release` on `MSVC 19.29.30133.0`.

Then I found that in `CMakeCache.txt` of astcencoder-build, `CMAKE_BUILD_TYPE:STRING=Debug`.

This can be fixed by propagating `CMAKE_BUILD_TYPE`.

The error log I got,
```shell
====================[ Build | astcenc_example | Release ]=======================
"C:\Program Files\CMake\bin\cmake.exe" --build C:\Users\yelizhatijinesi\CLionProjects\astc-encoder\Utils\Example\cmake-build-release --target astcenc_example
[ 10%] Creating directories for 'astcencoder'
[ 20%] Performing download step (git clone) for 'astcencoder'
Cloning into 'astcencoder'...
Already on 'main'
Your branch is up to date with 'origin/main'.
Submodule 'Source/GoogleTest' (https://github.com/google/googletest.git) registered for path 'Source/GoogleTest'
Cloning into 'C:/Users/yelizhatijinesi/CLionProjects/astc-encoder/Utils/Example/cmake-build-release/astcencoder-prefix/src/astcencoder/Source/GoogleTest'...
Submodule path 'Source/GoogleTest': checked out '703bd9caab50b139428cea1aaff9974ebee5742e'
[ 30%] Performing update step for 'astcencoder'
HEAD is now at 58bfb28 Update README.md
[ 40%] No patch step for 'astcencoder'
[ 50%] Performing configure step for 'astcencoder'
CMake Warning (dev) at C:/Users/yelizhatijinesi/CLionProjects/astc-encoder/Utils/Example/cmake-build-release/astcencoder-prefix/tmp/astcencoder-cache-Release.cmake:2 (set):
implicitly converting 'String' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.

loading initial cache file C:/Users/yelizhatijinesi/CLionProjects/astc-encoder/Utils/Example/cmake-build-release/astcencoder-prefix/tmp/astcencoder-cache-Release.cmake
-- The C compiler identification is MSVC 19.29.30133.0
-- The CXX compiler identification is MSVC 19.29.30133.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: F:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: F:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
--   AVX2 backend    - OFF
--   SSE4.1 backend  - OFF
--   SSE2 backend    - OFF
--   NEON backend    - OFF
--   NONE backend    - OFF
--   NATIVE backend  -  ON
--   Decompressor    - OFF
--   Diagnostics     - OFF
--   Unit tests      - OFF
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/yelizhatijinesi/CLionProjects/astc-encoder/Utils/Example/cmake-build-release/astcencoder-prefix/src/astcencoder-build
[ 60%] Performing build step for 'astcencoder'

Microsoft (R) Program Maintenance Utility Version 14.30.30423.0
Copyright (C) Microsoft Corporation.  All rights reserved.

[  4%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_averages_and_directions.cpp.obj
astcenc_averages_and_directions.cpp
[  8%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_block_sizes.cpp.obj
astcenc_block_sizes.cpp
[ 12%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_color_quantize.cpp.obj
astcenc_color_quantize.cpp
[ 16%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_color_unquantize.cpp.obj
astcenc_color_unquantize.cpp
[ 20%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_compress_symbolic.cpp.obj
astcenc_compress_symbolic.cpp
[ 25%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_compute_variance.cpp.obj
astcenc_compute_variance.cpp
[ 29%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_decompress_symbolic.cpp.obj
astcenc_decompress_symbolic.cpp
[ 33%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_diagnostic_trace.cpp.obj
astcenc_diagnostic_trace.cpp
[ 37%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_entry.cpp.obj
astcenc_entry.cpp
[ 41%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_find_best_partitioning.cpp.obj
astcenc_find_best_partitioning.cpp
[ 45%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_ideal_endpoints_and_weights.cpp.obj
astcenc_ideal_endpoints_and_weights.cpp
[ 50%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_image.cpp.obj
astcenc_image.cpp
[ 54%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_integer_sequence.cpp.obj
astcenc_integer_sequence.cpp
[ 58%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_mathlib.cpp.obj
astcenc_mathlib.cpp
[ 62%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_mathlib_softfloat.cpp.obj
astcenc_mathlib_softfloat.cpp
[ 66%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_partition_tables.cpp.obj
astcenc_partition_tables.cpp
[ 70%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_percentile_tables.cpp.obj
astcenc_percentile_tables.cpp
[ 75%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_pick_best_endpoint_format.cpp.obj
astcenc_pick_best_endpoint_format.cpp
[ 79%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_platform_isa_detection.cpp.obj
astcenc_platform_isa_detection.cpp
[ 83%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_quantization.cpp.obj
astcenc_quantization.cpp
[ 87%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_symbolic_physical.cpp.obj
astcenc_symbolic_physical.cpp
[ 91%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_weight_align.cpp.obj
astcenc_weight_align.cpp
[ 95%] Building CXX object Source/CMakeFiles/astcenc-native-static.dir/astcenc_weight_quant_xfer_tables.cpp.obj
astcenc_weight_quant_xfer_tables.cpp
[100%] Linking CXX static library astcenc-native-static.lib
[100%] Built target astcenc-native-static
[ 70%] No install step for 'astcencoder'
[ 80%] Completed 'astcencoder'
[ 80%] Built target astcencoder
Scanning dependencies of target astcenc_example
[ 90%] Building CXX object CMakeFiles/astcenc_example.dir/astc_api_example.cpp.obj
astc_api_example.cpp
[100%] Linking CXX executable astcenc_example.exe
LINK: command "F:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\astcenc_example.dir\objects1.rsp /out:astcenc_example.exe /implib:astcenc_example.lib /pdb:C:\Users\yelizhatijinesi\CLionProjects\astc-encoder\Utils\Example\cmake-build-release\astcenc_example.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console -LIBPATH:C:\Users\yelizhatijinesi\CLionProjects\astc-encoder\Utils\Example\cmake-build-release\astcencoder-prefix\src\astcencoder-build\Source astcenc-native-static.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:astcenc_example.exe.manifest" failed (exit code 1120) with the following output:
LINK : warning LNK4098: defaultlib 'MSVCRTD' conflicts with use of other libs; use /NODEFAULTLIB:library
astcenc-native-static.lib(astcenc_entry.cpp.obj) : error LNK2019: unresolved external symbol __imp__invalid_parameter referenced in function "void * __cdecl std::_Allocate_manually_vector_aligned<struct std::_Default_allocate_traits>(unsigned __int64)" (??$_Allocate_manually_vector_aligned@U_Default_allocate_traits@std@@@std@@YAPEAX_K@Z)
astcenc-native-static.lib(astcenc_compute_variance.cpp.obj) : error LNK2001: unresolved external symbol __imp__invalid_parameter
astcenc-native-static.lib(astcenc_integer_sequence.cpp.obj) : error LNK2001: unresolved external symbol __imp__invalid_parameter
astcenc-native-static.lib(astcenc_entry.cpp.obj) : error LNK2019: unresolved external symbol __imp__CrtDbgReport referenced in function "void * __cdecl std::_Allocate_manually_vector_aligned<struct std::_Default_allocate_traits>(unsigned __int64)" (??$_Allocate_manually_vector_aligned@U_Default_allocate_traits@std@@@std@@YAPEAX_K@Z)
astcenc-native-static.lib(astcenc_compute_variance.cpp.obj) : error LNK2001: unresolved external symbol __imp__CrtDbgReport
astcenc-native-static.lib(astcenc_integer_sequence.cpp.obj) : error LNK2001: unresolved external symbol __imp__CrtDbgReport
astcenc_example.exe : fatal error LNK1120: 2 unresolved externals
NMAKE : fatal error U1077: '"C:\Program Files\CMake\bin\cmake.exe"' : return code '0xffffffff'
Stop.
NMAKE : fatal error U1077: '"F:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.30.30423\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"F:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.30.30423\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"F:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.30.30423\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.

```

