### PR TITLE
Vectorize block load and store

### DIFF
--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1944,7 +1944,6 @@ TEST(vint4, interleave_rgba8)
 	EXPECT_EQ(result.lane<3>(), 0x34333231);
 }
 
-
 # if ASTCENC_SIMD_WIDTH == 8
 
 // VFLOAT8 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3028,6 +3027,42 @@ TEST(vint8, max)
 	EXPECT_EQ(r.lane<5>(), 3);
 	EXPECT_EQ(r.lane<6>(), 3);
 	EXPECT_EQ(r.lane<7>(), 5);
+}
+
+/** @brief Test vint8 lsl. */
+TEST(vint8, lsl)
+{
+	vint8 a(1, 2, 4, -4, 1, 2, 4, -4);
+	a = lsl<0>(a);
+	EXPECT_EQ(a.lane<0>(), 1);
+	EXPECT_EQ(a.lane<1>(), 2);
+	EXPECT_EQ(a.lane<2>(), 4);
+	EXPECT_EQ(a.lane<3>(), 0xFFFFFFFC);
+	EXPECT_EQ(a.lane<4>(), 1);
+	EXPECT_EQ(a.lane<5>(), 2);
+	EXPECT_EQ(a.lane<6>(), 4);
+	EXPECT_EQ(a.lane<7>(), 0xFFFFFFFC);
+
+
+	a = lsl<1>(a);
+	EXPECT_EQ(a.lane<0>(), 2);
+	EXPECT_EQ(a.lane<1>(), 4);
+	EXPECT_EQ(a.lane<2>(), 8);
+	EXPECT_EQ(a.lane<3>(), 0xFFFFFFF8);
+	EXPECT_EQ(a.lane<4>(), 2);
+	EXPECT_EQ(a.lane<5>(), 4);
+	EXPECT_EQ(a.lane<6>(), 8);
+	EXPECT_EQ(a.lane<7>(), 0xFFFFFFF8);
+
+	a = lsl<2>(a);
+	EXPECT_EQ(a.lane<0>(), 8);
+	EXPECT_EQ(a.lane<1>(), 16);
+	EXPECT_EQ(a.lane<2>(), 32);
+	EXPECT_EQ(a.lane<3>(), 0xFFFFFFE0);
+	EXPECT_EQ(a.lane<4>(), 8);
+	EXPECT_EQ(a.lane<5>(), 16);
+	EXPECT_EQ(a.lane<6>(), 32);
+	EXPECT_EQ(a.lane<7>(), 0xFFFFFFE0);
 }
 
 /** @brief Test vint8 lsr. */

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1753,6 +1753,72 @@ TEST(vint4, store_nbytes)
 	EXPECT_EQ(out, 42);
 }
 
