### PR TITLE
mathlib: Remove incomplete support for SSE3 which assumed SSSE3

### DIFF
--- a/Source/astcenc_mathlib.h
+++ b/Source/astcenc_mathlib.h
@@ -48,8 +48,6 @@
     #define ASTCENC_SSE 42
   #elif defined(__SSE4_1__)
     #define ASTCENC_SSE 41
-  #elif defined(__SSE3__)
-    #define ASTCENC_SSE 30
   #elif defined(__SSE2__)
     #define ASTCENC_SSE 20
   #else

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1046,7 +1046,7 @@ ASTCENC_SIMD_INLINE void vtable_prepare(vint4 t0, vint4& t0p)
  */
 ASTCENC_SIMD_INLINE void vtable_prepare(vint4 t0, vint4 t1, vint4& t0p, vint4& t1p)
 {
-#if ASTCENC_SSE >= 30
+#if ASTCENC_SSE >= 41
 	t0p = t0;
 	t1p = t0 ^ t1;
 #else
@@ -1062,7 +1062,7 @@ ASTCENC_SIMD_INLINE void vtable_prepare(
 	vint4 t0, vint4 t1, vint4 t2, vint4 t3,
 	vint4& t0p, vint4& t1p, vint4& t2p, vint4& t3p)
 {
-#if ASTCENC_SSE >= 30
+#if ASTCENC_SSE >= 41
 	t0p = t0;
 	t1p = t0 ^ t1;
 	t2p = t1 ^ t2;
@@ -1080,7 +1080,7 @@ ASTCENC_SIMD_INLINE void vtable_prepare(
  */
 ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 idx)
 {
-#if ASTCENC_SSE >= 30
+#if ASTCENC_SSE >= 41
 	// Set index byte MSB to 1 for unused bytes so shuffle returns zero
 	__m128i idxx = _mm_or_si128(idx.m, _mm_set1_epi32(static_cast<int>(0xFFFFFF00)));
 
@@ -1102,7 +1102,7 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 idx)
  */
 ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 idx)
 {
-#if ASTCENC_SSE >= 30
+#if ASTCENC_SSE >= 41
 	// Set index byte MSB to 1 for unused bytes so shuffle returns zero
 	__m128i idxx = _mm_or_si128(idx.m, _mm_set1_epi32(static_cast<int>(0xFFFFFF00)));
 
@@ -1130,7 +1130,7 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 idx)
  */
 ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 t2, vint4 t3, vint4 idx)
 {
-#if ASTCENC_SSE >= 30
+#if ASTCENC_SSE >= 41
 	// Set index byte MSB to 1 for unused bytes so shuffle returns zero
 	__m128i idxx = _mm_or_si128(idx.m, _mm_set1_epi32(static_cast<int>(0xFFFFFF00)));
 


### PR DESCRIPTION
`_mm_shuffle_epi8` requires SSSE3 so the check on `ASTCENC_SSE >= 30` is
too lax and would fail if `__SSE3__` is supported, but not `__SSSE3__`.

The only supported configurations are SSE2, SSE4.1, and AVX2, so as
discussed in #393 we drop the SSE3 checks and require SSE4.1 instead.

Downstream issue: https://github.com/godotengine/godot/issues/71700

Confirmed the bug by building astcenc with MinGW-GCC on Linux with `-msse3`, and confirming that it defines `__SSE3__` but not `__SSSE3__`.
Adding `-mssse3`, or my patch, fixes the issue.

### Notes

- ~I'm not very knowledgeable on SIMD stuff. I don't know if "31" is a good index for `SSSE3` here.~
- ~I updated all `>= 30` checks to `>= 31` assuming that they need to be kept in sync. Please advise if I should change some back.~
- Updated to require SSE4.1 for this code instead, as discussed below.