### PR TITLE
Add more extensive -exhaustive partition searches

### DIFF
--- a/Docs/ChangeLog-4x.md
+++ b/Docs/ChangeLog-4x.md
@@ -15,12 +15,28 @@ The 4.2.0 release is an optimization release. There are significant performance
 improvements and minor image quality changes in this release.
 
 * **General:**
+  * **Feature:** The `-exhaustive` mode now runs full trials on more
+    partitioning candidates and block candidates. This improves image quality
+    by 0.1 to 0.25 dB, but slows down compression by 3x. The `-verythorough`
+    and `-thorough` modes also test more candidates.
+  * **Feature:** A new preset, `-verythorough`, has been introduced to provide
+    a standard performance point between `-thorough` and the re-tuned
+    `-exhaustive` mode. This new mode is faster and higher quality than the
+    `-exhaustive` preset in the 4.1 release.
+  * **Feature:** The compressor can now independently vary the number of
+    partitionings considered for error estimation for 2/3/4 partitions. This
+    allows heuristics to put more effort into 2 partitions, and less in to
+    3/4 partitions.
+  * **Feature:** The compressor can now run trials on a variable number of
+    candidate partitionings, allowing high quality modes to explore more of the
+    search space at the expensive of slower compression. The number of trials
+    is independently configurable for 2/3/4 partition cases.
   * **Optimization:** Introduce early-out threshold for 2/3/4 partition
-    searches based on the results after 1 of 2 trials. This signficantly
+    searches based on the results after 1 of 2 trials. This significantly
     improves performance for `-medium` and `-thorough` searches, for a minor
     loss in image quality.
   * **Optimization:** Reduce early-out threshold for 3/4 partition searches
-    based on 2/3 partition results. This signficantly improves performance,
+    based on 2/3 partition results. This significantly improves performance,
     especially for `-thorough` searches, for a minor loss in image quality.
   * **Optimization:** Use direct vector compare to create a SIMD mask instead
     of a scalar compare that is broadcast to a vector mask.

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -241,6 +241,9 @@ static const float ASTCENC_PRE_MEDIUM = 60.0f;
 /** @brief The thorough quality search preset. */
 static const float ASTCENC_PRE_THOROUGH = 98.0f;
 
+/** @brief The thorough quality search preset. */
+static const float ASTCENC_PRE_VERYTHOROUGH = 99.0f;
+
 /** @brief The exhaustive, highest quality, search preset. */
 static const float ASTCENC_PRE_EXHAUSTIVE = 100.0f;
 
@@ -440,11 +443,25 @@ struct astcenc_config
 	unsigned int tune_partition_count_limit;
 
 	/**
-	 * @brief The maximum number of partitions searched (-partitionindexlimit).
+	 * @brief The maximum number of partitions searched (-2partitionindexlimit).
 	 *
 	 * Valid values are between 1 and 1024.
 	 */
-	unsigned int tune_partition_index_limit;
+	unsigned int tune_2partition_index_limit;
+
+	/**
+	 * @brief The maximum number of partitions searched (-3partitionindexlimit).
+	 *
+	 * Valid values are between 1 and 1024.
+	 */
+	unsigned int tune_3partition_index_limit;
+
+	/**
+	 * @brief The maximum number of partitions searched (-4partitionindexlimit).
+	 *
+	 * Valid values are between 1 and 1024.
+	 */
+	unsigned int tune_4partition_index_limit;
 
 	/**
 	 * @brief The maximum centile for block modes searched (-blockmodelimit).
@@ -469,11 +486,25 @@ struct astcenc_config
 	unsigned int tune_candidate_limit;
 
 	/**
-	 * @brief The number of trial partitionings per search (-partitioncandidatelimit).
+	 * @brief The number of trial partitionings per search (-2partitioncandidatelimit).
 	 *
 	 * Valid values are between 1 and 1024.
 	 */
-	unsigned int tune_partitioning_candidate_limit;
+	unsigned int tune_2partitioning_candidate_limit;
+
+	/**
+	 * @brief The number of trial partitionings per search (-3partitioncandidatelimit).
+	 *
+	 * Valid values are between 1 and 1024.
+	 */
+	unsigned int tune_3partitioning_candidate_limit;
+
+	/**
+	 * @brief The number of trial partitionings per search (-4partitioncandidatelimit).
+	 *
+	 * Valid values are between 1 and 1024.
+	 */
+	unsigned int tune_4partitioning_candidate_limit;
 
 	/**
 	 * @brief The dB threshold for stopping block search (-dblimit).

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -488,21 +488,21 @@ struct astcenc_config
 	/**
 	 * @brief The number of trial partitionings per search (-2partitioncandidatelimit).
 	 *
-	 * Valid values are between 1 and 1024.
+	 * Valid values are between 1 and TUNE_MAX_PARTITIIONING_CANDIDATES.
 	 */
 	unsigned int tune_2partitioning_candidate_limit;
 
 	/**
 	 * @brief The number of trial partitionings per search (-3partitioncandidatelimit).
 	 *
-	 * Valid values are between 1 and 1024.
+	 * Valid values are between 1 and TUNE_MAX_PARTITIIONING_CANDIDATES.
 	 */
 	unsigned int tune_3partitioning_candidate_limit;
 
 	/**
 	 * @brief The number of trial partitionings per search (-4partitioncandidatelimit).
 	 *
-	 * Valid values are between 1 and 1024.
+	 * Valid values are between 1 and TUNE_MAX_PARTITIIONING_CANDIDATES.
 	 */
 	unsigned int tune_4partitioning_candidate_limit;
 

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -469,6 +469,13 @@ struct astcenc_config
 	unsigned int tune_candidate_limit;
 
 	/**
+	 * @brief The number of trial partitionings per search (-partitioncandidatelimit).
+	 *
+	 * Valid values are between 1 and 1024.
+	 */
+	unsigned int tune_partitioning_candidate_limit;
+
+	/**
 	 * @brief The dB threshold for stopping block search (-dblimit).
 	 *
 	 * This option is ineffective for HDR textures.

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1378,7 +1378,7 @@ void compress_block(
 	// Find best blocks for 2, 3 and 4 partitions
 	for (int partition_count = 2; partition_count <= max_partitions; partition_count++)
 	{
-		unsigned int partition_indices[TUNE_MAX_PARTITIION_CANDIDATES];
+		unsigned int partition_indices[TUNE_MAX_PARTITIIONING_CANDIDATES];
 
 		unsigned int requested_indices = requested_partition_indices[partition_count - 2];
 

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1366,15 +1366,15 @@ void compress_block(
 	// Find best blocks for 2, 3 and 4 partitions
 	for (int partition_count = 2; partition_count <= max_partitions; partition_count++)
 	{
-		unsigned int partition_indices[2] { 0 };
-
-		find_best_partition_candidates(bsd, blk, partition_count,
-		                               ctx.config.tune_partition_index_limit,
-		                               partition_indices);
+		unsigned int partition_indices[TUNE_MAX_PARTITIION_CANDIDATES];
+		unsigned int requested = astc::min(ctx.config.tune_partitioning_candidate_limit, ctx.config.tune_partition_index_limit);
+		unsigned int actual = find_best_partition_candidates(bsd, blk, partition_count,
+		                                                     ctx.config.tune_partition_index_limit,
+		                                                     partition_indices, requested);
 
 		float best_error_in_prev = best_errorvals_for_pcount[partition_count - 2];
 
-		for (unsigned int i = 0; i < 2; i++)
+		for (unsigned int i = 0; i < actual; i++)
 		{
 			TRACE_NODE(node1, "pass");
 			trace_add_data("partition_count", partition_count);

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1197,6 +1197,18 @@ void compress_block(
 	bool block_skip_two_plane = false;
 	int max_partitions = ctx.config.tune_partition_count_limit;
 
+	unsigned int requested_partition_indices[3] {
+		ctx.config.tune_2partition_index_limit,
+		ctx.config.tune_3partition_index_limit,
+		ctx.config.tune_4partition_index_limit
+	};
+
+	unsigned int requested_partition_trials[3] {
+		ctx.config.tune_2partitioning_candidate_limit,
+		ctx.config.tune_3partitioning_candidate_limit,
+		ctx.config.tune_4partitioning_candidate_limit
+	};
+
 #if defined(ASTCENC_DIAGNOSTICS)
 	// Do this early in diagnostic builds so we can dump uniform metrics
 	// for every block. Do it later in release builds to avoid redundant work!
@@ -1367,14 +1379,18 @@ void compress_block(
 	for (int partition_count = 2; partition_count <= max_partitions; partition_count++)
 	{
 		unsigned int partition_indices[TUNE_MAX_PARTITIION_CANDIDATES];
-		unsigned int requested = astc::min(ctx.config.tune_partitioning_candidate_limit, ctx.config.tune_partition_index_limit);
-		unsigned int actual = find_best_partition_candidates(bsd, blk, partition_count,
-		                                                     ctx.config.tune_partition_index_limit,
-		                                                     partition_indices, requested);
+
+		unsigned int requested_indices = requested_partition_indices[partition_count - 2];
+
+		unsigned int requested_trials = requested_partition_trials[partition_count - 2];
+		requested_trials = astc::min(requested_trials, requested_indices);
+
+		unsigned int actual_trials = find_best_partition_candidates(
+		    bsd, blk, partition_count, requested_indices, partition_indices, requested_trials);
 
 		float best_error_in_prev = best_errorvals_for_pcount[partition_count - 2];
 
-		for (unsigned int i = 0; i < actual; i++)
+		for (unsigned int i = 0; i < actual_trials; i++)
 		{
 			TRACE_NODE(node1, "pass");
 			trace_add_data("partition_count", partition_count);

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -76,7 +76,7 @@ static const std::array<astcenc_preset_config, 6> preset_configs_high {{
 		4, 34, 28, 16, 77, 3, 3, 2, 2, 2, 95.0f, 70.0f, 2.5f, 2.5f, 1.1f, 1.05f, 0.85f, 16
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 82, 60, 30, 94, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.1f, 0.95f, 12
+		4, 82, 60, 30, 94, 4, 4, 3, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.35f, 1.15f, 0.95f, 12
 	}, {
 		ASTCENC_PRE_VERYTHOROUGH,
 		4, 256, 128, 64, 98, 4, 6, 20, 14, 8, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
@@ -102,7 +102,7 @@ static const std::array<astcenc_preset_config, 6> preset_configs_mid {{
 		4, 34, 28, 16, 77, 3, 3, 2, 2, 2, 95.0f, 70.0f, 3.0f, 3.0f, 1.1f, 1.05f, 0.75f, 14
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 82, 60, 30, 94, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.15f, 0.95f, 10
+		4, 82, 60, 30, 94, 4, 4, 3, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.4f, 1.2f, 0.95f, 10
 	}, {
 		ASTCENC_PRE_VERYTHOROUGH,
 		4, 256, 128, 64, 98, 4, 6, 12, 8, 3, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
@@ -128,7 +128,7 @@ static const std::array<astcenc_preset_config, 6> preset_configs_low {{
 		3, 34, 28, 16, 77, 3, 3, 2, 2, 2, 95.0f, 70.0f, 3.5f, 3.5f, 1.1f, 1.05f, 0.65f, 12
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 82, 60, 30, 93, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.2f, 1.1f, 0.85f, 10
+		4, 82, 60, 30, 93, 4, 4, 3, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.2f, 0.85f, 10
 	}, {
 		ASTCENC_PRE_VERYTHOROUGH,
 		4, 256, 128, 64, 98, 4, 6, 9, 5, 2, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -40,11 +40,15 @@ struct astcenc_preset_config
 {
 	float quality;
 	unsigned int tune_partition_count_limit;
-	unsigned int tune_partition_index_limit;
+	unsigned int tune_2partition_index_limit;
+	unsigned int tune_3partition_index_limit;
+	unsigned int tune_4partition_index_limit;
 	unsigned int tune_block_mode_limit;
 	unsigned int tune_refinement_limit;
 	unsigned int tune_candidate_limit;
-	unsigned int tune_partitioning_candidate_limit;
+	unsigned int tune_2partitioning_candidate_limit;
+	unsigned int tune_3partitioning_candidate_limit;
+	unsigned int tune_4partitioning_candidate_limit;
 	float tune_db_limit_a_base;
 	float tune_db_limit_b_base;
 	float tune_mode0_mse_overshoot;
@@ -60,22 +64,25 @@ struct astcenc_preset_config
  * @brief The static quality presets that are built-in for high bandwidth
  * presets (x < 25 texels per block).
  */
