### PR TITLE
Implement veneer for ISA compat checks

### DIFF
--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -158,48 +158,6 @@ static astcenc_error validate_cpu_float()
 }
 
 /**
- * @brief Validate CPU ISA support meets the requirements of this build of the library.
- *
- * Each library build is statically compiled for a particular set of CPU ISA features, such as the
- * SIMD support or other ISA extensions such as POPCNT. This function checks that the host CPU
- * actually supports everything this build needs.
- *
- * @return Return @c ASTCENC_SUCCESS if validated, otherwise an error on failure.
- */
-static astcenc_error validate_cpu_isa()
-{
-	#if ASTCENC_SSE >= 41
-		if (!cpu_supports_sse41())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	#if ASTCENC_POPCNT >= 1
-		if (!cpu_supports_popcnt())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	#if ASTCENC_F16C >= 1
-		if (!cpu_supports_f16c())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	#if ASTCENC_AVX >= 2
-		if (!cpu_supports_avx2())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	return ASTCENC_SUCCESS;
-}
-
-/**
  * @brief Validate config profile.
  *
  * @param profile   The profile to check.
@@ -464,7 +422,7 @@ static astcenc_error validate_config(
 }
 
 /* See header for documentation. */
-astcenc_error astcenc_config_init(
+astcenc_error astcenc_config_init_actual(
 	astcenc_profile profile,
 	unsigned int block_x,
 	unsigned int block_y,
@@ -474,14 +432,6 @@ astcenc_error astcenc_config_init(
 	astcenc_config* configp
 ) {
 	astcenc_error status;
-
-	// Check basic library compatibility options here so they are checked early. Note, these checks
-	// are repeated in context_alloc for cases where callers use a manually defined config struct
-	status = validate_cpu_isa();
-	if (status != ASTCENC_SUCCESS)
-	{
-		return status;
-	}
 
 	status = validate_cpu_float();
 	if (status != ASTCENC_SUCCESS)
@@ -694,19 +644,13 @@ astcenc_error astcenc_config_init(
 }
 
 /* See header for documentation. */
-astcenc_error astcenc_context_alloc(
+astcenc_error astcenc_context_alloc_actual(
 	const astcenc_config* configp,
 	unsigned int thread_count,
 	astcenc_context** context
 ) {
 	astcenc_error status;
 	const astcenc_config& config = *configp;
-
-	status = validate_cpu_isa();
-	if (status != ASTCENC_SUCCESS)
-	{
-		return status;
-	}
 
 	status = validate_cpu_float();
 	if (status != ASTCENC_SUCCESS)

--- a/Source/astcenc_entry_veneer.cpp
+++ b/Source/astcenc_entry_veneer.cpp
@@ -95,7 +95,7 @@ astcenc_error astcenc_config_init(
 	unsigned int flags,
 	astcenc_config* configp
 ) {
-	// Check ISA compatability in the veneer before handing off to main implementation
+	// Check ISA compatability in the veneer before handing off
 	astcenc_error status = validate_cpu_isa();
 	if (status != ASTCENC_SUCCESS)
 	{
@@ -112,7 +112,7 @@ astcenc_error astcenc_context_alloc(
 	unsigned int thread_count,
 	astcenc_context** context
 ) {
-	// Check ISA compatability in the veneer before handing off to main implementation
+	// Check ISA compatability in the veneer before handing off
 	astcenc_error status = validate_cpu_isa();
 	if (status != ASTCENC_SUCCESS)
 	{

--- a/Source/astcenc_entry_veneer.cpp
+++ b/Source/astcenc_entry_veneer.cpp
@@ -102,6 +102,8 @@ astcenc_error astcenc_config_init(
 		return status;
 	}
 
+	cpu_isb();
+
 	return astcenc_config_init_actual(
 		profile, block_x, block_y, block_z, quality, flags, configp);
 }
@@ -118,6 +120,8 @@ astcenc_error astcenc_context_alloc(
 	{
 		return status;
 	}
+
+	cpu_isb();
 
 	return astcenc_context_alloc_actual(
 		configp, thread_count, context);

--- a/Source/astcenc_entry_veneer.cpp
+++ b/Source/astcenc_entry_veneer.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// ----------------------------------------------------------------------------
+// Copyright 2023 Arm Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief Functions for the library entrypoint veneer layer.
+ *
+ * This veneer is a minimal shim compiled for a base instruction set that is
+ * guaranteed to be supported, e.g. SSE2 on x86_64. This prevents use of any
+ * unsupported enhanced instruction set before the ISA compatability error
+ * check is performed.
+ */
+
+#include "astcenc.h"
+#include "astcenc_internal_entry.h"
+
+/* Non-veneer function implementation. */
+astcenc_error astcenc_config_init_actual(
+	astcenc_profile profile,
+	unsigned int block_x,
+	unsigned int block_y,
+	unsigned int block_z,
+	float quality,
+	unsigned int flags,
+	astcenc_config* config);
+
+/* Non-veneer function implementation. */
+astcenc_error astcenc_context_alloc_actual(
+	const astcenc_config* config,
+	unsigned int thread_count,
+	astcenc_context** context);
+
+/**
+ * @brief Validate CPU ISA support meets the requirements of this build of the library.
+ *
+ * Each library build is statically compiled for a particular set of CPU ISA features, such as the
+ * SIMD support or other ISA extensions such as POPCNT. This function checks that the host CPU
+ * actually supports everything this build needs.
+ *
+ * @return Return @c ASTCENC_SUCCESS if validated, otherwise an error on failure.
+ */
+static astcenc_error validate_cpu_isa()
+{
+	#if ASTCENC_SSE >= 41
+		if (!cpu_supports_sse41())
+		{
+			return ASTCENC_ERR_BAD_CPU_ISA;
+		}
+	#endif
+
+	#if ASTCENC_POPCNT >= 1
+		if (!cpu_supports_popcnt())
+		{
+			return ASTCENC_ERR_BAD_CPU_ISA;
+		}
+	#endif
+
+	#if ASTCENC_F16C >= 1
+		if (!cpu_supports_f16c())
+		{
+			return ASTCENC_ERR_BAD_CPU_ISA;
+		}
+	#endif
+
+	#if ASTCENC_AVX >= 2
+		if (!cpu_supports_avx2())
+		{
+			return ASTCENC_ERR_BAD_CPU_ISA;
+		}
+	#endif
+
+	return ASTCENC_SUCCESS;
+}
+
+/* See header for documentation. */
+astcenc_error astcenc_config_init(
+	astcenc_profile profile,
+	unsigned int block_x,
+	unsigned int block_y,
+	unsigned int block_z,
+	float quality,
+	unsigned int flags,
+	astcenc_config* configp
+) {
+	// Check ISA compatability in the veneer before handing off to main implementation
+	astcenc_error status = validate_cpu_isa();
+	if (status != ASTCENC_SUCCESS)
+	{
+		return status;
+	}
+
+	return astcenc_config_init_actual(
+		profile, block_x, block_y, block_z, quality, flags, configp);
+}
+
+/* See header for documentation. */
+astcenc_error astcenc_context_alloc(
+	const astcenc_config* configp,
+	unsigned int thread_count,
+	astcenc_context** context
+) {
+	// Check ISA compatability in the veneer before handing off to main implementation
+	astcenc_error status = validate_cpu_isa();
+	if (status != ASTCENC_SUCCESS)
+	{
+		return status;
+	}
+
+	return astcenc_context_alloc_actual(
+		configp, thread_count, context);
+}

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -2149,6 +2149,11 @@ bool cpu_supports_sse41();
 bool cpu_supports_avx2();
 
 /**
+ * @brief Instruction stream barrier to stop out-of-order execution over the barrier.
+ */
+void cpu_isb();
+
+/**
  * @brief Allocate an aligned memory buffer.
  *
  * Allocated memory must be freed by aligned_free;

--- a/Source/astcenc_platform_isa_detection.cpp
+++ b/Source/astcenc_platform_isa_detection.cpp
@@ -164,4 +164,16 @@ bool cpu_supports_avx2()
 	return g_cpu_has_avx2;
 }
 
+void cpu_isb()
+{
+	_mm_lfence();
+}
+
+#else
+
+void cpu_isb()
+{
+	// Only need this today for x86_64 implementations using SIMD
+}
+
 #endif

--- a/Source/astcenc_platform_isa_detection.cpp
+++ b/Source/astcenc_platform_isa_detection.cpp
@@ -28,18 +28,19 @@
 #if (ASTCENC_SSE > 0)    || (ASTCENC_AVX > 0) || \
     (ASTCENC_POPCNT > 0) || (ASTCENC_F16C > 0)
 
+/** Have the global trackers been initialized? */
 static bool g_init { false };
 
-/** Does this CPU support SSE 4.1? Set to -1 if not yet initialized. */
+/** Does this CPU support SSE 4.1? Set to false if not yet initialized. */
 static bool g_cpu_has_sse41 { false };
 
-/** Does this CPU support AVX2? Set to -1 if not yet initialized. */
+/** Does this CPU support AVX2? Set to false if not yet initialized. */
 static bool g_cpu_has_avx2 { false };
 
-/** Does this CPU support POPCNT? Set to -1 if not yet initialized. */
+/** Does this CPU support POPCNT? Set to false if not yet initialized. */
 static bool g_cpu_has_popcnt { false };
 
-/** Does this CPU support F16C? Set to -1 if not yet initialized. */
+/** Does this CPU support F16C? Set to false if not yet initialized. */
 static bool g_cpu_has_f16c { false };
 
 /* ============================================================================

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -56,12 +56,12 @@ target_include_directories(${ASTC_TARGET}-core-static
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:.>)
 
-add_library(${ASTC_TARGET}-entry-static
+add_library(${ASTC_TARGET}-veneer-static
     STATIC
         astcenc_entry_veneer.cpp
         astcenc_platform_isa_detection.cpp)
 
-target_include_directories(${ASTC_TARGET}-entry-static
+target_include_directories(${ASTC_TARGET}-veneer-static
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:.>)
@@ -78,7 +78,7 @@ if(${CLI})
 
     target_link_libraries(${ASTC_TARGET}
         PRIVATE
-            ${ASTC_TARGET}-entry-static
+            ${ASTC_TARGET}-veneer-static
             ${ASTC_TARGET}-core-static)
 endif()
 
@@ -336,14 +336,14 @@ endif()
 
 astcenc_set_properties(${ASTC_TARGET}-core-static OFF)
 
-astcenc_set_properties(${ASTC_TARGET}-entry-static ON)
+astcenc_set_properties(${ASTC_TARGET}-veneer-static ON)
 
 # TODO: Move this inside set_properties?
 target_compile_options(${ASTC_TARGET}-core-static
     PRIVATE
         $<$<CXX_COMPILER_ID:MSVC>:/W4>)
 
-target_compile_options(${ASTC_TARGET}-entry-static
+target_compile_options(${ASTC_TARGET}-veneer-static
     PRIVATE
         $<$<CXX_COMPILER_ID:MSVC>:/W4>)
 

--- a/Utils/Example/CMakeLists.txt
+++ b/Utils/Example/CMakeLists.txt
@@ -28,13 +28,19 @@ project(astcencoder_example VERSION 1.0.0)
 # SIMD enable to the CMAKE_CACHE_ARGS option to force something specific, but
 # remember to change the link library in target_link_libraries() to match.
 #
-#  *  Add "-DISA_SSE2:String=ON" and link against "astcenc-sse2-static"
-#  *  Add "-DISA_SSE41:String=ON" and link against "astcenc-sse4.1-static"
-#  *  Add "-DISA_AVX2:String=ON" and link against "astcenc-avx2-static"
-#  *  Add "-DISA_NEON:String=ON" and link against "astcenc-neon-static"
+# Two libraries are created per target instruction set:
+#  * astcenc-<ISA>-veneer-static
+#  * astcenc-<ISA>-core-static
+#
+# You must link against BOTH libraries, with the veneer first on the link line.
+#
+#  *  Add "-DISA_SSE2:String=ON" and link against the libraries with ISA=sse2
+#  *  Add "-DISA_SSE41:String=ON" and link against the libraries with ISA=sse4.1
+#  *  Add "-DISA_AVX2:String=ON" and link against the libraries with ISA=avx2
+#  *  Add "-DISA_NEON:String=ON" and link against the libraries with ISA=neon
 ExternalProject_Add(astcencoder
     GIT_REPOSITORY https://github.com/ARM-software/astc-encoder
-    GIT_TAG main
+    GIT_TAG origin/384_isacheck
     CMAKE_CACHE_ARGS -DCLI:STRING=OFF -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     INSTALL_COMMAND "")
 
@@ -62,4 +68,5 @@ target_link_directories(astcenc_example
 
 target_link_libraries(astcenc_example
     PRIVATE
-        astcenc-native-static)
+        astcenc-native-veneer-static
+        astcenc-native-core-static)

--- a/Utils/Example/CMakeLists.txt
+++ b/Utils/Example/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2021 Arm Limited
+#  Copyright 2021-2023 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -19,20 +19,21 @@
 cmake_minimum_required(VERSION 3.15)
 include(ExternalProject)
 
-project(astcencoder_example VERSION 1.0.0)
+project(astcencoder_example VERSION 1.1.0)
 
 # Add the external project and pull out the project directories we need
 
 # The default build is a native build which supports the highest level of SIMD
 # exposed by the compiler when using default compiler flags. Add a single
 # SIMD enable to the CMAKE_CACHE_ARGS option to force something specific, but
-# remember to change the link library in target_link_libraries() to match.
+# remember to change the link libraries in target_link_libraries() to match.
 #
-# Two libraries are created per target instruction set:
+# Note that two libraries are created per target instruction set:
+#
 #  * astcenc-<ISA>-veneer-static
 #  * astcenc-<ISA>-core-static
 #
-# You must link against BOTH libraries, with the veneer first on the link line.
+# You must link against BOTH libraries, with the veneer first in the link order.
 #
 #  *  Add "-DISA_SSE2:String=ON" and link against the libraries with ISA=sse2
 #  *  Add "-DISA_SSE41:String=ON" and link against the libraries with ISA=sse4.1
@@ -40,7 +41,7 @@ project(astcencoder_example VERSION 1.0.0)
 #  *  Add "-DISA_NEON:String=ON" and link against the libraries with ISA=neon
 ExternalProject_Add(astcencoder
     GIT_REPOSITORY https://github.com/ARM-software/astc-encoder
-    GIT_TAG origin/384_isacheck
+    GIT_TAG main
     CMAKE_CACHE_ARGS -DCLI:STRING=OFF -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     INSTALL_COMMAND "")
 


### PR DESCRIPTION
This PR implements a small veneer on the core library that is designed to be compiled using a base ISA which is guaranteed to be supported on the target architecture. This ensures that we can safely perform the ISA compatibility check in the library without failing with a SIGILL.

Fixes #384.