+/** @brief Test vint8 store_lanes_masked. */
+TEST(vint4, store_lanes_masked)
+{
+	int resulta[4] { 0 };
+
+	// Store nothing
+	vmask4 mask1 = vint4(0) == vint4(1);
+	vint4 data1 = vint4(1);
+
+	store_lanes_masked(resulta, data1, mask1);
+	vint4 result1v(resulta);
+	vint4 expect1v = vint4::zero();
+	EXPECT_TRUE(all(result1v == expect1v));
+
+	// Store half
+	vmask4 mask2 = vint4(1, 1, 0, 0) == vint4(1);
+	vint4 data2 = vint4(2);
+
+	store_lanes_masked(resulta, data2, mask2);
+	vint4 result2v(resulta);
+	vint4 expect2v = vint4(2, 2, 0, 0);
+	EXPECT_TRUE(all(result2v == expect2v));
+
+	// Store all
+	vmask4 mask3 = vint4(1) == vint4(1);
+	vint4 data3 = vint4(3);
+
+	store_lanes_masked(resulta, data3, mask3);
+	vint4 result3v(resulta);
+	vint4 expect3v = vint4(3);
+	EXPECT_TRUE(all(result3v == expect3v));
+}
+
+/** @brief Test vint8 store_lanes_masked to unaligned address. */
+TEST(vint4, store_lanes_masked_unaligned)
+{
+	int8_t resulta[17] { 0 };
+
+	// Store nothing
+	vmask4 mask1 = vint4(0) == vint4(1);
+	vint4 data1 = vint4(1);
+
+	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data1, mask1);
+	vint4 result1v(reinterpret_cast<int*>(resulta + 1));
+	vint4 expect1v = vint4::zero();
+	EXPECT_TRUE(all(result1v == expect1v));
+
+	// Store half
+	vmask4 mask2 = vint4(1, 1, 0, 0) == vint4(1);
+	vint4 data2 = vint4(2);
+
+	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data2, mask2);
+	vint4 result2v(reinterpret_cast<int*>(resulta + 1));
+	vint4 expect2v = vint4(2, 2, 0, 0);
+	EXPECT_TRUE(all(result2v == expect2v));
+
+	// Store all
+	vmask4 mask3 = vint4(1) == vint4(1);
+	vint4 data3 = vint4(3);
+
+	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data3, mask3);
+	vint4 result3v(reinterpret_cast<int*>(resulta + 1));
+	vint4 expect3v = vint4(3);
+	EXPECT_TRUE(all(result3v == expect3v));
+}
+
 /** @brief Test vint4 gatheri. */
 TEST(vint4, gatheri)
 {
@@ -3229,6 +3295,72 @@ TEST(vint8, store_nbytes)
 	store_nbytes(a, (uint8_t*)&out);
 	EXPECT_EQ(out[0], 42);
 	EXPECT_EQ(out[1], 314);
+}
+
+/** @brief Test vint8 store_lanes_masked. */
+TEST(vint8, store_lanes_masked)
+{
+	int resulta[8] { 0 };
+
+	// Store nothing
+	vmask8 mask1 = vint8(0) == vint8(1);
+	vint8 data1 = vint8(1);
+
+	store_lanes_masked(resulta, data1, mask1);
+	vint8 result1v(resulta);
+	vint8 expect1v = vint8::zero();
+	EXPECT_TRUE(all(result1v == expect1v));
+
+	// Store half
+	vmask8 mask2 = vint8(1, 1, 1, 1, 0, 0, 0, 0) == vint8(1);
+	vint8 data2 = vint8(2);
+
+	store_lanes_masked(resulta, data2, mask2);
+	vint8 result2v(resulta);
+	vint8 expect2v = vint8(2, 2, 2, 2, 0, 0, 0, 0);
+	EXPECT_TRUE(all(result2v == expect2v));
+
+	// Store all
+	vmask8 mask3 = vint8(1) == vint8(1);
+	vint8 data3 = vint8(3);
+
+	store_lanes_masked(resulta, data3, mask3);
+	vint8 result3v(resulta);
+	vint8 expect3v = vint8(3);
+	EXPECT_TRUE(all(result3v == expect3v));
+}
+
+/** @brief Test vint8 store_lanes_masked to unaligned address. */
+TEST(vint8, store_lanes_masked_unaligned)
+{
+	int8_t resulta[33] { 0 };
+
+	// Store nothing
+	vmask8 mask1 = vint8(0) == vint8(1);
+	vint8 data1 = vint8(1);
+
+	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data1, mask1);
+	vint8 result1v(reinterpret_cast<int*>(resulta + 1));
+	vint8 expect1v = vint8::zero();
+	EXPECT_TRUE(all(result1v == expect1v));
+
+	// Store half
+	vmask8 mask2 = vint8(1, 1, 1, 1, 0, 0, 0, 0) == vint8(1);
+	vint8 data2 = vint8(2);
+
+	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data2, mask2);
+	vint8 result2v(reinterpret_cast<int*>(resulta + 1));
+	vint8 expect2v = vint8(2, 2, 2, 2, 0, 0, 0, 0);
+	EXPECT_TRUE(all(result2v == expect2v));
+
+	// Store all
+	vmask8 mask3 = vint8(1) == vint8(1);
+	vint8 data3 = vint8(3);
+
+	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data3, mask3);
+	vint8 result3v(reinterpret_cast<int*>(resulta + 1));
+	vint8 expect3v = vint8(3);
+	EXPECT_TRUE(all(result3v == expect3v));
 }
 
 /** @brief Test vint8 gatheri. */

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1928,6 +1928,23 @@ TEST(vint4, vtable_8bt_32bi_64entry)
 	EXPECT_EQ(result.lane<3>(), 60);
 }
 