-static const std::array<astcenc_preset_config, 5> preset_configs_high {{
+static const std::array<astcenc_preset_config, 6> preset_configs_high {{
 	{
 		ASTCENC_PRE_FASTEST,
-		2, 10, 43, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 25
+		2, 10, 6, 4, 43, 2, 2, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 25
 	}, {
 		ASTCENC_PRE_FAST,
-		3, 14, 55, 3, 3, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.65f, 20
+		3, 18, 10, 8, 55, 3, 3, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.65f, 20
 	}, {
 		ASTCENC_PRE_MEDIUM,
-		4, 31, 77, 3, 3, 2, 95.0f, 70.0f, 2.5f, 2.5f, 1.1f, 1.05f, 0.85f, 16
+		4, 34, 28, 16, 77, 3, 3, 2, 2, 2, 95.0f, 70.0f, 2.5f, 2.5f, 1.1f, 1.05f, 0.85f, 16
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 78, 94, 4, 4, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.1f, 0.95f, 12
+		4, 82, 60, 30, 94, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.1f, 0.95f, 12
+	}, {
+		ASTCENC_PRE_VERYTHOROUGH,
+		4, 256, 128, 64, 98, 4, 4, 20, 14, 8, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 256, 99, 4, 4, 10, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.98f, 4
+		4, 512, 512, 512, 100, 4, 4, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
 	}
 }};
 
@@ -83,22 +90,25 @@ static const std::array<astcenc_preset_config, 5> preset_configs_high {{
  * @brief The static quality presets that are built-in for medium bandwidth
  * presets (25 <= x < 64 texels per block).
  */
-static const std::array<astcenc_preset_config, 5> preset_configs_mid {{
+static const std::array<astcenc_preset_config, 6> preset_configs_mid {{
 	{
 		ASTCENC_PRE_FASTEST,
-		2, 10, 43, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
+		2, 10, 6, 4, 43, 2, 2, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
 	}, {
 		ASTCENC_PRE_FAST,
-		3, 15, 55, 3, 3, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
+		3, 18, 12, 10, 55, 3, 3, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
 	}, {
 		ASTCENC_PRE_MEDIUM,
-		4, 33, 77, 3, 3, 2, 95.0f, 70.0f, 3.0f, 3.0f, 1.1f, 1.05f, 0.75f, 14
+		4, 34, 28, 16, 77, 3, 3, 2, 2, 2, 95.0f, 70.0f, 3.0f, 3.0f, 1.1f, 1.05f, 0.75f, 14
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 78, 94, 4, 4, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.15f, 0.95f, 10
+		4, 82, 60, 30, 94, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.15f, 0.95f, 10
+	}, {
+		ASTCENC_PRE_VERYTHOROUGH,
+		4, 256, 128, 64, 98, 4, 4, 12, 8, 3, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 256, 99, 4, 4, 8, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.98f, 4
+		4, 256, 256, 256, 100, 4, 4, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
 	}
 }};
 
@@ -106,22 +116,25 @@ static const std::array<astcenc_preset_config, 5> preset_configs_mid {{
  * @brief The static quality presets that are built-in for low bandwidth
  * presets (64 <= x texels per block).
  */
-static const std::array<astcenc_preset_config, 5> preset_configs_low {{
+static const std::array<astcenc_preset_config, 6> preset_configs_low {{
 	{
 		ASTCENC_PRE_FASTEST,
-		2, 10, 40, 2, 2, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
+		2, 10, 6, 4, 40, 2, 2, 2, 2, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
 	}, {
 		ASTCENC_PRE_FAST,
-		2, 15, 55, 3, 3, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
+		2, 18, 12, 10, 55, 3, 3, 2, 2, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
 	}, {
 		ASTCENC_PRE_MEDIUM,
-		3, 33, 77, 3, 3, 2, 95.0f, 70.0f, 3.5f, 3.5f, 1.1f, 1.05f, 0.65f, 12
+		3, 34, 28, 16, 77, 3, 3, 2, 2, 2, 95.0f, 70.0f, 3.5f, 3.5f, 1.1f, 1.05f, 0.65f, 12
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 77, 93, 4, 4, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.2f, 1.1f, 0.85f, 10
+		4, 82, 60, 30, 93, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.2f, 1.1f, 0.85f, 10
+	}, {
+		ASTCENC_PRE_VERYTHOROUGH,
+		4, 256, 128, 64, 98, 4, 4, 9, 5, 2, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 256, 99, 4, 4, 8, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.98f, 4
+		4, 256, 256, 256, 100, 4, 4, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
 	}
 }};
 
@@ -422,11 +435,15 @@ static astcenc_error validate_config(
 	config.rgbm_m_scale = astc::max(config.rgbm_m_scale, 1.0f);
 
 	config.tune_partition_count_limit = astc::clamp(config.tune_partition_count_limit, 1u, 4u);
-	config.tune_partition_index_limit = astc::clamp(config.tune_partition_index_limit, 1u, BLOCK_MAX_PARTITIONINGS);
+	config.tune_2partition_index_limit = astc::clamp(config.tune_2partition_index_limit, 1u, BLOCK_MAX_PARTITIONINGS);
+	config.tune_3partition_index_limit = astc::clamp(config.tune_3partition_index_limit, 1u, BLOCK_MAX_PARTITIONINGS);
+	config.tune_4partition_index_limit = astc::clamp(config.tune_4partition_index_limit, 1u, BLOCK_MAX_PARTITIONINGS);
 	config.tune_block_mode_limit = astc::clamp(config.tune_block_mode_limit, 1u, 100u);
 	config.tune_refinement_limit = astc::max(config.tune_refinement_limit, 1u);
 	config.tune_candidate_limit = astc::clamp(config.tune_candidate_limit, 1u, TUNE_MAX_TRIAL_CANDIDATES);
-	config.tune_partitioning_candidate_limit = astc::clamp(config.tune_partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
+	config.tune_2partitioning_candidate_limit = astc::clamp(config.tune_2partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
+	config.tune_3partitioning_candidate_limit = astc::clamp(config.tune_3partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
+	config.tune_4partitioning_candidate_limit = astc::clamp(config.tune_4partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
 	config.tune_db_limit = astc::max(config.tune_db_limit, 0.0f);
 	config.tune_mode0_mse_overshoot = astc::max(config.tune_mode0_mse_overshoot, 1.0f);
 	config.tune_refinement_mse_overshoot = astc::max(config.tune_refinement_mse_overshoot, 1.0f);
@@ -494,7 +511,7 @@ astcenc_error astcenc_config_init(
 		return ASTCENC_ERR_BAD_QUALITY;
 	}
 
-	static const std::array<astcenc_preset_config, 5>* preset_configs;
+	static const std::array<astcenc_preset_config, 6>* preset_configs;
 	int texels_int = block_x * block_y * block_z;
 	if (texels_int < 25)
 	{
@@ -526,11 +543,15 @@ astcenc_error astcenc_config_init(
 	if (start == end)
 	{
 		config.tune_partition_count_limit = (*preset_configs)[start].tune_partition_count_limit;
-		config.tune_partition_index_limit = (*preset_configs)[start].tune_partition_index_limit;
+		config.tune_2partition_index_limit = (*preset_configs)[start].tune_2partition_index_limit;
+		config.tune_3partition_index_limit = (*preset_configs)[start].tune_3partition_index_limit;
+		config.tune_4partition_index_limit = (*preset_configs)[start].tune_4partition_index_limit;
 		config.tune_block_mode_limit = (*preset_configs)[start].tune_block_mode_limit;
 		config.tune_refinement_limit = (*preset_configs)[start].tune_refinement_limit;
 		config.tune_candidate_limit = astc::min((*preset_configs)[start].tune_candidate_limit, TUNE_MAX_TRIAL_CANDIDATES);
-		config.tune_partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
+		config.tune_2partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_2partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
+		config.tune_3partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_3partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
+		config.tune_4partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_4partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
 		config.tune_db_limit = astc::max((*preset_configs)[start].tune_db_limit_a_base - 35 * ltexels,
 		                                 (*preset_configs)[start].tune_db_limit_b_base - 19 * ltexels);
 
@@ -562,13 +583,19 @@ astcenc_error astcenc_config_init(
 		#define LERPUI(param) static_cast<unsigned int>(LERPI(param))
 
 		config.tune_partition_count_limit = LERPI(tune_partition_count_limit);
-		config.tune_partition_index_limit = LERPI(tune_partition_index_limit);
+		config.tune_2partition_index_limit = LERPI(tune_2partition_index_limit);
+		config.tune_3partition_index_limit = LERPI(tune_3partition_index_limit);
+		config.tune_4partition_index_limit = LERPI(tune_4partition_index_limit);
 		config.tune_block_mode_limit = LERPI(tune_block_mode_limit);
 		config.tune_refinement_limit = LERPI(tune_refinement_limit);
 		config.tune_candidate_limit = astc::min(LERPUI(tune_candidate_limit),
 		                                        TUNE_MAX_TRIAL_CANDIDATES);
-		config.tune_partitioning_candidate_limit = astc::min(LERPUI(tune_partitioning_candidate_limit),
-		                                                     BLOCK_MAX_PARTITIONINGS);
+		config.tune_2partitioning_candidate_limit = astc::min(LERPUI(tune_2partitioning_candidate_limit),
+		                                                      BLOCK_MAX_PARTITIONINGS);
+		config.tune_3partitioning_candidate_limit = astc::min(LERPUI(tune_3partitioning_candidate_limit),
+		                                                      BLOCK_MAX_PARTITIONINGS);
+		config.tune_4partitioning_candidate_limit = astc::min(LERPUI(tune_4partitioning_candidate_limit),
+		                                                      BLOCK_MAX_PARTITIONINGS);
 		config.tune_db_limit = astc::max(LERP(tune_db_limit_a_base) - 35 * ltexels,
 		                                 LERP(tune_db_limit_b_base) - 19 * ltexels);
 

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -44,6 +44,7 @@ struct astcenc_preset_config
 	unsigned int tune_block_mode_limit;
 	unsigned int tune_refinement_limit;
 	unsigned int tune_candidate_limit;
+	unsigned int tune_partitioning_candidate_limit;
 	float tune_db_limit_a_base;
 	float tune_db_limit_b_base;
 	float tune_mode0_mse_overshoot;
@@ -62,19 +63,19 @@ struct astcenc_preset_config
 static const std::array<astcenc_preset_config, 5> preset_configs_high {{
 	{
 		ASTCENC_PRE_FASTEST,
-		2, 10, 43, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 25
+		2, 10, 43, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 25
 	}, {
 		ASTCENC_PRE_FAST,
-		3, 14, 55, 3, 3, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.65f, 20
+		3, 14, 55, 3, 3, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.65f, 20
 	}, {
 		ASTCENC_PRE_MEDIUM,
-		4, 31, 77, 3, 3, 95.0f, 70.0f, 2.5f, 2.5f, 1.1f, 1.05f, 0.85f, 16
+		4, 31, 77, 3, 3, 2, 95.0f, 70.0f, 2.5f, 2.5f, 1.1f, 1.05f, 0.85f, 16
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 78, 94, 4, 4, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.1f, 0.95f, 12
+		4, 78, 94, 4, 4, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.1f, 0.95f, 12
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 1024, 100, 4, 4, 200.0f, 200.0f, 10.0f, 10.0f, 10.0f, 10.0f, 0.99f, 0
+		4, 256, 99, 4, 4, 10, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.98f, 4
 	}
 }};
 
@@ -85,19 +86,19 @@ static const std::array<astcenc_preset_config, 5> preset_configs_high {{
 static const std::array<astcenc_preset_config, 5> preset_configs_mid {{
 	{
 		ASTCENC_PRE_FASTEST,
-		2, 10, 43, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
+		2, 10, 43, 2, 2, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
 	}, {
 		ASTCENC_PRE_FAST,
-		3, 15, 55, 3, 3, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
+		3, 15, 55, 3, 3, 2, 85.2f, 63.2f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
 	}, {
 		ASTCENC_PRE_MEDIUM,
-		4, 33, 77, 3, 3, 95.0f, 70.0f, 3.0f, 3.0f, 1.1f, 1.05f, 0.75f, 14
+		4, 33, 77, 3, 3, 2, 95.0f, 70.0f, 3.0f, 3.0f, 1.1f, 1.05f, 0.75f, 14
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 78, 94, 4, 4, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.15f, 0.95f, 10
+		4, 78, 94, 4, 4, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.15f, 0.95f, 10
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 1024, 100, 4, 4, 200.0f, 200.0f, 10.0f, 10.0f, 10.0f, 10.0f, 0.99f, 0
+		4, 256, 99, 4, 4, 8, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.98f, 4
 	}
 }};
 
@@ -108,19 +109,19 @@ static const std::array<astcenc_preset_config, 5> preset_configs_mid {{
 static const std::array<astcenc_preset_config, 5> preset_configs_low {{
 	{
 		ASTCENC_PRE_FASTEST,
-		2, 10, 40, 2, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
+		2, 10, 40, 2, 2, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 20
 	}, {
 		ASTCENC_PRE_FAST,
-		2, 15, 55, 3, 3, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
+		2, 15, 55, 3, 3, 2, 85.0f, 63.0f, 3.5f, 3.5f, 1.0f, 1.0f, 0.5f, 16
 	}, {
 		ASTCENC_PRE_MEDIUM,
-		3, 33, 77, 3, 3, 95.0f, 70.0f, 3.5f, 3.5f, 1.1f, 1.05f, 0.65f, 12
+		3, 33, 77, 3, 3, 2, 95.0f, 70.0f, 3.5f, 3.5f, 1.1f, 1.05f, 0.65f, 12
 	}, {
 		ASTCENC_PRE_THOROUGH,
-		4, 77, 93, 4, 4, 105.0f, 77.0f, 10.0f, 10.0f, 1.2f, 1.1f, 0.85f, 10
+		4, 77, 93, 4, 4, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.2f, 1.1f, 0.85f, 10
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 1024, 100, 4, 4, 200.0f, 200.0f, 10.0f, 10.0f, 10.0f, 10.0f, 0.99f, 0
+		4, 256, 99, 4, 4, 8, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.98f, 4
 	}
 }};
 
@@ -425,6 +426,7 @@ static astcenc_error validate_config(
 	config.tune_block_mode_limit = astc::clamp(config.tune_block_mode_limit, 1u, 100u);
 	config.tune_refinement_limit = astc::max(config.tune_refinement_limit, 1u);
 	config.tune_candidate_limit = astc::clamp(config.tune_candidate_limit, 1u, TUNE_MAX_TRIAL_CANDIDATES);
+	config.tune_partitioning_candidate_limit = astc::clamp(config.tune_partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
 	config.tune_db_limit = astc::max(config.tune_db_limit, 0.0f);
 	config.tune_mode0_mse_overshoot = astc::max(config.tune_mode0_mse_overshoot, 1.0f);
 	config.tune_refinement_mse_overshoot = astc::max(config.tune_refinement_mse_overshoot, 1.0f);
@@ -527,8 +529,8 @@ astcenc_error astcenc_config_init(
 		config.tune_partition_index_limit = (*preset_configs)[start].tune_partition_index_limit;
 		config.tune_block_mode_limit = (*preset_configs)[start].tune_block_mode_limit;
 		config.tune_refinement_limit = (*preset_configs)[start].tune_refinement_limit;
-		config.tune_candidate_limit = astc::min((*preset_configs)[start].tune_candidate_limit,
-		                                        TUNE_MAX_TRIAL_CANDIDATES);
+		config.tune_candidate_limit = astc::min((*preset_configs)[start].tune_candidate_limit, TUNE_MAX_TRIAL_CANDIDATES);
+		config.tune_partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
 		config.tune_db_limit = astc::max((*preset_configs)[start].tune_db_limit_a_base - 35 * ltexels,
 		                                 (*preset_configs)[start].tune_db_limit_b_base - 19 * ltexels);
 
@@ -565,6 +567,8 @@ astcenc_error astcenc_config_init(
 		config.tune_refinement_limit = LERPI(tune_refinement_limit);
 		config.tune_candidate_limit = astc::min(LERPUI(tune_candidate_limit),
 		                                        TUNE_MAX_TRIAL_CANDIDATES);
+		config.tune_partitioning_candidate_limit = astc::min(LERPUI(tune_partitioning_candidate_limit),
+		                                                     BLOCK_MAX_PARTITIONINGS);
 		config.tune_db_limit = astc::max(LERP(tune_db_limit_a_base) - 35 * ltexels,
 		                                 LERP(tune_db_limit_b_base) - 19 * ltexels);
 

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -79,10 +79,10 @@ static const std::array<astcenc_preset_config, 6> preset_configs_high {{
 		4, 82, 60, 30, 94, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.1f, 0.95f, 12
 	}, {
 		ASTCENC_PRE_VERYTHOROUGH,
-		4, 256, 128, 64, 98, 4, 4, 20, 14, 8, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
+		4, 256, 128, 64, 98, 4, 6, 20, 14, 8, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 512, 512, 512, 100, 4, 4, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
+		4, 512, 512, 512, 100, 4, 8, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
 	}
 }};
 
@@ -105,10 +105,10 @@ static const std::array<astcenc_preset_config, 6> preset_configs_mid {{
 		4, 82, 60, 30, 94, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.3f, 1.15f, 0.95f, 10
 	}, {
 		ASTCENC_PRE_VERYTHOROUGH,
-		4, 256, 128, 64, 98, 4, 4, 12, 8, 3, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
+		4, 256, 128, 64, 98, 4, 6, 12, 8, 3, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 256, 256, 256, 100, 4, 4, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
+		4, 256, 256, 256, 100, 4, 8, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
 	}
 }};
 
@@ -131,10 +131,10 @@ static const std::array<astcenc_preset_config, 6> preset_configs_low {{
 		4, 82, 60, 30, 93, 4, 4, 2, 2, 2, 105.0f, 77.0f, 10.0f, 10.0f, 1.2f, 1.1f, 0.85f, 10
 	}, {
 		ASTCENC_PRE_VERYTHOROUGH,
-		4, 256, 128, 64, 98, 4, 4, 9, 5, 2, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
+		4, 256, 128, 64, 98, 4, 6, 9, 5, 2, 200.0f, 200.0f, 10.0f, 10.0f, 1.6f, 1.4f, 0.98f, 4
 	}, {
 		ASTCENC_PRE_EXHAUSTIVE,
-		4, 256, 256, 256, 100, 4, 4, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
+		4, 256, 256, 256, 100, 4, 8, 32, 32, 32, 200.0f, 200.0f, 10.0f, 10.0f, 2.0f, 2.0f, 0.99f, 0
 	}
 }};
 
@@ -441,9 +441,9 @@ static astcenc_error validate_config(
 	config.tune_block_mode_limit = astc::clamp(config.tune_block_mode_limit, 1u, 100u);
 	config.tune_refinement_limit = astc::max(config.tune_refinement_limit, 1u);
 	config.tune_candidate_limit = astc::clamp(config.tune_candidate_limit, 1u, TUNE_MAX_TRIAL_CANDIDATES);
-	config.tune_2partitioning_candidate_limit = astc::clamp(config.tune_2partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
-	config.tune_3partitioning_candidate_limit = astc::clamp(config.tune_3partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
-	config.tune_4partitioning_candidate_limit = astc::clamp(config.tune_4partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIION_CANDIDATES);
+	config.tune_2partitioning_candidate_limit = astc::clamp(config.tune_2partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIIONING_CANDIDATES);
+	config.tune_3partitioning_candidate_limit = astc::clamp(config.tune_3partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIIONING_CANDIDATES);
+	config.tune_4partitioning_candidate_limit = astc::clamp(config.tune_4partitioning_candidate_limit, 1u, TUNE_MAX_PARTITIIONING_CANDIDATES);
 	config.tune_db_limit = astc::max(config.tune_db_limit, 0.0f);
 	config.tune_mode0_mse_overshoot = astc::max(config.tune_mode0_mse_overshoot, 1.0f);
 	config.tune_refinement_mse_overshoot = astc::max(config.tune_refinement_mse_overshoot, 1.0f);
@@ -549,9 +549,9 @@ astcenc_error astcenc_config_init(
 		config.tune_block_mode_limit = (*preset_configs)[start].tune_block_mode_limit;
 		config.tune_refinement_limit = (*preset_configs)[start].tune_refinement_limit;
 		config.tune_candidate_limit = astc::min((*preset_configs)[start].tune_candidate_limit, TUNE_MAX_TRIAL_CANDIDATES);
-		config.tune_2partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_2partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
-		config.tune_3partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_3partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
-		config.tune_4partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_4partitioning_candidate_limit, TUNE_MAX_PARTITIION_CANDIDATES);
+		config.tune_2partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_2partitioning_candidate_limit, TUNE_MAX_PARTITIIONING_CANDIDATES);
+		config.tune_3partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_3partitioning_candidate_limit, TUNE_MAX_PARTITIIONING_CANDIDATES);
+		config.tune_4partitioning_candidate_limit = astc::min((*preset_configs)[start].tune_4partitioning_candidate_limit, TUNE_MAX_PARTITIIONING_CANDIDATES);
 		config.tune_db_limit = astc::max((*preset_configs)[start].tune_db_limit_a_base - 35 * ltexels,
 		                                 (*preset_configs)[start].tune_db_limit_b_base - 19 * ltexels);
 

--- a/Source/astcenc_find_best_partitioning.cpp
+++ b/Source/astcenc_find_best_partitioning.cpp
@@ -553,12 +553,12 @@ unsigned int find_best_partition_candidates(
 
 	// Partitioning errors assuming uncorrelated-chrominance endpoints
 	unsigned int best_error_count { 0 };
-	float uncor_best_errors[TUNE_MAX_PARTITIION_CANDIDATES];
-	unsigned int uncor_best_partitions[TUNE_MAX_PARTITIION_CANDIDATES];
+	float uncor_best_errors[TUNE_MAX_PARTITIIONING_CANDIDATES];
+	unsigned int uncor_best_partitions[TUNE_MAX_PARTITIIONING_CANDIDATES];
 
 	// Partitioning errors assuming same-chrominance endpoints
-	float samec_best_errors[TUNE_MAX_PARTITIION_CANDIDATES];
-	unsigned int samec_best_partitions[TUNE_MAX_PARTITIION_CANDIDATES];
+	float samec_best_errors[TUNE_MAX_PARTITIIONING_CANDIDATES];
+	unsigned int samec_best_partitions[TUNE_MAX_PARTITIIONING_CANDIDATES];
 
 	for (unsigned int i = 0; i < requested; i++)
 	{
@@ -715,7 +715,7 @@ unsigned int find_best_partition_candidates(
 
 	best_error_count = astc::min(best_error_count, requested);
 
-	unsigned int interleave[2 * TUNE_MAX_PARTITIION_CANDIDATES];
+	unsigned int interleave[2 * TUNE_MAX_PARTITIIONING_CANDIDATES];
 	for (unsigned int i = 0; i < best_error_count; i++)
 	{
 		interleave[2 * i] = bsd.get_raw_partition_info(partition_count, uncor_best_partitions[i]).partition_index;

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -130,14 +130,14 @@ static constexpr unsigned int TUNE_MIN_TEXELS_MODE0_FASTPATH { 24 };
  *
  * This can be dynamically reduced by the compression quality preset.
  */
-static constexpr unsigned int TUNE_MAX_TRIAL_CANDIDATES { 4 };
+static constexpr unsigned int TUNE_MAX_TRIAL_CANDIDATES { 8 };
 
 /**
  * @brief The maximum number of candidate partitionings tested for each encoding mode.
  *
  * This can be dynamically reduced by the compression quality preset.
  */
-static constexpr unsigned int TUNE_MAX_PARTITIION_CANDIDATES { 32 };
+static constexpr unsigned int TUNE_MAX_PARTITIIONING_CANDIDATES { 32 };
 
 /**
  * @brief The maximum quant level using full angular endpoint search method.
@@ -1539,7 +1539,7 @@ unsigned int find_best_partition_candidates(
 	const image_block& blk,
 	unsigned int partition_count,
 	unsigned int partition_search_limit,
-	unsigned int best_partitions[TUNE_MAX_PARTITIION_CANDIDATES],
+	unsigned int best_partitions[TUNE_MAX_PARTITIIONING_CANDIDATES],
 	unsigned int requested);
 
 /* ============================================================================

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -137,7 +137,7 @@ static constexpr unsigned int TUNE_MAX_TRIAL_CANDIDATES { 4 };
  *
  * This can be dynamically reduced by the compression quality preset.
  */
-static constexpr unsigned int TUNE_MAX_PARTITIION_CANDIDATES { 16 };
+static constexpr unsigned int TUNE_MAX_PARTITIION_CANDIDATES { 32 };
 
 /**
  * @brief The maximum quant level using full angular endpoint search method.

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -133,6 +133,13 @@ static constexpr unsigned int TUNE_MIN_TEXELS_MODE0_FASTPATH { 24 };
 static constexpr unsigned int TUNE_MAX_TRIAL_CANDIDATES { 4 };
 
 /**
+ * @brief The maximum number of candidate partitionings tested for each encoding mode.
+ *
+ * This can be dynamically reduced by the compression quality preset.
+ */
+static constexpr unsigned int TUNE_MAX_PARTITIION_CANDIDATES { 16 };
+
+/**
  * @brief The maximum quant level using full angular endpoint search method.
  *
  * The angular endpoint search is used to find the min/max weight that should
@@ -1525,13 +1532,15 @@ void compute_error_squared_rgba(
  * @param      partition_count            The number of partitions in the block.
  * @param      partition_search_limit     The number of candidate partition encodings to trial.
  * @param[out] best_partitions            The best partition candidates.
+ * @param      requested                  The number of requsted partitionings.
  */
-void find_best_partition_candidates(
+unsigned int find_best_partition_candidates(
 	const block_size_descriptor& bsd,
 	const image_block& blk,
 	unsigned int partition_count,
 	unsigned int partition_search_limit,
-	unsigned int best_partitions[2]);
+	unsigned int best_partitions[TUNE_MAX_PARTITIION_CANDIDATES],
+	unsigned int requested);
 
 /* ============================================================================
   Functionality for managing images and image related data.

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -1352,11 +1352,11 @@ extern const int8_t quant_mode_table[10][128];
  * Note that BISE can return strings that are not a whole number of bytes in length, and ASTC can
  * start storing strings in a block at arbitrary bit offsets in the encoded data.
  *
- * @param         quant_level      The BISE alphabet size.
- * @param         character_count  The number of characters in the string.
- * @param         input_data       The unpacked string, one byte per character.
- * @param[in,out] output_data      The output packed string.
- * @param         bit_offset       The starting offset in the output storage.
+ * @param         quant_level       The BISE alphabet size.
+ * @param         character_count   The number of characters in the string.
+ * @param         input_data        The unpacked string, one byte per character.
+ * @param[in,out] output_data       The output packed string.
+ * @param         bit_offset        The starting offset in the output storage.
  */
 void encode_ise(
 	quant_method quant_level,
@@ -1443,11 +1443,11 @@ void compute_avgs_and_dirs_3_comp(
  * This is a specialization of @c compute_avgs_and_dirs_3_comp where the omitted component is
  * always alpha, a common case during partition search.
  *
- * @param      pi                  The partition info for the current trial.
- * @param      blk                 The image block color data to be compressed.
- * @param[out] pm                  The output partition metrics.
- *                                 - Only pi.partition_count array entries actually get initialized.
- *                                 - Direction vectors @c pm.dir are not normalized.
+ * @param      pi    The partition info for the current trial.
+ * @param      blk   The image block color data to be compressed.
+ * @param[out] pm    The output partition metrics.
+ *                   - Only pi.partition_count array entries actually get initialized.
+ *                   - Direction vectors @c pm.dir are not normalized.
  */
 void compute_avgs_and_dirs_3_comp_rgb(
 	const partition_info& pi,
@@ -1478,11 +1478,11 @@ void compute_avgs_and_dirs_4_comp(
  *
  * This function computes the squared error when using these two representations.
  *
- * @param         pi              The partition info for the current trial.
- * @param         blk             The image block color data to be compressed.
- * @param[in,out] plines          Processed line inputs, and line length outputs.
- * @param[out]    uncor_error     The cumulative error for using the uncorrelated line.
- * @param[out]    samec_error     The cumulative error for using the same chroma line.
+ * @param         pi            The partition info for the current trial.
+ * @param         blk           The image block color data to be compressed.
+ * @param[in,out] plines        Processed line inputs, and line length outputs.
+ * @param[out]    uncor_error   The cumulative error for using the uncorrelated line.
+ * @param[out]    samec_error   The cumulative error for using the same chroma line.
  */
 void compute_error_squared_rgb(
 	const partition_info& pi,
@@ -1527,12 +1527,15 @@ void compute_error_squared_rgba(
  * candidates; one assuming data has uncorrelated chroma and one assuming the
  * data has correlated chroma. The best candidate is returned first in the list.
  *
- * @param      bsd                        The block size information.
- * @param      blk                        The image block color data to compress.
- * @param      partition_count            The number of partitions in the block.
- * @param      partition_search_limit     The number of candidate partition encodings to trial.
- * @param[out] best_partitions            The best partition candidates.
- * @param      requested                  The number of requsted partitionings.
+ * @param      bsd                      The block size information.
+ * @param      blk                      The image block color data to compress.
+ * @param      partition_count          The number of partitions in the block.
+ * @param      partition_search_limit   The number of candidate partition encodings to trial.
+ * @param[out] best_partitions          The best partition candidates.
+ * @param      requested_candidates     The number of requsted partitionings. May return fewer if
+ *                                      candidates are not avaiable.
+ *
+ * @return The actual number of candidates returned.
  */
 unsigned int find_best_partition_candidates(
 	const block_size_descriptor& bsd,
@@ -1540,7 +1543,7 @@ unsigned int find_best_partition_candidates(
 	unsigned int partition_count,
 	unsigned int partition_search_limit,
 	unsigned int best_partitions[TUNE_MAX_PARTITIIONING_CANDIDATES],
-	unsigned int requested);
+	unsigned int requested_candidates);
 
 /* ============================================================================
   Functionality for managing images and image related data.
@@ -1554,10 +1557,10 @@ unsigned int find_best_partition_candidates(
  *
  * Results are written back into @c img->input_alpha_averages.
  *
- * @param      img                     The input image data, also holds output data.
- * @param      alpha_kernel_radius     The kernel radius (in pixels) for alpha mods.
- * @param      swz                     Input data component swizzle.
- * @param[out] ag                      The average variance arguments to init.
+ * @param      img                   The input image data, also holds output data.
+ * @param      alpha_kernel_radius   The kernel radius (in pixels) for alpha mods.
+ * @param      swz                   Input data component swizzle.
+ * @param[out] ag                    The average variance arguments to init.
  *
  * @return The number of tasks in the processing stage.
  */
@@ -1775,13 +1778,13 @@ float compute_error_of_weight_set_2planes(
  * The user requests a base color endpoint mode in @c format, but the quantizer may choose a
  * delta-based representation. It will report back the format variant it actually used.
  *
- * @param      color0       The input unquantized color0 endpoint for absolute endpoint pairs.
- * @param      color1       The input unquantized color1 endpoint for absolute endpoint pairs.
- * @param      rgbs_color   The input unquantized RGBS variant endpoint for same chroma endpoints.
- * @param      rgbo_color   The input unquantized RGBS variant endpoint for HDR endpoints..
- * @param      format       The desired base format.
- * @param[out] output       The output storage for the quantized colors/
- * @param      quant_level  The quantization level requested.
+ * @param      color0        The input unquantized color0 endpoint for absolute endpoint pairs.
+ * @param      color1        The input unquantized color1 endpoint for absolute endpoint pairs.
+ * @param      rgbs_color    The input unquantized RGBS variant endpoint for same chroma endpoints.
+ * @param      rgbo_color    The input unquantized RGBS variant endpoint for HDR endpoints.
+ * @param      format        The desired base format.
+ * @param[out] output        The output storage for the quantized colors/
+ * @param      quant_level   The quantization level requested.
  *
  * @return The actual endpoint mode used.
  */
@@ -1882,13 +1885,13 @@ unsigned int compute_ideal_endpoint_formats(
  * As we quantize and decimate weights the optimal endpoint colors may change slightly, so we must
  * recompute the ideal colors for a specific weight set.
  *
- * @param         blk                        The image block color data to compress.
- * @param         pi                         The partition info for the current trial.
- * @param         di                         The weight grid decimation table.
+ * @param         blk                  The image block color data to compress.
+ * @param         pi                   The partition info for the current trial.
+ * @param         di                   The weight grid decimation table.
  * @param         dec_weights_uquant   The quantized weight set.
- * @param[in,out] ep                         The color endpoints (modifed in place).
- * @param[out]    rgbs_vectors               The RGB+scale vectors for LDR blocks.
- * @param[out]    rgbo_vectors               The RGB+offset vectors for HDR blocks.
+ * @param[in,out] ep                   The color endpoints (modifed in place).
+ * @param[out]    rgbs_vectors         The RGB+scale vectors for LDR blocks.
+ * @param[out]    rgbo_vectors         The RGB+offset vectors for HDR blocks.
  */
 void recompute_ideal_colors_1plane(
 	const image_block& blk,
@@ -1905,15 +1908,15 @@ void recompute_ideal_colors_1plane(
  * As we quantize and decimate weights the optimal endpoint colors may change slightly, so we must
  * recompute the ideal colors for a specific weight set.
  *
- * @param         blk                               The image block color data to compress.
- * @param         bsd                               The block_size descriptor.
- * @param         di                                The weight grid decimation table.
+ * @param         blk                         The image block color data to compress.
+ * @param         bsd                         The block_size descriptor.
+ * @param         di                          The weight grid decimation table.
  * @param         dec_weights_uquant_plane1   The quantized weight set for plane 1.
  * @param         dec_weights_uquant_plane2   The quantized weight set for plane 2.
- * @param[in,out] ep                                The color endpoints (modifed in place).
- * @param[out]    rgbs_vector                       The RGB+scale color for LDR blocks.
- * @param[out]    rgbo_vector                       The RGB+offset color for HDR blocks.
- * @param         plane2_component                  The component assigned to plane 2.
+ * @param[in,out] ep                          The color endpoints (modifed in place).
+ * @param[out]    rgbs_vector                 The RGB+scale color for LDR blocks.
+ * @param[out]    rgbo_vector                 The RGB+offset color for HDR blocks.
+ * @param         plane2_component            The component assigned to plane 2.
  */
 void recompute_ideal_colors_2planes(
 	const image_block& blk,
@@ -1934,12 +1937,12 @@ void prepare_angular_tables();
 /**
  * @brief Compute the angular endpoints for one plane for each block mode.
  *
- * @param      tune_low_weight_limit     Weight count cutoff below which we use simpler searches.
- * @param      only_always               Only consider block modes that are always enabled.
- * @param      bsd                       The block size descriptor for the current trial.
- * @param      dec_weight_ideal_value    The ideal decimated unquantized weight values.
- * @param      max_weight_quant          The maximum block mode weight quantization allowed.
- * @param[out] tmpbuf                    Preallocated scratch buffers for the compressor.
+ * @param      tune_low_weight_limit    Weight count cutoff below which we use simpler searches.
+ * @param      only_always              Only consider block modes that are always enabled.
+ * @param      bsd                      The block size descriptor for the current trial.
+ * @param      dec_weight_ideal_value   The ideal decimated unquantized weight values.
+ * @param      max_weight_quant         The maximum block mode weight quantization allowed.
+ * @param[out] tmpbuf                   Preallocated scratch buffers for the compressor.
  */
 void compute_angular_endpoints_1plane(
 	unsigned int tune_low_weight_limit,
@@ -1952,11 +1955,11 @@ void compute_angular_endpoints_1plane(
 /**
  * @brief Compute the angular endpoints for two planes for each block mode.
  *
- * @param      tune_low_weight_limit     Weight count cutoff below which we use simpler searches.
- * @param      bsd                       The block size descriptor for the current trial.
- * @param      dec_weight_ideal_value    The ideal decimated unquantized weight values.
- * @param      max_weight_quant          The maximum block mode weight quantization allowed.
- * @param[out] tmpbuf                    Preallocated scratch buffers for the compressor.
+ * @param      tune_low_weight_limit    Weight count cutoff below which we use simpler searches.
+ * @param      bsd                      The block size descriptor for the current trial.
+ * @param      dec_weight_ideal_value   The ideal decimated unquantized weight values.
+ * @param      max_weight_quant         The maximum block mode weight quantization allowed.
+ * @param[out] tmpbuf                   Preallocated scratch buffers for the compressor.
  */
 void compute_angular_endpoints_2planes(
 	unsigned int tune_low_weight_limit,
@@ -2169,20 +2172,6 @@ void aligned_free(T* ptr)
 #else
 	free(reinterpret_cast<void*>(ptr));
 #endif
-}
-
-static inline void dump_weights(const char* label, uint8_t* weights, int weight_count)
-{
-	printf("%s\n", label);
-	vint lane = vint::lane_id();
-	for (int i = 0; i < weight_count; i += ASTCENC_SIMD_WIDTH)
-	{
-		vmask mask = lane < vint(weight_count);
-		vint val(weights + i);
-		val = select(vint::zero(), val, mask);
-		print(val);
-		lane += vint(ASTCENC_SIMD_WIDTH);
-	}
 }
 
 #endif

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -519,6 +519,10 @@ static int init_astcenc_config(
 		{
 			quality = ASTCENC_PRE_THOROUGH;
 		}
+		else if (!strcmp(argv[5], "-verythorough"))
+		{
+			quality = ASTCENC_PRE_VERYTHOROUGH;
+		}
 		else if (!strcmp(argv[5], "-exhaustive"))
 		{
 			quality = ASTCENC_PRE_EXHAUSTIVE;
@@ -902,16 +906,71 @@ static int edit_astcenc_config(
 
 			config.tune_partition_count_limit = atoi(argv[argidx - 1]);
 		}
-		else if (!strcmp(argv[argidx], "-partitionindexlimit"))
+		else if (!strcmp(argv[argidx], "-2partitionindexlimit"))
 		{
 			argidx += 2;
 			if (argidx > argc)
 			{
-				printf("ERROR: -partitionindexlimit switch with no argument\n");
+				printf("ERROR: -2partitionindexlimit switch with no argument\n");
 				return 1;
 			}
 
-			config.tune_partition_index_limit = atoi(argv[argidx - 1]);
+			config.tune_2partition_index_limit = atoi(argv[argidx - 1]);
+		}
+		else if (!strcmp(argv[argidx], "-3partitionindexlimit"))
+		{
+			argidx += 2;
+			if (argidx > argc)
+			{
+				printf("ERROR: -3partitionindexlimit switch with no argument\n");
+				return 1;
+			}
+
+			config.tune_2partition_index_limit = atoi(argv[argidx - 1]);
+		}
+		else if (!strcmp(argv[argidx], "-4partitionindexlimit"))
+		{
+			argidx += 2;
+			if (argidx > argc)
+			{
+				printf("ERROR: -4partitionindexlimit switch with no argument\n");
+				return 1;
+			}
+
+			config.tune_2partition_index_limit = atoi(argv[argidx - 1]);
+		}
+		else if (!strcmp(argv[argidx], "-2partitioncandiatelimit"))
+		{
+			argidx += 2;
+			if (argidx > argc)
+			{
+				printf("ERROR: -2partitioncandidatelimit switch with no argument\n");
+				return 1;
+			}
+
+			config.tune_2partitioning_candidate_limit = atoi(argv[argidx - 1]);
+		}
+		else if (!strcmp(argv[argidx], "-3partitioncandiatelimit"))
+		{
+			argidx += 2;
+			if (argidx > argc)
+			{
+				printf("ERROR: -3partitioncandiatelimit switch with no argument\n");
+				return 1;
+			}
+
+			config.tune_3partitioning_candidate_limit = atoi(argv[argidx - 1]);
+		}
+		else if (!strcmp(argv[argidx], "-4partitioncandiatelimit"))
+		{
+			argidx += 2;
+			if (argidx > argc)
+			{
+				printf("ERROR: -4partitioncandiatelimit switch with no argument\n");
+				return 1;
+			}
+
+			config.tune_4partitioning_candidate_limit = atoi(argv[argidx - 1]);
 		}
 		else if (!strcmp(argv[argidx], "-dblimit"))
 		{
@@ -1171,7 +1230,9 @@ static void print_astcenc_config(
 		printf("    B component weight:         %g\n", static_cast<double>(config.cw_b_weight));
 		printf("    A component weight:         %g\n", static_cast<double>(config.cw_a_weight));
 		printf("    Partition cutoff:           %u partitions\n", config.tune_partition_count_limit);
-		printf("    Partition index cutoff:     %u partition ids\n", config.tune_partition_index_limit);
+		printf("    2 partition index cutoff:   %u partition ids\n", config.tune_2partition_index_limit);
+		printf("    3 partition index cutoff:   %u partition ids\n", config.tune_3partition_index_limit);
+		printf("    4 partition index cutoff:   %u partition ids\n", config.tune_4partition_index_limit);
 		printf("    PSNR cutoff:                %g dB\n", static_cast<double>(config.tune_db_limit));
 		printf("    3 partition cutoff:         %g\n", static_cast<double>(config.tune_2_partition_early_out_limit_factor));
 		printf("    4 partition cutoff:         %g\n", static_cast<double>(config.tune_3_partition_early_out_limit_factor));

--- a/Source/astcenccli_toplevel_help.cpp
+++ b/Source/astcenccli_toplevel_help.cpp
@@ -337,8 +337,8 @@ ADVANCED COMPRESSION
                -fast         : 3
                -medium       : 3
                -thorough     : 4
-               -verythorough : 4
-               -exhaustive   : 4
+               -verythorough : 6
+               -exhaustive   : 8
 
        -dblimit <number>
            Stop compression work on a block as soon as the PSNR of the

--- a/Source/astcenccli_toplevel_help.cpp
+++ b/Source/astcenccli_toplevel_help.cpp
@@ -138,13 +138,14 @@ COMPRESSION
        The quality level configures the quality-performance tradeoff for
        the compressor; more complete searches of the search space improve
        image quality at the expense of compression time. The quality level
-       can be set to any value between 0 (fastest) and 100 (thorough), or
-       to a fixed quality preset:
+       can be set to any value between 0 (fastest) and 100 (exhaustive),
+       or to a fixed quality preset:
 
            -fastest       (equivalent to quality =   0)
            -fast          (equivalent to quality =  10)
            -medium        (equivalent to quality =  60)
            -thorough      (equivalent to quality =  98)
+           -verythorough  (equivalent to quality =  99)
            -exhaustive    (equivalent to quality = 100)
 
        For compression of production content we recommend using a quality
@@ -273,53 +274,71 @@ ADVANCED COMPRESSION
            Higher numbers give better quality, as more complex blocks can
            be encoded, but will increase search time. Preset defaults are:
 
-               -fastest    : 2
-               -fast       : 3
-               -medium     : 4
-               -thorough   : 4
-               -exhaustive : 4
+               -fastest      : 2
+               -fast         : 3
+               -medium       : 4
+               -thorough     : 4
+               -verythorough : 4
+               -exhaustive   : 4
 
-       -partitionindexlimit <number>
-           Test <number> block partition indices for each partition count.
-           Higher numbers give better quality, however large values give
-           diminishing returns especially for smaller block sizes. Preset
-           defaults are:
+       -[2|3|4]partitionindexlimit <number>
+           Estimate errors for <number> block partition indices for this
+           partition count. Higher numbers give better quality, however
+           large values give diminishing returns especially for smaller
+           block sizes. Preset defaults are:
 
-               -fastest    :    8
-               -fast       :   12
-               -medium     :   26
-               -thorough   :   76
-               -exhaustive : 1024
+               -fastest      :   10 |   6 |   4
+               -fast         :   18 |  10 |   8
+               -medium       :   34 |  28 |  16
+               -thorough     :   82 |  60 |  30
+               -vertthorough :  256 | 128 |  64
+               -exhaustive   :  512 | 512 | 512
+
+       -[2|3|4]partitioncandidatelimit <number>
+           Calculate errors for <number> block partition indices for this
+           partition count. Higher numbers give better quality, however
+           large values give diminishing returns especially for smaller
+           block sizes. Preset defaults are:
+
+               -fastest      :   2 |  2 |  2
+               -fast         :   2 |  2 |  2
+               -medium       :   2 |  2 |  2
+               -thorough     :   2 |  2 |  2
+               -verythorough :  20 | 14 |  8
+               -exhaustive   :  32 | 32 | 32
 
        -blockmodelimit <number>
            Test block modes below <number> usage centile in an empirically
            determined distribution of block mode frequency. This option is
            ineffective for 3D textures. Preset defaults are:
 
-               -fastest    :  40
-               -fast       :  55
-               -medium     :  76
-               -thorough   :  93
-               -exhaustive : 100
+               -fastest      :  43
+               -fast         :  55
+               -medium       :  77
+               -thorough     :  94
+               -verythorough :  98
+               -exhaustive   : 100
 
-       -refinementlimit <value>
-           Iterate only <value> refinement iterations on colors and
+       -refinementlimit <number>
+           Iterate <number> refinement iterations on colors and
            weights. Minimum value is 1. Preset defaults are:
 
-               -fastest    : 2
-               -fast       : 3
-               -medium     : 3
-               -thorough   : 4
-               -exhaustive : 4
+               -fastest      : 2
+               -fast         : 3
+               -medium       : 3
+               -thorough     : 4
+               -verythorough : 4
+               -exhaustive   : 4
 
-       -candidatelimit <value>
-           Trial only <value> candidate encodings for each block mode:
+       -candidatelimit <number>
+           Trial <number> candidate encodings for each block mode:
 
-               -fastest    : 2
-               -fast       : 3
-               -medium     : 3
-               -thorough   : 4
-               -exhaustive : 4
+               -fastest      : 2
+               -fast         : 3
+               -medium       : 3
+               -thorough     : 4
+               -verythorough : 4
+               -exhaustive   : 4
 
        -dblimit <number>
            Stop compression work on a block as soon as the PSNR of the
@@ -327,37 +346,26 @@ ADVANCED COMPRESSION
            ineffective for HDR textures. Preset defaults, where N is the
            number of texels in a block, are:
 
-               -fastest    : MAX(63-19*log10(N),  85-35*log10(N))
-               -fast       : MAX(63-19*log10(N),  85-35*log10(N))
-               -medium     : MAX(70-19*log10(N),  95-35*log10(N))
-               -thorough   : MAX(77-19*log10(N), 105-35*log10(N))
-               -exhaustive : 999
+               -fastest      : MAX(63-19*log10(N),  85-35*log10(N))
+               -fast         : MAX(63-19*log10(N),  85-35*log10(N))
+               -medium       : MAX(70-19*log10(N),  95-35*log10(N))
+               -thorough     : MAX(77-19*log10(N), 105-35*log10(N))
+               -verythorough : 999
+               -exhaustive   : 999
 
-       -2partitionlimitfactor <factor>
+       -[2|3]partitionlimitfactor <factor>
            Stop compression work on a block after only testing blocks with
-           up to two partitions and one plane of weights, unless the two
+           up to 2/3 partitions and one plane of weights, unless the 2/3
            partition error term is lower than the error term from encoding
-           with one partition by more than the specified factor. Preset
+           with 1/2 partitions by more than the specified factor. Preset
            defaults are:
 
-               -fastest    :  1.0
-               -fast       :  1.0
-               -medium     :  1.2
-               -thorough   :  2.5
-               -exhaustive : 10.0
-
-       -3partitionlimitfactor <factor>
-           Stop compression work on a block after only testing blocks with
-           up to three partitions and one plane of weights, unless the three
-           partition error term is lower than the error term from encoding
-           with two partitions by more than the specified factor. Preset
-           defaults are:
-
-               -fastest    :  1.00
-               -fast       :  1.10
-               -medium     :  1.25
-               -thorough   :  1.25
-               -exhaustive : 10.00
+               -fastest       : 1.00 | 1.00
+               -fast          : 1.00 | 1.00
+               -medium        : 1.10 | 1.05
+               -thorough      : 1.30 | 1.10
+               -verythrorough : 1.60 | 1.40
+               -exhaustive    : 2.00 | 2.00
 
        -2planelimitcorrelation <factor>
            Stop compression after testing only one plane of weights, unless
@@ -365,22 +373,26 @@ ADVANCED COMPRESSION
            components is below this factor. This option is ineffective for
            normal maps. Preset defaults are:
 
-               -fastest    : 0.50
-               -fast       : 0.65
-               -medium     : 0.85
-               -thorough   : 0.95
-               -exhaustive : 0.99
+               -fastest      : 0.50
+               -fast         : 0.65
+               -medium       : 0.85
+               -thorough     : 0.95
+               -verythorough : 0.98
+               -exhaustive   : 0.99
 
        -lowweightmodelimit <weight count>
            Use a simpler weight search for weight counts less than or
            equal to this threshold. Preset defaults are bitrate dependent:
 
-               -fastest    : 25
-               -fast       : 20
-               -medium     : 16
-               -thorough   : 12
-               -exhaustive : 0
-
+               -fastest      : 25
+               -fast         : 20
+               -medium       : 16
+               -thorough     : 12
+               -verythorough : 4
+               -exhaustive   : 0)"
+// This split in the literals is needed for Visual Studio; the compiler
+// will concatenate these two strings together ...
+R"(
        Other options
        -------------
 
@@ -540,7 +552,7 @@ QUICK REFERENCE
            astcenc {-tl|-ts|-th|-tH} <in> <out> <blockdim> <quality> [options]
 
        Mode -*l = linear LDR, -*s = sRGB LDR, -*h = HDR RGB/LDR A, -*H = HDR.
-       Quality = -fastest/-fast/-medium/-thorough/-exhaustive/a float [0-100].
+       Quality = -fastest/-fast/-medium/-thorough/-verythorough/-exhaustive/a float [0-100].
 )";
 
 /* See header for documentation. */

--- a/Source/astcenccli_toplevel_help.cpp
+++ b/Source/astcenccli_toplevel_help.cpp
@@ -141,12 +141,12 @@ COMPRESSION
        can be set to any value between 0 (fastest) and 100 (exhaustive),
        or to a fixed quality preset:
 
-           -fastest       (equivalent to quality =   0)
-           -fast          (equivalent to quality =  10)
-           -medium        (equivalent to quality =  60)
-           -thorough      (equivalent to quality =  98)
-           -verythorough  (equivalent to quality =  99)
-           -exhaustive    (equivalent to quality = 100)
+           -fastest      (equivalent to quality =   0)
+           -fast         (equivalent to quality =  10)
+           -medium       (equivalent to quality =  60)
+           -thorough     (equivalent to quality =  98)
+           -verythorough (equivalent to quality =  99)
+           -exhaustive   (equivalent to quality = 100)
 
        For compression of production content we recommend using a quality
        level equivalent to -medium or higher.
@@ -291,7 +291,7 @@ ADVANCED COMPRESSION
                -fast         :   18 |  10 |   8
                -medium       :   34 |  28 |  16
                -thorough     :   82 |  60 |  30
-               -vertthorough :  256 | 128 |  64
+               -verythorough :  256 | 128 |  64
                -exhaustive   :  512 | 512 | 512
 
        -[2|3|4]partitioncandidatelimit <number>
@@ -303,7 +303,7 @@ ADVANCED COMPRESSION
                -fastest      :   2 |  2 |  2
                -fast         :   2 |  2 |  2
                -medium       :   2 |  2 |  2
-               -thorough     :   2 |  2 |  2
+               -thorough     :   3 |  2 |  2
                -verythorough :  20 | 14 |  8
                -exhaustive   :  32 | 32 | 32
 
@@ -363,7 +363,7 @@ ADVANCED COMPRESSION
                -fastest       : 1.00 | 1.00
                -fast          : 1.00 | 1.00
                -medium        : 1.10 | 1.05
-               -thorough      : 1.30 | 1.10
+               -thorough      : 1.35 | 1.15
                -verythrorough : 1.60 | 1.40
                -exhaustive    : 2.00 | 2.00
 

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -105,6 +105,7 @@ macro(astcenc_set_properties NAME)
         PRIVATE
             # Use pthreads on Linux/macOS
             $<$<PLATFORM_ID:Linux,Darwin>:-pthread>
+            -gdwarf-4
 
             # MSVC compiler defines
             $<$<CXX_COMPILER_ID:MSVC>:/EHsc>

--- a/Test/astc_test_image.py
+++ b/Test/astc_test_image.py
@@ -49,7 +49,7 @@ RESULT_THRESHOLD_3D_FAIL = -0.00
 
 TEST_BLOCK_SIZES = ["4x4", "5x5", "6x6", "8x8", "12x12", "3x3x3", "6x6x6"]
 
-TEST_QUALITIES = ["fastest", "fast", "medium", "thorough", "exhaustive"]
+TEST_QUALITIES = ["fastest", "fast", "medium", "thorough", "verythorough", "exhaustive"]
 
 
 def is_3d(blockSize):

--- a/Test/astc_test_image.py
+++ b/Test/astc_test_image.py
@@ -47,10 +47,9 @@ RESULT_THRESHOLD_FAIL = -0.00
 RESULT_THRESHOLD_3D_FAIL = -0.00
 
 
-TEST_BLOCK_SIZES = ["4x4", "5x5", "6x6", "8x8", "12x12",
-                    "3x3x3", "6x6x6"]
+TEST_BLOCK_SIZES = ["4x4", "5x5", "6x6", "8x8", "12x12", "3x3x3", "6x6x6"]
 
-TEST_QUALITIES = ["fastest", "fast", "medium", "thorough"]
+TEST_QUALITIES = ["fastest", "fast", "medium", "thorough", "exhaustive"]
 
 
 def is_3d(blockSize):


### PR DESCRIPTION
This PR adds multiple improvements to how we handle partitioning searches during encoding. 

Firstly, it adds the ability to compute error estimates for different numbers of  partitioning for each of 2/3/4 partitions. This heuristic existed before, but used the same count for all three. This allows us to bias the search towards the 2 partition case, where it is more likely to be useful, and away from the 4 partition case. 

Secondly, it adds the ability for 2/3/4 partition searches to run full coding trials on a variable number of partition candidates; again, with a unique setting for each partition count. Prior to this they could only ever test exactly two based on error estimates. This improves IQ, as error estimates cannot accurately factor in quantization, at the expense of significantly more coding time. 

Finally, a new `-verythorough` preset is introduced to provide a drop-in for the old `-exhaustive` (as the new `-exhaustive` is 2-3x slower). It benefits from the new heuristics to improve both IQ and performance over the previous `-exhaustive` setting.

For `-verythorough` 4x4 blocks the Kodak suite is not 0.08 dB higher IQ, and run at 1.08x speed. 6x6 blocks have 0.08 dB higher IQ, and run at 1.02x speed.

For `-exhaustive` 4x4 blocks the Kodak suite is now 0.13 dB higher IQ and runs at 0.4x speed. 6x6 blocks have 0.10 dB higher IQ and run at 0.3x speed.