### PR TITLE
Fixing build failure on windows arm64

### DIFF
--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -204,7 +204,7 @@ struct vint4
 	{
 		uint32x2_t t8 {};
 		// Cast is safe - NEON loads are allowed to be unaligned
-		t8 = vld1_lane_u32((const uint32_t*)p, t8, 0);
+		t8 = vld1_lane_u32(reinterpret_cast<const uint32_t*>(p), t8, 0);
 		uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
 		m = vreinterpretq_s32_u32(vmovl_u16(t16));
 	}
@@ -590,7 +590,7 @@ ASTCENC_SIMD_INLINE void store(vint4 a, int* p)
  */
 ASTCENC_SIMD_INLINE void store_nbytes(vint4 a, uint8_t* p)
 {
-	vst1q_lane_s32((int32_t*)p, a.m, 0);
+	vst1q_lane_s32(reinterpret_cast<int32_t*>(p), a.m, 0);
 }
 
 /**
@@ -882,7 +882,7 @@ ASTCENC_SIMD_INLINE vint4 float_to_float16(vfloat4 a)
 static inline uint16_t float_to_float16(float a)
 {
 	vfloat4 av(a);
-	return (uint16_t)float_to_float16(av).lane<0>();
+	return static_cast<uint16_t>(float_to_float16(av).lane<0>());
 }
 
 /**

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -346,6 +346,16 @@ struct vmask4
 		m = vreinterpretq_u32_s32(ms);
 	}
 
+	ASTCENC_SIMD_INLINE uint32_t operator[] (int32_t i)
+	{
+		// Workaround for how msvc handles intrinsic types
+#if defined(_MSC_VER)
+		return m.n128_u32[i];
+#else
+		return m[i];
+#endif
+	}
+
 	/**
 	 * @brief The vector ...
 	 */
@@ -1017,22 +1027,22 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
  */
 ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 {
-	if (mask.m[3])
+	if (mask[3])
 	{
 		store(data, base);
 	}
-	else if(mask.m[2])
+	else if(mask[2])
 	{
 		base[0] = data.lane<0>();
 		base[1] = data.lane<1>();
 		base[2] = data.lane<2>();
 	}
-	else if(mask.m[1])
+	else if(mask[1])
 	{
 		base[0] = data.lane<0>();
 		base[1] = data.lane<1>();
 	}
-	else if(mask.m[0])
+	else if(mask[0])
 	{
 		base[0] = data.lane<0>();
 	}

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -346,14 +346,12 @@ struct vmask4
 		m = vreinterpretq_u32_s32(ms);
 	}
 
-	ASTCENC_SIMD_INLINE uint32_t operator[] (int32_t i)
+	/**
+	 * @brief Get the scalar from a single lane.
+	 */
+	template <int32_t l> ASTCENC_SIMD_INLINE uint32_t lane() const
 	{
-		// Workaround for how msvc handles intrinsic types
-#if defined(_MSC_VER)
-		return m.n128_u32[i];
-#else
-		return m[i];
-#endif
+		return vgetq_lane_s32(m, l);
 	}
 
 	/**
@@ -884,7 +882,7 @@ ASTCENC_SIMD_INLINE vint4 float_to_float16(vfloat4 a)
 static inline uint16_t float_to_float16(float a)
 {
 	vfloat4 av(a);
-	return float_to_float16(av).lane<0>();
+	return (uint16_t)float_to_float16(av).lane<0>();
 }
 
 /**
@@ -1027,22 +1025,22 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
  */
 ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 {
-	if (mask[3])
+	if (mask.lane<3>())
 	{
 		store(data, base);
 	}
-	else if(mask[2])
+	else if(mask.lane<2>())
 	{
 		base[0] = data.lane<0>();
 		base[1] = data.lane<1>();
 		base[2] = data.lane<2>();
 	}
-	else if(mask[1])
+	else if(mask.lane<1>())
 	{
 		base[0] = data.lane<0>();
 		base[1] = data.lane<1>();
 	}
-	else if(mask[0])
+	else if(mask.lane<0>())
 	{
 		base[0] = data.lane<0>();
 	}


### PR DESCRIPTION
As part of an ongoing saga in this PR: https://github.com/KhronosGroup/KTX-Software/pull/582

It turns out this project fails to build when targeting arm64 for windows. 

You can repro the failure yourself with:
* `cmake -B build-msvc-arm -G "Visual Studio 17 2022" -Aarm64 -DISA_NEON=ON`
* `cmake --build build-msvc-arm`

The issue comes down to how msvc handles NEON intrinsics. Since `uint32x4_t` is a union in msvc, I decided to override `operator[]` on vmask to reduce the footprint of the workaround.