+/** @brief Test vint4 rgba byte interleave. */
+TEST(vint4, interleave_rgba8)
+{
+	vint4 r(0x01, 0x11, 0x21, 0x31);
+	vint4 g(0x02, 0x12, 0x22, 0x32);
+	vint4 b(0x03, 0x13, 0x23, 0x33);
+	vint4 a(0x04, 0x14, 0x24, 0x34);
+
+	vint4 result = interleave_rgba8(r, g, b, a);
+
+	EXPECT_EQ(result.lane<0>(), 0x04030201);
+	EXPECT_EQ(result.lane<1>(), 0x14131211);
+	EXPECT_EQ(result.lane<2>(), 0x24232221);
+	EXPECT_EQ(result.lane<3>(), 0x34333231);
+}
+
+
 # if ASTCENC_SIMD_WIDTH == 8
 
 // VFLOAT8 tests - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/Source/astcenc_image.cpp
+++ b/Source/astcenc_image.cpp
@@ -357,10 +357,6 @@ void store_image_block(
 	unsigned int z_start = zpos;
 	unsigned int z_end = astc::min(z_size, zpos + bsd.zdim);
 
-	float data[7];
-	data[ASTCENC_SWZ_0] = 0.0f;
-	data[ASTCENC_SWZ_1] = 1.0f;
-
 	// True if any non-identity swizzle
 	bool needs_swz = (swz.r != ASTCENC_SWZ_R) || (swz.g != ASTCENC_SWZ_G) ||
 	                 (swz.b != ASTCENC_SWZ_B) || (swz.a != ASTCENC_SWZ_A);
@@ -381,47 +377,66 @@ void store_image_block(
 			{
 				uint8_t* data8_row = data8 + (4 * x_size * y) + (4 * x_start);
 
-				for (unsigned int x = 0; x < x_count; x++)
+				for (unsigned int x = 0; x < x_count; x += ASTCENC_SIMD_WIDTH)
 				{
-					vint4 colori;
+					unsigned int max_texels = ASTCENC_SIMD_WIDTH;
+					unsigned int used_texels = astc::min(x_count - x, max_texels);
 
-					// Errors are NaN encoded - convert to magenta error color
-					if (blk.data_r[idx] != blk.data_r[idx])
+					// Unaligned load as rows are not always SIMD_WIDTH long
+					vfloat data_r(blk.data_r + idx);
+					vfloat data_g(blk.data_g + idx);
+					vfloat data_b(blk.data_b + idx);
+					vfloat data_a(blk.data_a + idx);
+
+					vint data_ri = float_to_int_rtn(min(data_r, 1.0f) * 255.0f);
+					vint data_gi = float_to_int_rtn(min(data_g, 1.0f) * 255.0f);
+					vint data_bi = float_to_int_rtn(min(data_b, 1.0f) * 255.0f);
+					vint data_ai = float_to_int_rtn(min(data_a, 1.0f) * 255.0f);
+
+					if (needs_swz)
 					{
-						colori = vint4(0xFF, 0x00, 0xFF, 0xFF);
-					}
-					else if (needs_swz)
-					{
-						data[ASTCENC_SWZ_R] = blk.data_r[idx];
-						data[ASTCENC_SWZ_G] = blk.data_g[idx];
-						data[ASTCENC_SWZ_B] = blk.data_b[idx];
-						data[ASTCENC_SWZ_A] = blk.data_a[idx];
+						vint swizzle_table[7];
+						swizzle_table[ASTCENC_SWZ_0] = vint(0);
+						swizzle_table[ASTCENC_SWZ_1] = vint(255);
+						swizzle_table[ASTCENC_SWZ_R] = data_ri;
+						swizzle_table[ASTCENC_SWZ_G] = data_gi;
+						swizzle_table[ASTCENC_SWZ_B] = data_bi;
+						swizzle_table[ASTCENC_SWZ_A] = data_ai;
 
 						if (needs_z)
 						{
-							float xcoord = (data[0] * 2.0f) - 1.0f;
-							float ycoord = (data[3] * 2.0f) - 1.0f;
-							float zcoord = 1.0f - xcoord * xcoord - ycoord * ycoord;
-							if (zcoord < 0.0f)
-							{
-								zcoord = 0.0f;
-							}
-							data[ASTCENC_SWZ_Z] = (astc::sqrt(zcoord) * 0.5f) + 0.5f;
+							vfloat data_x = (data_r * vfloat(2.0f)) - vfloat(1.0f);
+							vfloat data_y = (data_a * vfloat(2.0f)) - vfloat(1.0f);
+							vfloat data_z = vfloat(1.0f) - (data_x * data_x) - (data_y * data_y);
+							data_z = max(data_z, 0.0f);
+							data_z = (sqrt(data_z) * vfloat(0.5f)) + vfloat(0.5f);
+
+							swizzle_table[ASTCENC_SWZ_Z] = float_to_int_rtn(min(data_z, 1.0f) * 255.0f);
 						}
 
-						vfloat4 color = vfloat4(data[swz.r], data[swz.g], data[swz.b], data[swz.a]);
-						colori = float_to_int_rtn(min(color, 1.0f) * 255.0f);
-					}
-					else
-					{
-						vfloat4 color = blk.texel(idx);
-						colori = float_to_int_rtn(min(color, 1.0f) * 255.0f);
+						data_ri = swizzle_table[swz.r];
+						data_gi = swizzle_table[swz.g];
+						data_bi = swizzle_table[swz.b];
+						data_ai = swizzle_table[swz.a];
 					}
 
-					colori = pack_low_bytes(colori);
-					store_nbytes(colori, data8_row);
-					data8_row += 4;
-					idx++;
+					// Errors are NaN encoded - convert to magenta error color
+					// Branch is OK here - it is almost never true so predicts well
+					vmask nan_mask = data_r != data_r;
+					if (any(nan_mask))
+					{
+						data_ri = select(data_ri, vint(0xFF), nan_mask);
+						data_gi = select(data_gi, vint(0x00), nan_mask);
+						data_bi = select(data_bi, vint(0xFF), nan_mask);
+						data_ai = select(data_ai, vint(0xFF), nan_mask);
+					}
+
+					vint data_rgbai = interleave_rgba8(data_ri, data_gi, data_bi, data_ai);
+					vmask store_mask = vint::lane_id() < vint(used_texels);
+					store_bytes_masked((int*)data8_row, data_rgbai, store_mask);
+
+					data8_row += ASTCENC_SIMD_WIDTH * 4;
+					idx += used_texels;
 				}
 				idx += x_nudge;
 			}
@@ -446,6 +461,9 @@ void store_image_block(
 					// NaNs are handled inline - no need to special case
 					if (needs_swz)
 					{
+						float data[7];
+						data[ASTCENC_SWZ_0] = 0.0f;
+						data[ASTCENC_SWZ_1] = 1.0f;
 						data[ASTCENC_SWZ_R] = blk.data_r[idx];
 						data[ASTCENC_SWZ_G] = blk.data_g[idx];
 						data[ASTCENC_SWZ_B] = blk.data_b[idx];
@@ -505,6 +523,9 @@ void store_image_block(
 					// NaNs are handled inline - no need to special case
 					if (needs_swz)
 					{
+						float data[7];
+						data[ASTCENC_SWZ_0] = 0.0f;
+						data[ASTCENC_SWZ_1] = 1.0f;
 						data[ASTCENC_SWZ_R] = color.lane<0>();
 						data[ASTCENC_SWZ_G] = color.lane<1>();
 						data[ASTCENC_SWZ_B] = color.lane<2>();

--- a/Source/astcenc_image.cpp
+++ b/Source/astcenc_image.cpp
@@ -433,7 +433,7 @@ void store_image_block(
 
 					vint data_rgbai = interleave_rgba8(data_ri, data_gi, data_bi, data_ai);
 					vmask store_mask = vint::lane_id() < vint(used_texels);
-					store_bytes_masked((int*)data8_row, data_rgbai, store_mask);
+					store_lanes_masked((int*)data8_row, data_rgbai, store_mask);
 
 					data8_row += ASTCENC_SIMD_WIDTH * 4;
 					idx += used_texels;

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -465,6 +465,14 @@ ASTCENC_SIMD_INLINE vmask8 operator>(vint8 a, vint8 b)
 }
 
 /**
+ * @brief Logical shift left.
+ */
+template <int s> ASTCENC_SIMD_INLINE vint8 lsl(vint8 a)
+{
+	return vint8(_mm256_slli_epi32(a.m, s));
+}
+
+/**
  * @brief Arithmetic shift right.
  */
 template <int s> ASTCENC_SIMD_INLINE vint8 asr(vint8 a)
@@ -1135,11 +1143,7 @@ ASTCENC_SIMD_INLINE vint8 vtable_8bt_32bi(vint8 t0, vint8 t1, vint8 t2, vint8 t3
  */
 ASTCENC_SIMD_INLINE vint8 interleave_rgba8(vint8 r, vint8 g, vint8 b, vint8 a)
 {
-	__m256i value = r.m;
-	value = _mm256_add_epi32(value, _mm256_bslli_epi128(g.m, 1));
-	value = _mm256_add_epi32(value, _mm256_bslli_epi128(b.m, 2));
-	value = _mm256_add_epi32(value, _mm256_bslli_epi128(a.m, 3));
-	return vint8(value);
+	return r + lsl<8>(g) + lsl<16>(b) + lsl<24>(a);
 }
 
 /**

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -1151,7 +1151,7 @@ ASTCENC_SIMD_INLINE vint8 interleave_rgba8(vint8 r, vint8 g, vint8 b, vint8 a)
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint8 data, vmask8 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint8 data, vmask8 mask)
 {
 	_mm256_maskstore_epi32(base, mask.m, data.m);
 }

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -1144,6 +1144,8 @@ ASTCENC_SIMD_INLINE vint8 interleave_rgba8(vint8 r, vint8 g, vint8 b, vint8 a)
 
 /**
  * @brief Store a vector, skipping masked lanes.
+ *
+ * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
 ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint8 data, vmask8 mask)
 {

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -726,6 +726,16 @@ ASTCENC_SIMD_INLINE vfloat8 min(vfloat8 a, vfloat8 b)
 }
 
 /**
+ * @brief Return the min vector of a vector and a scalar.
+ *
+ * If either lane value is NaN, @c b will be returned for that lane.
+ */
+ASTCENC_SIMD_INLINE vfloat8 min(vfloat8 a, float b)
+{
+	return min(a, vfloat8(b));
+}
+
+/**
  * @brief Return the max vector of two vectors.
  *
  * If either lane value is NaN, @c b will be returned for that lane.
@@ -733,6 +743,16 @@ ASTCENC_SIMD_INLINE vfloat8 min(vfloat8 a, vfloat8 b)
 ASTCENC_SIMD_INLINE vfloat8 max(vfloat8 a, vfloat8 b)
 {
 	return vfloat8(_mm256_max_ps(a.m, b.m));
+}
+
+/**
+ * @brief Return the max vector of a vector and a scalar.
+ *
+ * If either lane value is NaN, @c b will be returned for that lane.
+ */
+ASTCENC_SIMD_INLINE vfloat8 max(vfloat8 a, float b)
+{
+	return max(a, vfloat8(b));
 }
 
 /**
@@ -967,6 +987,16 @@ ASTCENC_SIMD_INLINE vint8 float_to_int(vfloat8 a)
 }
 
 /**
+ * @brief Return a integer value for a float vector, using round-to-nearest.
+ */
+ASTCENC_SIMD_INLINE vint8 float_to_int_rtn(vfloat8 a)
+{
+	a = round(a);
+	return vint8(_mm256_cvttps_epi32(a.m));
+}
+
+
+/**
  * @brief Return a float value for an integer vector.
  */
 ASTCENC_SIMD_INLINE vfloat8 int_to_float(vint8 a)
@@ -1093,6 +1123,30 @@ ASTCENC_SIMD_INLINE vint8 vtable_8bt_32bi(vint8 t0, vint8 t1, vint8 t2, vint8 t3
 	result = _mm256_xor_si256(result, result2);
 
 	return vint8(result);
+
+/**
+ * @brief Return a vector of interleaved RGBA data.
+ *
+ * Input vectors have the value stored in the bottom 8 bits of each lane,
+ * with high  bits set to zero.
+ *
+ * Output vector stores a single RGBA texel packed in each lane.
+ */
+ASTCENC_SIMD_INLINE vint8 interleave_rgba8(vint8 r, vint8 g, vint8 b, vint8 a)
+{
+	__m256i value = r.m;
+	value = _mm256_add_epi32(value, _mm256_bslli_epi128(g.m, 1));
+	value = _mm256_add_epi32(value, _mm256_bslli_epi128(b.m, 2));
+	value = _mm256_add_epi32(value, _mm256_bslli_epi128(a.m, 3));
+	return vint8(value);
+}
+
+/**
+ * @brief Store a vector, skipping masked lanes.
+ */
+ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint8 data, vmask8 mask)
+{
+	_mm256_maskstore_epi32(base, mask.m, data.m);
 }
 
 /**

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -1123,6 +1123,7 @@ ASTCENC_SIMD_INLINE vint8 vtable_8bt_32bi(vint8 t0, vint8 t1, vint8 t2, vint8 t3
 	result = _mm256_xor_si256(result, result2);
 
 	return vint8(result);
+}
 
 /**
  * @brief Return a vector of interleaved RGBA data.

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -1015,7 +1015,7 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 {
 	if (mask.m[3])
 	{

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -1118,6 +1118,44 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 t2, vint4 t3
 	             table[idx.lane<1>()],
 	             table[idx.lane<2>()],
 	             table[idx.lane<3>()]);
+
+/**
+ * @brief Return a vector of interleaved RGBA data.
+ *
+ * Input vectors have the value stored in the bottom 8 bits of each lane,
+ * with high  bits set to zero.
+ *
+ * Output vector stores a single RGBA texel packed in each lane.
+ */
+ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
+{
+	return r + lsl<8>(g) + lsl<16>(b) + lsl<24>(a);
+}
+
+/**
+ * @brief Store a vector, skipping masked lanes.
+ */
+ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
+{
+	if (mask.m[0])
+	{
+		base[0] = data.lane<0>();
+	}
+
+	if (mask.m[1])
+	{
+		base[1] = data.lane<1>();
+	}
+
+	if (mask.m[2])
+	{
+		base[2] = data.lane<2>();
+	}
+
+	if (mask.m[3])
+	{
+		base[3] = data.lane<3>();
+	}
 }
 
 #endif // #ifndef ASTC_VECMATHLIB_NONE_4_H_INCLUDED

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -1137,7 +1137,7 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 {
 	if (mask.m[3])
 	{

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -1134,27 +1134,30 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
 
 /**
  * @brief Store a vector, skipping masked lanes.
+ *
+ * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
 ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
 {
-	if (mask.m[0])
-	{
-		base[0] = data.lane<0>();
-	}
-
-	if (mask.m[1])
-	{
-		base[1] = data.lane<1>();
-	}
-
-	if (mask.m[2])
-	{
-		base[2] = data.lane<2>();
-	}
-
 	if (mask.m[3])
 	{
-		base[3] = data.lane<3>();
+		store(data, base);
+	}
+	else if(mask.m[2])
+	{
+		base[0] = data.lane<0>();
+		base[1] = data.lane<1>();
+		base[2] = data.lane<2>();
+	}
+	else if(mask.m[1])
+	{
+		base[0] = data.lane<0>();
+		base[1] = data.lane<1>();
+	}
+	else if(mask.m[0])
+	{
+		base[0] = data.lane<0>();
+		base[1] = data.lane<1>();
 	}
 }
 

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1177,7 +1177,7 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 {
 #if ASTCENC_AVX >= 2
 	_mm_maskstore_epi32(base, mask.m, data.m);

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1174,6 +1174,8 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
 
 /**
  * @brief Store a vector, skipping masked lanes.
+ *
+ * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
 ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
 {

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1155,6 +1155,34 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 t2, vint4 t3
 #endif
 }
 
+/**
+ * @brief Return a vector of interleaved RGBA data.
+ *
+ * Input vectors have the value stored in the bottom 8 bits of each lane,
+ * with high  bits set to zero.
+ *
+ * Output vector stores a single RGBA texel packed in each lane.
+ */
+ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
+{
+	__m128i value = r.m;
+	value = _mm_add_epi32(value, _mm_bslli_si128(g.m, 1));
+	value = _mm_add_epi32(value, _mm_bslli_si128(b.m, 2));
+	value = _mm_add_epi32(value, _mm_bslli_si128(a.m, 3));
+	return vint4(value);
+}
+
+/**
+ * @brief Store a vector, skipping masked lanes.
+ */
+ASTCENC_SIMD_INLINE void store_bytes_masked(int* base, vint4 data, vmask4 mask)
+{
+#if ASTCENC_AVX >= 2
+	_mm_maskstore_epi32(base, mask.m, data.m);
+#else
+	_mm_maskmoveu_si128(data.m, mask.m, (char*)base);
+#endif
+}
 
 #if defined(ASTCENC_NO_INVARIANCE) && (ASTCENC_SSE >= 41)
 


### PR DESCRIPTION
The current code uses a per-texel load and store path. The load path isn't critical for performance (2% for `-cl -fastest`) but the store path is a significant percentage of the decompressor performance (24% for `-dl`).

### Design sketch

For `store_image_block()` we currently do a nested loop of:

```
foreach plane:
    foreach row:
        foreach column:
            convert texel
            store texel
```

This proposal looks at vectorizing the inner `foreach column` loop. Loosely:

* Load SIMD-sized blocks of texels for each color channel. 
    * We'll need to add padding to the block storage to avoid out-of-bounds fetch for last row in 6x6x6 blocks.
* Perform color conversion down to UNORM8 data. 
* Swizzle R,G,B,A into packed RGBA; this result should always fit into one SIMD-sized vector due to type reduction.
* Use masked stores to write necessary bytes.
    * Necessary will be `min(block size, free row storage)`.

To reduce control-plane overheads we could also specialize the store function to hoist some of the branchy logic in the inner loop out to a higher level (e.g. specialize based on color format, or need for swizzles).

### SIMD library improvements

Add new `interleave_rgba8(r, g, b, a)` function which takes 4 vectors of `vint` data with the color data in the least-significant 8 bits of each 32-bit lane. Returns an interleaved vector of packed rgba data. We can implement lane swizzles by changing the order of parameters passed in to this function.

Add new `interleave_rgba16(r, g, b, a)` function which takes 4 vectors of `vint` data with the color data in the least-significant 16 bits of each 32-bit lane. Returns two interleaved vectors of packed rgba data. We can implement lane swizzles by changing the order of parameters passed in to this function.

Add new `store_bytes_masked(base, vector, mask)` function which stores a whole SIMD `vector` of bytes to the `base` pointer, applying the byte mask specified in the `mask` parameter. Note x86 and SVE2 have native masked stores, but NEON doesn't so we'll need to emulate cases where the mask is not full (but this should be no worse than the current scalar code). 

### Status

First pass of the 8-bit implementation is complete for x86:

* AVX2 decompression gets faster by ~10%
* SSE2 and SSE4.1 decompression gets faster by ~3%