### PR TITLE
Fix build with GCC 11 onwards

### DIFF
--- a/Source/astcenc_find_best_partitioning.cpp
+++ b/Source/astcenc_find_best_partitioning.cpp
@@ -46,6 +46,7 @@
  * lines for endpoint selection.
  */
 
+#include <limits>
 #include "astcenc_internal.h"
 
 /**


### PR DESCRIPTION
GCC 11 [changed header dependencies](https://gcc.gnu.org/gcc-11/porting_to.html). It now requires to explicitly include the `<limits>` header for using `std::numeric_limits`.

Commit 30a6c68bc3 broke build with GCC 11 and GCC 12, since it removes some `#include` directives which satisfied the `<limits>` header with previous versions of GCC, giving the following error:

```
Source/astcenc_find_best_partitioning.cpp:160:44: error: ‘numeric_limits’ is not a member of ‘std’
```

This will fix build in Arch Linux, which currently uses GCC 12.