### PR TITLE
Fix: compare compiler not Visual Studio version.

### DIFF
--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -200,21 +200,21 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_IS_VENEER)
             PRIVATE
                 ASTCENC_NO_INVARIANCE=1)
 
-        # For Visual Studio prior to 2022 (compiler < 17.0) /fp:precise
-        # For Visual Studio 2022 (compiler >= 17.0) /fp:precise and /fp:contract
+        # For Visual Studio prior to 2022 (compiler < 19.30) /fp:precise
+        # For Visual Studio 2022 (compiler >= 19.30) /fp:precise and /fp:contract
         target_compile_options(${ASTCENC_TARGET_NAME}
             PRIVATE
                 $<$<CXX_COMPILER_ID:MSVC>:/fp:precise>
-                $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17>>:/fp:contract>
+                $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:contract>
                 $<$<AND:$<PLATFORM_ID:Linux,Darwin>,$<CXX_COMPILER_ID:${CLANG_LIKE}>>:-ffp-model=precise>
                 $<$<PLATFORM_ID:Linux,Darwin>:-ffp-contract=fast>)
     else()
-        # For Visual Studio prior to 2022 (compiler < 17.0) /fp:strict
-        # For Visual Studio 2022 (compiler >= 17.0) /fp:precise
+        # For Visual Studio prior to 2022 (compiler < 19.30) /fp:strict
+        # For Visual Studio 2022 (compiler >= 19.30) /fp:precise
         target_compile_options(${ASTCENC_TARGET_NAME}
             PRIVATE
-                $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,17>>:/fp:strict>
-                $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17>>:/fp:precise>
+                $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.30>>:/fp:strict>
+                $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:precise>
                 $<$<AND:$<PLATFORM_ID:Linux,Darwin>,$<CXX_COMPILER_ID:${CLANG_LIKE}>>:-ffp-model=precise>
                 $<$<PLATFORM_ID:Linux,Darwin>:-ffp-contract=off>)
     endif()


### PR DESCRIPTION
This is why KTX-Software's ASTC encoder tests are failing on Visual Studio 2019.