### PR TITLE
Only use -ffp-model on Clang 10 or higher

### DIFF
--- a/Docs/Building.md
+++ b/Docs/Building.md
@@ -229,7 +229,7 @@ cmake \
     -DANDROID_TOOLCHAIN=clang \
     -DANDROID_STL=c++_static \
     -DARCH=aarch64 \
-    -DISA_NEON=ON \
+    -DASTCENC_ISA_NEON=ON \
     ..
 
 make -j16

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -219,7 +219,7 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_IS_VENEER)
         # For Visual Studio prior to 2022 (compiler < 19.30) /fp:precise
         # For Visual Studio 2022 (compiler >= 19.30) /fp:precise and /fp:contract
 
-        # For Visual Studio 2022 ClangCL seems to have accidentially enabled contraction by default,
+        # For Visual Studio 2022 ClangCL seems to have accidentally enabled contraction by default,
         # so behaves differently to CL.exe. Use the -Xclang argument to workaround and allow access
         # GNU-style switch to control contraction on the assumption this gets fixed and disabled.
         # Note ClangCL does not accept /fp:contract as an argument as of v15.0.7.
@@ -229,13 +229,13 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_IS_VENEER)
                 $<${is_clangcl}:/fp:precise>
                 $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:contract>
                 $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.0>>:-Xclang -ffp-contract=fast>
-                $<${is_clang}:-ffp-model=precise>
+                $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-ffp-model=precise>
                 $<${is_gnu_fe}:-ffp-contract=fast>)
     else()
         # For Visual Studio prior to 2022 (compiler < 19.30) /fp:strict
         # For Visual Studio 2022 (compiler >= 19.30) /fp:precise
 
-        # For Visual Studio 2022 ClangCL seems to have accidentially enabled contraction by default,
+        # For Visual Studio 2022 ClangCL seems to have accidentally enabled contraction by default,
         # so behaves differently to CL.exe. Use the -Xclang argument to workaround and allow access
         # GNU-style switch to control contraction and force disable.
         target_compile_options(${ASTCENC_TARGET_NAME}
@@ -244,7 +244,7 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_IS_VENEER)
                 $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:precise>
                 $<${is_clangcl}:/fp:precise>
                 $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.0>>:-Xclang -ffp-contract=off>
-                $<${is_clang}:-ffp-model=precise>
+                $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-ffp-model=precise>
                 $<${is_gnu_fe}:-ffp-contract=off>)
     endif()
 


### PR DESCRIPTION
Fixes #419 