### PR TITLE
Fix encoder base+offset endpoint encodings

### DIFF
--- a/Source/astcenc_color_unquantize.cpp
+++ b/Source/astcenc_color_unquantize.cpp
@@ -97,15 +97,8 @@ static void rgba_delta_unpack(
 	vint4 input0 = unquant_color(quant_level, input0q);
 	vint4 input1 = unquant_color(quant_level, input1q);
 
-	// Perform bit-transfer
-	input0 = input0 | lsl<1>(input1 & 0x80);
-	input1 = input1 & 0x7F;
-	vmask4 mask = (input1 & 0x40) != vint4::zero();
-	input1 = select(input1, input1 - 0x80, mask);
-
-	// Scale
-	input0 = asr<1>(input0);
-	input1 = asr<1>(input1);
+	// Apply bit transfer
+	bit_transfer_signed(input1, input0);
 
 	// Apply blue-uncontraction if needed
 	int rgb_sum = hadd_rgb_s(input1);

--- a/Source/astcenc_vecmathlib_common_4.h
+++ b/Source/astcenc_vecmathlib_common_4.h
@@ -362,6 +362,23 @@ static inline int popcount(uint64_t v)
 #endif
 
 /**
+ * @brief Apply signed bit transfer.
+ *
+ * @param input0   The first encoded endpoint.
+ * @param input1   The second encoded endpoint.
+ */
+static ASTCENC_SIMD_INLINE void bit_transfer_signed(
+	vint4& input0,
+	vint4& input1
+) {
+	input1 = lsr<1>(input1) | (input0 & 0x80);
+	input0 = lsr<1>(input0) & 0x3F;
+
+	vmask4 mask = (input0 & 0x20) != vint4::zero();
+	input0 = select(input0, input0 - 0x40, mask);
+}
+
+/**
  * @brief Debug function to print a vector of ints.
  */
 ASTCENC_SIMD_INLINE void print(vint4 a)


### PR DESCRIPTION
For the RGB/RGBA base+offset endpoint formats the compressor can fail to detect cases that incorrectly do/do not trigger blue-contraction for the encoding path it is trying. This can result in endpoint encodings that are incorrect when decompressed because the blue-contraction the data was expecting is/is not applied.

This occurs because the compressor arithmetic is using shifted values for the implementation of `bit_transfer_signed()` and follow on arithmetic, but doesn't factor in the shift when computing whether the endpoint R+G+B sum is invalid for the desired direction of blue-contraction. This only impacts the compressor; the decompressor is correct.

Fixes #382 