### PR TITLE
Move ISA check out of core library

### DIFF
--- a/Docs/ChangeLog-4x.md
+++ b/Docs/ChangeLog-4x.md
@@ -11,13 +11,18 @@ clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 
 **Status:** In development
 
-The 4.3.1 release is a minor development release.
+The 4.4.0 release is a minor development release.
 
 * **General:**
+  * **Change:** Core library no longer checks availability of required extended
+    instruction set extensions, such as SSE4.1 or AVX2. Checking compatibility
+    is now the responsibility of the caller. See `astcenc_entry.cpp` for an
+    example of code performing this check.
   * **Change:** Command line errors print to stderr instead of stdout.
   * **Change:** Color encoding uses new quantization tables, that now factor
-    in floating-point rounding if a distance tie is found using the integer
-    quant256 value. This improves image quality for 4x4 and 5x5 block sizes.
+    in floating-point rounding if a distance tie is found when using the
+    integer quant256 value. This improves image quality for 4x4 and 5x5 block
+    sizes.
   * **Optimization:** Partition selection uses a simplified line calculation
     with a faster approximation. This improves performance for all block sizes.
   * **Bug-fix:** Fixed infinity handling in debug trace JSON files.

--- a/Docs/ChangeLog-4x.md
+++ b/Docs/ChangeLog-4x.md
@@ -14,7 +14,7 @@ clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 The 4.4.0 release is a minor development release.
 
 * **General:**
-  * **Change:** Core library no longer checks availability of required extended
+  * **Change:** Core library no longer checks availability of required
     instruction set extensions, such as SSE4.1 or AVX2. Checking compatibility
     is now the responsibility of the caller. See `astcenc_entry.cpp` for an
     example of code performing this check.

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -43,6 +43,14 @@
  *       for faster processing. The caller is responsible for creating the worker threads, and
  *       synchronizing between images.
  *
+ * Extended instruction set support
+ * ================================
+ *
+ * This library supports use of extended instruction sets, such as SSE4.1 and AVX2. These are
+ * enabled at compile time when building the library. There is no runtime checking in the core
+ * library that the instruction sets used are actually available. Checking compatibility is the
+ * responsibility of the calling code.
+ *
  * Threading
  * =========
  *
@@ -191,8 +199,6 @@ enum astcenc_error {
 	ASTCENC_ERR_OUT_OF_MEM,
 	/** @brief The call failed due to the build using fast math. */
 	ASTCENC_ERR_BAD_CPU_FLOAT,
-	/** @brief The call failed due to the build using an unsupported ISA. */
-	ASTCENC_ERR_BAD_CPU_ISA,
 	/** @brief The call failed due to an out-of-spec parameter. */
 	ASTCENC_ERR_BAD_PARAM,
 	/** @brief The call failed due to an out-of-spec block size. */

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -158,48 +158,6 @@ static astcenc_error validate_cpu_float()
 }
 
 /**
- * @brief Validate CPU ISA support meets the requirements of this build of the library.
- *
- * Each library build is statically compiled for a particular set of CPU ISA features, such as the
- * SIMD support or other ISA extensions such as POPCNT. This function checks that the host CPU
- * actually supports everything this build needs.
- *
- * @return Return @c ASTCENC_SUCCESS if validated, otherwise an error on failure.
- */
-static astcenc_error validate_cpu_isa()
-{
-	#if ASTCENC_SSE >= 41
-		if (!cpu_supports_sse41())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	#if ASTCENC_POPCNT >= 1
-		if (!cpu_supports_popcnt())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	#if ASTCENC_F16C >= 1
-		if (!cpu_supports_f16c())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	#if ASTCENC_AVX >= 2
-		if (!cpu_supports_avx2())
-		{
-			return ASTCENC_ERR_BAD_CPU_ISA;
-		}
-	#endif
-
-	return ASTCENC_SUCCESS;
-}
-
-/**
  * @brief Validate config profile.
  *
  * @param profile   The profile to check.
@@ -475,14 +433,6 @@ astcenc_error astcenc_config_init(
 ) {
 	astcenc_error status;
 
-	// Check basic library compatibility options here so they are checked early. Note, these checks
-	// are repeated in context_alloc for cases where callers use a manually defined config struct
-	status = validate_cpu_isa();
-	if (status != ASTCENC_SUCCESS)
-	{
-		return status;
-	}
-
 	status = validate_cpu_float();
 	if (status != ASTCENC_SUCCESS)
 	{
@@ -701,12 +651,6 @@ astcenc_error astcenc_context_alloc(
 ) {
 	astcenc_error status;
 	const astcenc_config& config = *configp;
-
-	status = validate_cpu_isa();
-	if (status != ASTCENC_SUCCESS)
-	{
-		return status;
-	}
 
 	status = validate_cpu_float();
 	if (status != ASTCENC_SUCCESS)
@@ -1399,8 +1343,6 @@ const char* astcenc_get_error_string(
 		return "ASTCENC_ERR_OUT_OF_MEM";
 	case ASTCENC_ERR_BAD_CPU_FLOAT:
 		return "ASTCENC_ERR_BAD_CPU_FLOAT";
-	case ASTCENC_ERR_BAD_CPU_ISA:
-		return "ASTCENC_ERR_BAD_CPU_ISA";
 	case ASTCENC_ERR_BAD_PARAM:
 		return "ASTCENC_ERR_BAD_PARAM";
 	case ASTCENC_ERR_BAD_BLOCK_SIZE:

--- a/Source/astcenccli_entry.cpp
+++ b/Source/astcenccli_entry.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2022 Arm Limited
+// Copyright 2020-2023 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/Source/astcenccli_entry.cpp
+++ b/Source/astcenccli_entry.cpp
@@ -18,16 +18,8 @@
 /**
  * @brief Platform-specific function implementations.
  *
- * This module contains functions with strongly OS-dependent implementations:
- *
- *  * CPU count queries
- *  * Threading
- *  * Time
- *
- * In addition to the basic thread abstraction (which is native pthreads on
- * all platforms, except Windows where it is an emulation of pthreads), a
- * utility function to create N threads and wait for them to complete a batch
- * task has also been provided.
+ * This module contains the CLI entry point which also performs the role of
+ * validating the host extended ISA support meets the needs of the tools.
  */
 
 #include "astcenccli_internal.h"

