### PR TITLE
Remove use of __mm_maskmoveu_si128

### DIFF
--- a/Docs/ChangeLog-4x.md
+++ b/Docs/ChangeLog-4x.md
@@ -18,6 +18,8 @@ The 4.1.0 release is a maintenance release.
     `GL_LUMINANCE` or `GL_LUMINANCE_ALPHA` format enums when writing KTX
     output files. Luminance textures now use the `GL_RED` format and
     luminance_alpha textures now use the `GL_RG` format.
+  * **Bug-fix:** Library decompressor builds for SSE no longer use masked store
+    `maskmovdqu` instructions, as they can generate faults on masked lanes.
   * **Bug-fix:** Command line decompressor now correctly uses sized type enums
     for the internal format when writing output KTX files.
   * **Bug-fix:** Command line compressor now correctly loads 32-bit per

--- a/Source/astcenc_pick_best_endpoint_format.cpp
+++ b/Source/astcenc_pick_best_endpoint_format.cpp
@@ -517,7 +517,7 @@ static void compute_color_error_for_every_integer_count_and_quant_level(
 			best_error[i][1] = ERROR_CALC_DEFAULT;
 			best_error[i][0] = ERROR_CALC_DEFAULT;
 
-			format_of_choice[i][3] = encode_hdr_alpha ? FMT_HDR_RGBA : FMT_HDR_RGB_LDR_ALPHA;
+			format_of_choice[i][3] = static_cast<uint8_t>(encode_hdr_alpha ? FMT_HDR_RGBA : FMT_HDR_RGB_LDR_ALPHA);
 			format_of_choice[i][2] = FMT_HDR_RGB;
 			format_of_choice[i][1] = FMT_HDR_RGB_SCALE;
 			format_of_choice[i][0] = FMT_HDR_LUMINANCE_LARGE_RANGE;
@@ -537,7 +537,7 @@ static void compute_color_error_for_every_integer_count_and_quant_level(
 
 			float full_hdr_rgba_error = rgba_quantization_error + rgb_range_error + alpha_range_error;
 			best_error[i][3] = full_hdr_rgba_error;
-			format_of_choice[i][3] = encode_hdr_alpha ? FMT_HDR_RGBA : FMT_HDR_RGB_LDR_ALPHA;
+			format_of_choice[i][3] = static_cast<uint8_t>(encode_hdr_alpha ? FMT_HDR_RGBA : FMT_HDR_RGB_LDR_ALPHA);
 
 			// For 6 integers, we have one HDR-RGB encoding
 			float full_hdr_rgb_error = (rgb_quantization_error * mode11mult) + rgb_range_error + eci.alpha_drop_error;

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -364,6 +364,14 @@ struct vmask4
 	}
 
 	/**
+	 * @brief Get the scalar value of a single lane.
+	 */
+	template <int l> ASTCENC_SIMD_INLINE float lane() const
+	{
+		return _mm_cvtss_f32(_mm_shuffle_ps(m, m, l));
+	}
+
+	/**
 	 * @brief The vector ...
 	 */
 	__m128 m;
@@ -1192,7 +1200,27 @@ ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 #if ASTCENC_AVX >= 2
 	_mm_maskstore_epi32(base, _mm_castps_si128(mask.m), data.m);
 #else
-	_mm_maskmoveu_si128(data.m, _mm_castps_si128(mask.m), reinterpret_cast<char*>(base));
+	// Note - we cannot use _mm_maskmoveu_si128 as the underlying hardware doesn't guarantee
+	// fault suppression on masked lanes so we can get page faults at the end of an image.
+	if (mask.lane<3>())
+	{
+		store(data, base);
+	}
+	else if(mask.lane<2>())
+	{
+		base[0] = data.lane<0>();
+		base[1] = data.lane<1>();
+		base[2] = data.lane<2>();
+	}
+	else if(mask.lane<1>())
+	{
+		base[0] = data.lane<0>();
+		base[1] = data.lane<1>();
+	}
+	else if(mask.lane<0>())
+	{
+		base[0] = data.lane<0>();
+	}
 #endif
 }
 

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1202,22 +1202,22 @@ ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 #else
 	// Note - we cannot use _mm_maskmoveu_si128 as the underlying hardware doesn't guarantee
 	// fault suppression on masked lanes so we can get page faults at the end of an image.
-	if (mask.lane<3>())
+	if (mask.lane<3>() != 0.0f)
 	{
 		store(data, base);
 	}
-	else if(mask.lane<2>())
+	else if(mask.lane<2>() != 0.0f)
 	{
 		base[0] = data.lane<0>();
 		base[1] = data.lane<1>();
 		base[2] = data.lane<2>();
 	}
-	else if(mask.lane<1>())
+	else if(mask.lane<1>() != 0.0f)
 	{
 		base[0] = data.lane<0>();
 		base[1] = data.lane<1>();
 	}
-	else if(mask.lane<0>())
+	else if(mask.lane<0>() != 0.0f)
 	{
 		base[0] = data.lane<0>();
 	}


### PR DESCRIPTION
SSE masked stores do not guarantee fault masking, so we can get errors if the final store in an image spans a page boundary even if the overspill lanes are correctly masked.
 
Fixes #370 