### PR TITLE
Add -repeat option to CLI to support performance testing

### DIFF
--- a/Source/astcenccli_internal.h
+++ b/Source/astcenccli_internal.h
@@ -68,6 +68,9 @@ struct cli_config_options
 	/** @brief The number of threads to use for processing. */
 	unsigned int thread_count;
 
+	/** @brief The number of repeats to execute for benchmarking. */
+	unsigned int repeat_count;
+
 	/** @brief The number of image slices to load for a 3D image. */
 	unsigned int array_size;
 

--- a/Test/astc_test_image.py
+++ b/Test/astc_test_image.py
@@ -269,7 +269,7 @@ def get_encoder_params(encoderName, referenceName, imageSet):
 
         # Latest main
         if version == "main":
-            encoder = te.Encoder2x(simd)
+            encoder = te.Encoder4x(simd)
             name = f"reference-{version}-{simd}"
             outDir = "Test/Images/%s" % imageSet
             refName = None
@@ -277,7 +277,7 @@ def get_encoder_params(encoderName, referenceName, imageSet):
 
         assert False, f"Encoder {encoderName} not recognized"
 
-    encoder = te.Encoder2x(encoderName)
+    encoder = te.Encoder4x(encoderName)
     name = "develop-%s" % encoderName
     outDir = "TestOutput/%s" % imageSet
     refName = referenceName.replace("ref", "reference")

--- a/Test/testlib/encoder.py
+++ b/Test/testlib/encoder.py
@@ -46,6 +46,7 @@ class EncoderBase():
     VERSION = None
     SWITCHES = None
     OUTPUTS = None
+    HAS_REPEATS = False
 
     def __init__(self, name, variant, binary):
         """
@@ -210,6 +211,12 @@ class EncoderBase():
         # pylint: disable=assignment-from-no-return
         command = self.build_cli(image, blockSize, preset, keepOutput, threads)
 
+        # Inline repeats if the compressor supports it
+        if self.HAS_REPEATS:
+            command.append("-repeats")
+            command.append(f"{testRuns}")
+            testRuns = 1
+
         # Execute test runs
         bestPSNR = 0
         bestTTime = sys.float_info.max
@@ -232,7 +239,6 @@ class EncoderBase():
 class Encoder2x(EncoderBase):
     """
     This class wraps the latest `astcenc` 2.x series binaries from main branch.
-    branch.
     """
     VERSION = "main"
 
@@ -323,6 +329,30 @@ class Encoder2xRel(Encoder2x):
     """
     This class wraps a released 2.x series binary.
     """
+    def __init__(self, version, variant):
+
+        self.VERSION = version
+
+        if os.name == 'nt':
+            binary = f"./Binaries/{version}/astcenc-{variant}.exe"
+        else:
+            binary = f"./Binaries/{version}/astcenc-{variant}"
+
+        super().__init__(variant, binary)
+
+
+class Encoder4x(Encoder2x):
+    """
+    This class wraps the latest `astcenc` 4.x series binaries from main branch.
+    """
+    HAS_REPEATS = True
+
+
+class Encoder4xRel(Encoder4x):
+    """
+    This class wraps a released 4.x series binary.
+    """
+
     def __init__(self, version, variant):
 
         self.VERSION = version


### PR DESCRIPTION
This change moves benchmarking repeat iterations inside the command line tool, rather than implementing it in the Python test framework. This allows us to just loop the codec rather than the whole process, which improves result stability and significantly improves performance test throughput because we don't spend so much time handling file reading. 

For example, with this change our full test sweep for AVX2 with 5 repeats drops from 45 to 24 minutes.

This does change the reported performance as the loop is around just the core codec rather than the whole program, keeping the codec in caches and branch history. We're going to accept this a one-off discontinuity, and for the the most important results where codec runtime is more critical (`-medium` and `-thorough`) there is no significant change.

This change also make one other change to the benchmark which is to separate out compression and decompression reporting. For competitive analysis other compressors only report coding performance, so by bundling the two we look worse than we really are. 