### PR TITLE
Remove partition validity sentinels

### DIFF
--- a/Source/astcenc_find_best_partitioning.cpp
+++ b/Source/astcenc_find_best_partitioning.cpp
@@ -367,24 +367,21 @@ static void count_partition_mismatch_bits(
 	{
 		for (unsigned int i = 0; i < active_count; i++)
 		{
-			int bitcount = partition_mismatch2(bitmaps, bsd.coverage_bitmaps_2[i]);
-			mismatch_counts[i] = astc::max(bitcount, static_cast<int>(bsd.partitioning_valid_2[i]));
+			mismatch_counts[i] = partition_mismatch2(bitmaps, bsd.coverage_bitmaps_2[i]);
 		}
 	}
 	else if (partition_count == 3)
 	{
 		for (unsigned int i = 0; i < active_count; i++)
 		{
-			int bitcount = partition_mismatch3(bitmaps, bsd.coverage_bitmaps_3[i]);
-			mismatch_counts[i] = astc::max(bitcount, static_cast<int>(bsd.partitioning_valid_3[i]));
+			mismatch_counts[i] = partition_mismatch3(bitmaps, bsd.coverage_bitmaps_3[i]);
 		}
 	}
 	else
 	{
 		for (unsigned int i = 0; i < active_count; i++)
 		{
-			int bitcount = partition_mismatch4(bitmaps, bsd.coverage_bitmaps_4[i]);
-			mismatch_counts[i] = astc::max(bitcount, static_cast<int>(bsd.partitioning_valid_4[i]));
+			mismatch_counts[i] = partition_mismatch4(bitmaps, bsd.coverage_bitmaps_4[i]);
 		}
 	}
 }

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -580,13 +580,6 @@ struct block_size_descriptor
 	uint8_t kmeans_texels[BLOCK_MAX_KMEANS_TEXELS];
 
 	/**
-	 * @brief Is 0 if this 2-partition is valid for compression 255 otherwise.
-	 *
-	 * Indexed by remapped index, not physical index.
-	 */
-	uint8_t partitioning_valid_2[BLOCK_MAX_PARTITIONINGS];
-
-	/**
 	 * @brief The canonical 2-partition coverage pattern used during block partition search.
 	 *
 	 * Indexed by remapped index, not physical index.
@@ -594,25 +587,11 @@ struct block_size_descriptor
 	uint64_t coverage_bitmaps_2[BLOCK_MAX_PARTITIONINGS][2];
 
 	/**
-	 * @brief Is 0 if this 3-partition is valid for compression 255 otherwise.
-	 *
-	 * Indexed by remapped index, not physical index.
-	 */
-	uint8_t partitioning_valid_3[BLOCK_MAX_PARTITIONINGS];
-
-	/**
 	 * @brief The canonical 3-partition coverage pattern used during block partition search.
 	 *
 	 * Indexed by remapped index, not physical index.
 	 */
 	uint64_t coverage_bitmaps_3[BLOCK_MAX_PARTITIONINGS][3];
-
-	/**
-	 * @brief Is 0 if this 4-partition is valid for compression 255 otherwise.
-	 *
-	 * Indexed by remapped index, not physical index.
-	 */
-	uint8_t partitioning_valid_4[BLOCK_MAX_PARTITIONINGS];
 
 	/**
 	 * @brief The canonical 4-partition coverage pattern used during block partition search.

--- a/Source/astcenc_partition_tables.cpp
+++ b/Source/astcenc_partition_tables.cpp
@@ -320,21 +320,17 @@ static bool generate_one_partition_info_entry(
 
 	// Populate the coverage bitmaps for 2/3/4 partitions
 	uint64_t* bitmaps { nullptr };
-	uint8_t* valids { nullptr };
 	if (partition_count == 2)
 	{
 		bitmaps = bsd.coverage_bitmaps_2[partition_remap_index];
-		valids = bsd.partitioning_valid_2;
 	}
 	else if (partition_count == 3)
 	{
 		bitmaps = bsd.coverage_bitmaps_3[partition_remap_index];
-		valids = bsd.partitioning_valid_3;
 	}
 	else if (partition_count == 4)
 	{
 		bitmaps = bsd.coverage_bitmaps_4[partition_remap_index];
-		valids = bsd.partitioning_valid_4;
 	}
 
 	for (unsigned int i = 0; i < BLOCK_MAX_PARTITIONS; i++)
@@ -347,9 +343,7 @@ static bool generate_one_partition_info_entry(
 
 	if (bitmaps)
 	{
-		// Populate the bitmap validity mask
-		valids[partition_remap_index] = valid ? 0 : 255;
-
+		// Populate the partition coverage bitmap
 		for (unsigned int i = 0; i < partition_count; i++)
 		{
 			bitmaps[i] = 0ULL;
@@ -374,12 +368,6 @@ static void build_partition_table_for_one_partition_count(
 	partition_info* ptab,
 	uint64_t* canonical_patterns
 ) {
-	uint8_t* partitioning_valid[3] {
-		bsd.partitioning_valid_2,
-		bsd.partitioning_valid_3,
-		bsd.partitioning_valid_4
-	};
-
 	unsigned int next_index = 0;
 	bsd.partitioning_count_selected[partition_count - 1] = 0;
 	bsd.partitioning_count_all[partition_count - 1] = 0;
@@ -442,7 +430,6 @@ static void build_partition_table_for_one_partition_count(
 				{
 					bsd.partitioning_packed_index[partition_count - 2][i] = static_cast<uint16_t>(next_index);
 					bsd.partitioning_count_all[partition_count - 1]++;
-					partitioning_valid[partition_count - 2][next_index] = 255;
 					next_index++;
 				}
 			}


### PR DESCRIPTION
Validity sentinels are no longer needed during partition selection because the valid partition tables are now stored reindexed and tightly packed, with the invalid ones following after. Partition search can therefore guarantee to only ever touch active partition table entries.