### PR TITLE
Disable blue contraction at quant level 256

### DIFF
--- a/Source/astcenc_color_quantize.cpp
+++ b/Source/astcenc_color_quantize.cpp
@@ -1973,7 +1973,7 @@ uint8_t pack_color_endpoints(
 				break;
 			}
 		}
-		if (try_quantize_rgb_blue_contract(color0, color1, output, quant_level))
+		if (quant_level < QUANT_256 && try_quantize_rgb_blue_contract(color0, color1, output, quant_level))
 		{
 			retval = FMT_RGB;
 			break;
@@ -1996,7 +1996,7 @@ uint8_t pack_color_endpoints(
 				break;
 			}
 		}
-		if (try_quantize_rgba_blue_contract(color0, color1, output, quant_level))
+		if (quant_level < QUANT_256 && try_quantize_rgba_blue_contract(color0, color1, output, quant_level))
 		{
 			retval = FMT_RGBA;
 			break;

--- a/Source/astcenc_color_quantize.cpp
+++ b/Source/astcenc_color_quantize.cpp
@@ -1960,7 +1960,7 @@ uint8_t pack_color_endpoints(
 	switch (format)
 	{
 	case FMT_RGB:
-		if (quant_level <= 18)
+		if (quant_level <= QUANT_160)
 		{
 			if (try_quantize_rgb_delta_blue_contract(color0, color1, output, quant_level))
 			{
@@ -1983,7 +1983,7 @@ uint8_t pack_color_endpoints(
 		break;
 
 	case FMT_RGBA:
-		if (quant_level <= 18)
+		if (quant_level <= QUANT_160)
 		{
 			if (try_quantize_rgba_delta_blue_contract(color0, color1, output, quant_level))
 			{


### PR DESCRIPTION
At quantization level 256 there's no actual quantization happening, so blue contraction should not provide any benefit in that case. In fact, allowing blue contraction at that level seems to increase the error slightly. These are the results of running the encoder on the kodak image set:

```
new:
  fastest   RMSE = 2.9423
  fast      RMSE = 2.7559
  medium    RMSE = 2.6331

original:
  fastest   RMSE = 2.9478
  fast      RMSE = 2.7692
  medium    RMSE = 2.6470
```

I haven't evaluated performance. I would expect a slight increase, but may not be significant enough to be noticeable.