--- a/Source/astcenccli_internal.h
+++ b/Source/astcenccli_internal.h
@@ -393,4 +393,16 @@ void launch_threads(
 	void (*func)(int, int, void*),
 	void *payload);
 
+/**
+ * @brief The main entry point.
+ *
+ * @param argc   The number of arguments.
+ * @param argv   The vector of arguments.
+ *
+ * @return 0 on success, non-zero otherwise.
+ */
+int astcenc_main(
+	int argc,
+	char **argv);
+
 #endif

--- a/Source/astcenccli_toplevel.cpp
+++ b/Source/astcenccli_toplevel.cpp
@@ -610,11 +610,6 @@ static int init_astcenc_config(
 		print_error("ERROR: Block size '%s' is invalid\n", argv[4]);
 		return 1;
 	}
-	else if (status == ASTCENC_ERR_BAD_CPU_ISA)
-	{
-		print_error("ERROR: Required SIMD ISA support missing on this CPU\n");
-		return 1;
-	}
 	else if (status == ASTCENC_ERR_BAD_CPU_FLOAT)
 	{
 		print_error("ERROR: astcenc must not be compiled with -ffast-math\n");
@@ -1839,7 +1834,7 @@ static void print_diagnostic_images(
  *
  * @return 0 on success, non-zero otherwise.
  */
-int main(
+int astcenc_main(
 	int argc,
 	char **argv
 ) {

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -46,7 +46,6 @@ add_library(${ASTC_TARGET}-static
         astcenc_partition_tables.cpp
         astcenc_percentile_tables.cpp
         astcenc_pick_best_endpoint_format.cpp
-        astcenc_platform_isa_detection.cpp
         astcenc_quantization.cpp
         astcenc_symbolic_physical.cpp
         astcenc_weight_align.cpp
@@ -58,6 +57,9 @@ target_include_directories(${ASTC_TARGET}-static
         $<INSTALL_INTERFACE:.>)
 
 if(${CLI})
+    add_library(${ASTC_TARGET}-veneer
+        astcenccli_entry.cpp)
+
     add_executable(${ASTC_TARGET}
         astcenccli_error_metrics.cpp
         astcenccli_image.cpp
@@ -69,10 +71,11 @@ if(${CLI})
 
     target_link_libraries(${ASTC_TARGET}
         PRIVATE
+            ${ASTC_TARGET}-veneer
             ${ASTC_TARGET}-static)
 endif()
 
-macro(astcenc_set_properties NAME)
+macro(astcenc_set_properties NAME IS_VENEER)
 
     target_compile_features(${NAME}
         PRIVATE
@@ -223,8 +226,7 @@ macro(astcenc_set_properties NAME)
                     ASTCENC_F16C=0)
         endif()
 
-        # These settings are needed on AppleClang as SSE4.1 is on by default
-        # Suppress unused argument for macOS universal build behavior
+        # Force SSE2 on AppleClang (normally SSE4.1 is the default)
         target_compile_options(${NAME}
             PRIVATE
                 $<$<CXX_COMPILER_ID:AppleClang>:-msse2>
@@ -242,11 +244,19 @@ macro(astcenc_set_properties NAME)
                     ASTCENC_F16C=0)
         endif()
 
-        # Suppress unused argument for macOS universal build behavior
-        target_compile_options(${NAME}
-            PRIVATE
-                $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.1 -mpopcnt>
-                $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-command-line-argument>)
+        if (${IS_VENEER})
+            # Force SSE2 on AppleClang (normally SSE4.1 is the default)
+            target_compile_options(${NAME}
+                PRIVATE
+                    $<$<CXX_COMPILER_ID:AppleClang>:-msse2>
+                    $<$<CXX_COMPILER_ID:AppleClang>:-mno-sse4.1>
+                    $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-command-line-argument>)
+        else()
+            target_compile_options(${NAME}
+                PRIVATE
+                    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse4.1 -mpopcnt>
+                    $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-command-line-argument>)
+        endif()
 
     elseif((${ISA_SIMD} MATCHES "avx2") OR (${UNIVERSAL_BUILD} AND ${ISA_AVX2}))
         if(NOT ${UNIVERSAL_BUILD})
@@ -259,12 +269,20 @@ macro(astcenc_set_properties NAME)
                     ASTCENC_F16C=1)
         endif()
 
-        # Suppress unused argument for macOS universal build behavior
-        target_compile_options(${NAME}
-            PRIVATE
-                $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mavx2 -mpopcnt -mf16c>
-                $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>
-                $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-command-line-argument>)
+        if (${IS_VENEER})
+            # Force SSE2 on AppleClang (normally SSE4.1 is the default)
+            target_compile_options(${NAME}
+                PRIVATE
+                    $<$<CXX_COMPILER_ID:AppleClang>:-msse2>
+                    $<$<CXX_COMPILER_ID:AppleClang>:-mno-sse4.1>
+                    $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-command-line-argument>)
+        else()
+            target_compile_options(${NAME}
+                PRIVATE
+                    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mavx2 -mpopcnt -mf16c>
+                    $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>
+                    $<$<CXX_COMPILER_ID:AppleClang>:-Wno-unused-command-line-argument>)
+        endif()
 
         # Non-invariant builds enable us to loosen the compiler constraints on
         # floating point, but this is only worth doing on CPUs with AVX2 because
@@ -272,7 +290,7 @@ macro(astcenc_set_properties NAME)
         # which significantly improve performance. Note that this DOES reduce
         # image quality by up to 0.2 dB (normally much less), but buys an
         # average of 10-15% performance improvement ...
-        if(${NO_INVARIANCE})
+        if(${NO_INVARIANCE} AND NOT ${IS_VENEER})
             target_compile_options(${NAME}
                 PRIVATE
                     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mfma>)
@@ -309,16 +327,21 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
             COMPILE_FLAGS ${EXTERNAL_CXX_FLAGS})
 endif()
 
-astcenc_set_properties(${ASTC_TARGET}-static)
+astcenc_set_properties(${ASTC_TARGET}-static OFF)
 
     target_compile_options(${ASTC_TARGET}-static
         PRIVATE
             $<$<CXX_COMPILER_ID:MSVC>:/W4>)
 
 if(${CLI})
-    astcenc_set_properties(${ASTC_TARGET})
+    astcenc_set_properties(${ASTC_TARGET}-veneer ON)
+    astcenc_set_properties(${ASTC_TARGET} OFF)
 
     target_compile_options(${ASTC_TARGET}
+        PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/W3>)
+
+    target_compile_options(${ASTC_TARGET}-veneer
         PRIVATE
             $<$<CXX_COMPILER_ID:MSVC>:/W3>)
 

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020-2022 Arm Limited
+#  Copyright 2020-2023 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -57,6 +57,8 @@ target_include_directories(${ASTC_TARGET}-static
         $<INSTALL_INTERFACE:.>)
 
 if(${CLI})
+    # Veneer is compiled without any extended ISA so we can safely do
+    # ISA compatability checks without triggering a SIGILL
     add_library(${ASTC_TARGET}-veneer
         astcenccli_entry.cpp)
 


### PR DESCRIPTION
This PR moves the responsibility for the ISA compatibility checks out of the core library, and into the calling code. This avoids complicating the library build and link, given that for most practical usage the caller either knows it's safe or performs similar checks itself so it can `dlopen()` the correct library.

For the command line tool, the check has been moved into the CLI.

Fixes #384 