### PR TITLE
Reduce use of reinterpret_cast

### DIFF
--- a/Docs/ChangeLog-4x.md
+++ b/Docs/ChangeLog-4x.md
@@ -19,6 +19,8 @@ versions. We always recommend rebuilding your client-side code using the updated
 `astcenc.h` header.
 
 * **General:**
+  * **Bug-fix:** Reduced use of `reinterpret_cast` in the core codec to
+    avoid strict aliasing violations.
   * **Optimization:** `-medium` search quality no longer tests 4 partition
      encodings for block sizes between 25 and 83 texels (inclusive). This
      improves performance for a tiny drop in image quality.

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1755,17 +1755,17 @@ TEST(vint4, store_nbytes)
 	EXPECT_EQ(out, 42);
 }
 
-/** @brief Test vint8 store_lanes_masked. */
+/** @brief Test vint4 store_lanes_masked. */
 TEST(vint4, store_lanes_masked)
 {
-	int resulta[4] { 0 };
+	uint8_t resulta[16] { 0 };
 
 	// Store nothing
 	vmask4 mask1 = vint4(0) == vint4(1);
 	vint4 data1 = vint4(1);
 
 	store_lanes_masked(resulta, data1, mask1);
-	vint4 result1v(resulta);
+	vint4 result1v = vint4::load(resulta);
 	vint4 expect1v = vint4::zero();
 	EXPECT_TRUE(all(result1v == expect1v));
 
@@ -1774,7 +1774,7 @@ TEST(vint4, store_lanes_masked)
 	vint4 data2 = vint4(2);
 
 	store_lanes_masked(resulta, data2, mask2);
-	vint4 result2v(resulta);
+	vint4 result2v = vint4::load(resulta);
 	vint4 expect2v = vint4(2, 2, 0, 0);
 	EXPECT_TRUE(all(result2v == expect2v));
 
@@ -1783,22 +1783,22 @@ TEST(vint4, store_lanes_masked)
 	vint4 data3 = vint4(3);
 
 	store_lanes_masked(resulta, data3, mask3);
-	vint4 result3v(resulta);
+	vint4 result3v = vint4::load(resulta);
 	vint4 expect3v = vint4(3);
 	EXPECT_TRUE(all(result3v == expect3v));
 }
 
-/** @brief Test vint8 store_lanes_masked to unaligned address. */
+/** @brief Test vint4 store_lanes_masked to unaligned address. */
 TEST(vint4, store_lanes_masked_unaligned)
 {
-	int8_t resulta[17] { 0 };
+	uint8_t resulta[17] { 0 };
 
 	// Store nothing
 	vmask4 mask1 = vint4(0) == vint4(1);
 	vint4 data1 = vint4(1);
 
-	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data1, mask1);
-	vint4 result1v(reinterpret_cast<int*>(resulta + 1));
+	store_lanes_masked(resulta + 1, data1, mask1);
+	vint4 result1v = vint4::load(resulta + 1);
 	vint4 expect1v = vint4::zero();
 	EXPECT_TRUE(all(result1v == expect1v));
 
@@ -1806,8 +1806,8 @@ TEST(vint4, store_lanes_masked_unaligned)
 	vmask4 mask2 = vint4(1, 1, 0, 0) == vint4(1);
 	vint4 data2 = vint4(2);
 
-	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data2, mask2);
-	vint4 result2v(reinterpret_cast<int*>(resulta + 1));
+	store_lanes_masked(resulta + 1, data2, mask2);
+	vint4 result2v = vint4::load(resulta + 1);
 	vint4 expect2v = vint4(2, 2, 0, 0);
 	EXPECT_TRUE(all(result2v == expect2v));
 
@@ -1815,8 +1815,8 @@ TEST(vint4, store_lanes_masked_unaligned)
 	vmask4 mask3 = vint4(1) == vint4(1);
 	vint4 data3 = vint4(3);
 
-	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data3, mask3);
-	vint4 result3v(reinterpret_cast<int*>(resulta + 1));
+	store_lanes_masked(resulta + 1, data3, mask3);
+	vint4 result3v = vint4::load(resulta + 1);
 	vint4 expect3v = vint4(3);
 	EXPECT_TRUE(all(result3v == expect3v));
 }
@@ -3302,14 +3302,14 @@ TEST(vint8, store_nbytes)
 /** @brief Test vint8 store_lanes_masked. */
 TEST(vint8, store_lanes_masked)
 {
-	int resulta[8] { 0 };
+	uint8_t resulta[32] { 0 };
 
 	// Store nothing
 	vmask8 mask1 = vint8(0) == vint8(1);
 	vint8 data1 = vint8(1);
 
 	store_lanes_masked(resulta, data1, mask1);
-	vint8 result1v(resulta);
+	vint8 result1v = vint8::load(resulta);
 	vint8 expect1v = vint8::zero();
 	EXPECT_TRUE(all(result1v == expect1v));
 
@@ -3318,7 +3318,7 @@ TEST(vint8, store_lanes_masked)
 	vint8 data2 = vint8(2);
 
 	store_lanes_masked(resulta, data2, mask2);
-	vint8 result2v(resulta);
+	vint8 result2v = vint8::load(resulta);
 	vint8 expect2v = vint8(2, 2, 2, 2, 0, 0, 0, 0);
 	EXPECT_TRUE(all(result2v == expect2v));
 
@@ -3327,7 +3327,7 @@ TEST(vint8, store_lanes_masked)
 	vint8 data3 = vint8(3);
 
 	store_lanes_masked(resulta, data3, mask3);
-	vint8 result3v(resulta);
+	vint8 result3v = vint8::load(resulta);
 	vint8 expect3v = vint8(3);
 	EXPECT_TRUE(all(result3v == expect3v));
 }
@@ -3335,14 +3335,14 @@ TEST(vint8, store_lanes_masked)
 /** @brief Test vint8 store_lanes_masked to unaligned address. */
 TEST(vint8, store_lanes_masked_unaligned)
 {
-	int8_t resulta[33] { 0 };
+	uint8_t resulta[33] { 0 };
 
 	// Store nothing
 	vmask8 mask1 = vint8(0) == vint8(1);
 	vint8 data1 = vint8(1);
 
-	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data1, mask1);
-	vint8 result1v(reinterpret_cast<int*>(resulta + 1));
+	store_lanes_masked(resulta + 1, data1, mask1);
+	vint8 result1v = vint8::load(resulta + 1);
 	vint8 expect1v = vint8::zero();
 	EXPECT_TRUE(all(result1v == expect1v));
 
@@ -3350,8 +3350,8 @@ TEST(vint8, store_lanes_masked_unaligned)
 	vmask8 mask2 = vint8(1, 1, 1, 1, 0, 0, 0, 0) == vint8(1);
 	vint8 data2 = vint8(2);
 
-	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data2, mask2);
-	vint8 result2v(reinterpret_cast<int*>(resulta + 1));
+	store_lanes_masked(resulta + 1, data2, mask2);
+	vint8 result2v = vint8::load(resulta + 1);
 	vint8 expect2v = vint8(2, 2, 2, 2, 0, 0, 0, 0);
 	EXPECT_TRUE(all(result2v == expect2v));
 
@@ -3359,8 +3359,8 @@ TEST(vint8, store_lanes_masked_unaligned)
 	vmask8 mask3 = vint8(1) == vint8(1);
 	vint8 data3 = vint8(3);
 
-	store_lanes_masked(reinterpret_cast<int*>(resulta + 1), data3, mask3);
-	vint8 result3v(reinterpret_cast<int*>(resulta + 1));
+	store_lanes_masked(resulta + 1, data3, mask3);
+	vint8 result3v = vint8::load(resulta + 1);
 	vint8 expect3v = vint8(3);
 	EXPECT_TRUE(all(result3v == expect3v));
 }

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1163,7 +1163,7 @@ static float prepare_block_statistics(
 void compress_block(
 	const astcenc_contexti& ctx,
 	const image_block& blk,
-	physical_compressed_block& pcb,
+	uint8_t pcb[16],
 	compression_working_buffers& tmpbuf)
 {
 	astcenc_profile decode_mode = ctx.config.profile;

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -104,10 +104,10 @@ void unpack_weights(
 	if (!is_dual_plane)
 	{
 		// Build full 64-entry weight lookup table
-		vint4 tab0(reinterpret_cast<const int*>(scb.weights +  0));
-		vint4 tab1(reinterpret_cast<const int*>(scb.weights + 16));
-		vint4 tab2(reinterpret_cast<const int*>(scb.weights + 32));
-		vint4 tab3(reinterpret_cast<const int*>(scb.weights + 48));
+		vint4 tab0 = vint4::load(scb.weights +  0);
+		vint4 tab1 = vint4::load(scb.weights + 16);
+		vint4 tab2 = vint4::load(scb.weights + 32);
+		vint4 tab3 = vint4::load(scb.weights + 48);
 
 		vint tab0p, tab1p, tab2p, tab3p;
 		vtable_prepare(tab0, tab1, tab2, tab3, tab0p, tab1p, tab2p, tab3p);
@@ -134,14 +134,14 @@ void unpack_weights(
 	{
 		// Build a 32-entry weight lookup table per plane
 		// Plane 1
-		vint4 tab0_plane1(reinterpret_cast<const int*>(scb.weights +  0));
-		vint4 tab1_plane1(reinterpret_cast<const int*>(scb.weights + 16));
+		vint4 tab0_plane1 = vint4::load(scb.weights +  0);
+		vint4 tab1_plane1 = vint4::load(scb.weights + 16);
 		vint tab0_plane1p, tab1_plane1p;
 		vtable_prepare(tab0_plane1, tab1_plane1, tab0_plane1p, tab1_plane1p);
 
 		// Plane 2
-		vint4 tab0_plane2(reinterpret_cast<const int*>(scb.weights + 32));
-		vint4 tab1_plane2(reinterpret_cast<const int*>(scb.weights + 48));
+		vint4 tab0_plane2 = vint4::load(scb.weights + 32);
+		vint4 tab1_plane2 = vint4::load(scb.weights + 48);
 		vint tab0_plane2p, tab1_plane2p;
 		vtable_prepare(tab0_plane2, tab1_plane2, tab0_plane2p, tab1_plane2p);
 

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -914,8 +914,7 @@ static void compress_image(
 
 			int offset = ((z * yblocks + y) * xblocks + x) * 16;
 			uint8_t *bp = buffer + offset;
-			physical_compressed_block* pcb = reinterpret_cast<physical_compressed_block*>(bp);
-			compress_block(ctx, blk, *pcb, temp_buffers);
+			compress_block(ctx, blk, bp, temp_buffers);
 		}
 
 		ctxo.manage_compress.complete_task_assignment(count);
@@ -1182,10 +1181,9 @@ astcenc_error astcenc_decompress_image(
 			unsigned int offset = (((z * yblocks + y) * xblocks) + x) * 16;
 			const uint8_t* bp = data + offset;
 
-			const physical_compressed_block& pcb = *reinterpret_cast<const physical_compressed_block*>(bp);
 			symbolic_compressed_block scb;
 
-			physical_to_symbolic(*ctx->bsd, pcb, scb);
+			physical_to_symbolic(*ctx->bsd, bp, scb);
 
 			decompress_symbolic_block(ctx->config.profile, *ctx->bsd,
 			                          x * block_x, y * block_y, z * block_z,
@@ -1224,9 +1222,8 @@ astcenc_error astcenc_get_block_info(
 	astcenc_contexti* ctx = &ctxo->context;
 
 	// Decode the compressed data into a symbolic form
-	const physical_compressed_block&pcb = *reinterpret_cast<const physical_compressed_block*>(data);
 	symbolic_compressed_block scb;
-	physical_to_symbolic(*ctx->bsd, pcb, scb);
+	physical_to_symbolic(*ctx->bsd, data, scb);
 
 	// Fetch the appropriate partition and decimation tables
 	block_size_descriptor& bsd = *ctx->bsd;

--- a/Source/astcenc_ideal_endpoints_and_weights.cpp
+++ b/Source/astcenc_ideal_endpoints_and_weights.cpp
@@ -1023,7 +1023,7 @@ void compute_quantized_weights_for_decimation(
 	// safe data in compute_ideal_weights_for_decimation and arrays are always 64 elements
 	if (get_quant_level(quant_level) <= 16)
 	{
-		vint4 tab0(reinterpret_cast<const int*>(qat.quant_to_unquant));
+		vint4 tab0 = vint4::load(qat.quant_to_unquant);
 		vint tab0p;
 		vtable_prepare(tab0, tab0p);
 
@@ -1056,8 +1056,8 @@ void compute_quantized_weights_for_decimation(
 	}
 	else
 	{
-		vint4 tab0(reinterpret_cast<const int*>(qat.quant_to_unquant));
-		vint4 tab1(reinterpret_cast<const int*>(qat.quant_to_unquant + 16));
+		vint4 tab0 = vint4::load(qat.quant_to_unquant +  0);
+		vint4 tab1 = vint4::load(qat.quant_to_unquant + 16);
 		vint tab0p, tab1p;
 		vtable_prepare(tab0, tab1, tab0p, tab1p);
 

--- a/Source/astcenc_image.cpp
+++ b/Source/astcenc_image.cpp
@@ -433,7 +433,7 @@ void store_image_block(
 
 					vint data_rgbai = interleave_rgba8(data_ri, data_gi, data_bi, data_ai);
 					vmask store_mask = vint::lane_id() < vint(used_texels);
-					store_lanes_masked(reinterpret_cast<int*>(data8_row), data_rgbai, store_mask);
+					store_lanes_masked(data8_row, data_rgbai, store_mask);
 
 					data8_row += ASTCENC_SIMD_WIDTH * 4;
 					idx += used_texels;

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -1023,13 +1023,13 @@ struct dt_init_working_buffers
 struct quant_and_transfer_table
 {
 	/** @brief The unscrambled unquantized value. */
-	int8_t quant_to_unquant[32];
+	uint8_t quant_to_unquant[32];
 
 	/** @brief The scrambling order: scrambled_quant = map[unscrambled_quant]. */
-	int8_t scramble_map[32];
+	uint8_t scramble_map[32];
 
 	/** @brief The unscrambling order: unscrambled_unquant = map[scrambled_quant]. */
-	int8_t unscramble_and_unquant_map[32];
+	uint8_t unscramble_and_unquant_map[32];
 
 	/**
 	 * @brief A table of previous-and-next weights, indexed by the current unquantized value.

--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -1058,7 +1058,7 @@ static constexpr uint8_t SYM_BTYPE_NONCONST { 3 };
  * @brief A symbolic representation of a compressed block.
  *
  * The symbolic representation stores the unpacked content of a single
- * @c physical_compressed_block, in a form which is much easier to access for
+ * physical compressed block, in a form which is much easier to access for
  * the rest of the compressor code.
  */
 struct symbolic_compressed_block
@@ -1119,18 +1119,6 @@ struct symbolic_compressed_block
 		return this->quant_mode;
 	}
 };
-
-/**
- * @brief A physical representation of a compressed block.
- *
- * The physical representation stores the raw bytes of the format in memory.
- */
-struct physical_compressed_block
-{
-	/** @brief The ASTC encoded data for a single block. */
-	uint8_t data[16];
-};
-
 
 /**
  * @brief Parameter structure for @c compute_pixel_region_variance().
@@ -2033,7 +2021,7 @@ void compute_angular_endpoints_2planes(
 void compress_block(
 	const astcenc_contexti& ctx,
 	const image_block& blk,
-	physical_compressed_block& pcb,
+	uint8_t pcb[16],
 	compression_working_buffers& tmpbuf);
 
 /**
@@ -2126,12 +2114,12 @@ float compute_symbolic_block_difference_1plane_1partition(
  *
  * @param      bsd   The block size information.
  * @param      scb   The symbolic representation.
- * @param[out] pcb   The binary encoded data.
+ * @param[out] pcb   The physical compressed block output.
  */
 void symbolic_to_physical(
 	const block_size_descriptor& bsd,
 	const symbolic_compressed_block& scb,
-	physical_compressed_block& pcb);
+	uint8_t pcb[16]);
 
 /**
  * @brief Convert a binary physical encoding into a symbolic representation.
@@ -2140,12 +2128,12 @@ void symbolic_to_physical(
  * flagged as an error block if the encoding is invalid.
  *
  * @param      bsd   The block size information.
- * @param      pcb   The binary encoded data.
+ * @param      pcb   The physical compresesd block input.
  * @param[out] scb   The output symbolic representation.
  */
 void physical_to_symbolic(
 	const block_size_descriptor& bsd,
-	const physical_compressed_block& pcb,
+	const uint8_t pcb[16],
 	symbolic_compressed_block& scb);
 
 /* ============================================================================
@@ -2190,9 +2178,9 @@ template<typename T>
 void aligned_free(T* ptr)
 {
 #if defined(_WIN32)
-	_aligned_free(reinterpret_cast<void*>(ptr));
+	_aligned_free(ptr);
 #else
-	free(reinterpret_cast<void*>(ptr));
+	free(ptr);
 #endif
 }
 

--- a/Source/astcenc_symbolic_physical.cpp
+++ b/Source/astcenc_symbolic_physical.cpp
@@ -102,7 +102,7 @@ static inline void write_bits(
 void symbolic_to_physical(
 	const block_size_descriptor& bsd,
 	const symbolic_compressed_block& scb,
-	physical_compressed_block& pcb
+	uint8_t pcb[16]
 ) {
 	assert(scb.block_type != SYM_BTYPE_ERROR);
 
@@ -113,13 +113,13 @@ void symbolic_to_physical(
 		static const uint8_t cbytes[8] { 0xFC, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 		for (unsigned int i = 0; i < 8; i++)
 		{
-			pcb.data[i] = cbytes[i];
+			pcb[i] = cbytes[i];
 		}
 
 		for (unsigned int i = 0; i < BLOCK_MAX_COMPONENTS; i++)
 		{
-			pcb.data[2 * i + 8] = scb.constant_color[i] & 0xFF;
-			pcb.data[2 * i + 9] = (scb.constant_color[i] >> 8) & 0xFF;
+			pcb[2 * i + 8] = scb.constant_color[i] & 0xFF;
+			pcb[2 * i + 9] = (scb.constant_color[i] >> 8) & 0xFF;
 		}
 
 		return;
@@ -132,13 +132,13 @@ void symbolic_to_physical(
 		static const uint8_t cbytes[8]  { 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 		for (unsigned int i = 0; i < 8; i++)
 		{
-			pcb.data[i] = cbytes[i];
+			pcb[i] = cbytes[i];
 		}
 
 		for (unsigned int i = 0; i < BLOCK_MAX_COMPONENTS; i++)
 		{
-			pcb.data[2 * i + 8] = scb.constant_color[i] & 0xFF;
-			pcb.data[2 * i + 9] = (scb.constant_color[i] >> 8) & 0xFF;
+			pcb[2 * i + 8] = scb.constant_color[i] & 0xFF;
+			pcb[2 * i + 9] = (scb.constant_color[i] >> 8) & 0xFF;
 		}
 
 		return;
@@ -194,23 +194,23 @@ void symbolic_to_physical(
 
 	for (int i = 0; i < 16; i++)
 	{
-		pcb.data[i] = static_cast<uint8_t>(bitrev8(weightbuf[15 - i]));
+		pcb[i] = static_cast<uint8_t>(bitrev8(weightbuf[15 - i]));
 	}
 
-	write_bits(scb.block_mode, 11, 0, pcb.data);
-	write_bits(partition_count - 1, 2, 11, pcb.data);
+	write_bits(scb.block_mode, 11, 0, pcb);
+	write_bits(partition_count - 1, 2, 11, pcb);
 
 	int below_weights_pos = 128 - bits_for_weights;
 
 	// Encode partition index and color endpoint types for blocks with 2+ partitions
 	if (partition_count > 1)
 	{
-		write_bits(scb.partition_index, 6, 13, pcb.data);
-		write_bits(scb.partition_index >> 6, PARTITION_INDEX_BITS - 6, 19, pcb.data);
+		write_bits(scb.partition_index, 6, 13, pcb);
+		write_bits(scb.partition_index >> 6, PARTITION_INDEX_BITS - 6, 19, pcb);
 
 		if (scb.color_formats_matched)
 		{
-			write_bits(scb.color_formats[0] << 2, 6, 13 + PARTITION_INDEX_BITS, pcb.data);
+			write_bits(scb.color_formats[0] << 2, 6, 13 + PARTITION_INDEX_BITS, pcb);
 		}
 		else
 		{
@@ -249,20 +249,20 @@ void symbolic_to_physical(
 			int encoded_type_highpart = encoded_type >> 6;
 			int encoded_type_highpart_size = (3 * partition_count) - 4;
 			int encoded_type_highpart_pos = 128 - bits_for_weights - encoded_type_highpart_size;
-			write_bits(encoded_type_lowpart, 6, 13 + PARTITION_INDEX_BITS, pcb.data);
-			write_bits(encoded_type_highpart, encoded_type_highpart_size, encoded_type_highpart_pos, pcb.data);
+			write_bits(encoded_type_lowpart, 6, 13 + PARTITION_INDEX_BITS, pcb);
+			write_bits(encoded_type_highpart, encoded_type_highpart_size, encoded_type_highpart_pos, pcb);
 			below_weights_pos -= encoded_type_highpart_size;
 		}
 	}
 	else
 	{
-		write_bits(scb.color_formats[0], 4, 13, pcb.data);
+		write_bits(scb.color_formats[0], 4, 13, pcb);
 	}
 
 	// In dual-plane mode, encode the color component of the second plane of weights
 	if (is_dual_plane)
 	{
-		write_bits(scb.plane2_component, 2, below_weights_pos - 2, pcb.data);
+		write_bits(scb.plane2_component, 2, below_weights_pos - 2, pcb);
 	}
 
 	// Encode the color components
@@ -281,7 +281,7 @@ void symbolic_to_physical(
 		valuecount_to_encode += vals;
 	}
 
-	encode_ise(scb.get_color_quant_mode(), valuecount_to_encode, values_to_encode, pcb.data,
+	encode_ise(scb.get_color_quant_mode(), valuecount_to_encode, values_to_encode, pcb,
 	           scb.partition_count == 1 ? 17 : 19 + PARTITION_INDEX_BITS);
 }
 
@@ -290,7 +290,7 @@ void symbolic_to_physical(
 /* See header for documentation. */
 void physical_to_symbolic(
 	const block_size_descriptor& bsd,
-	const physical_compressed_block& pcb,
+	const uint8_t pcb[16],
 	symbolic_compressed_block& scb
 ) {
 	uint8_t bswapped[16];
@@ -298,7 +298,7 @@ void physical_to_symbolic(
 	scb.block_type = SYM_BTYPE_NONCONST;
 
 	// Extract header fields
-	int block_mode = read_bits(11, 0, pcb.data);
+	int block_mode = read_bits(11, 0, pcb);
 	if ((block_mode & 0x1FF) == 0x1FC)
 	{
 		// Constant color block
@@ -316,24 +316,24 @@ void physical_to_symbolic(
 		scb.partition_count = 0;
 		for (int i = 0; i < 4; i++)
 		{
-			scb.constant_color[i] = pcb.data[2 * i + 8] | (pcb.data[2 * i + 9] << 8);
+			scb.constant_color[i] = pcb[2 * i + 8] | (pcb[2 * i + 9] << 8);
 		}
 
 		// Additionally, check that the void-extent
 		if (bsd.zdim == 1)
 		{
 			// 2D void-extent
-			int rsvbits = read_bits(2, 10, pcb.data);
+			int rsvbits = read_bits(2, 10, pcb);
 			if (rsvbits != 3)
 			{
 				scb.block_type = SYM_BTYPE_ERROR;
 				return;
 			}
 
-			int vx_low_s = read_bits(8, 12, pcb.data) | (read_bits(5, 12 + 8, pcb.data) << 8);
-			int vx_high_s = read_bits(8, 25, pcb.data) | (read_bits(5, 25 + 8, pcb.data) << 8);
-			int vx_low_t = read_bits(8, 38, pcb.data) | (read_bits(5, 38 + 8, pcb.data) << 8);
-			int vx_high_t = read_bits(8, 51, pcb.data) | (read_bits(5, 51 + 8, pcb.data) << 8);
+			int vx_low_s = read_bits(8, 12, pcb) | (read_bits(5, 12 + 8, pcb) << 8);
+			int vx_high_s = read_bits(8, 25, pcb) | (read_bits(5, 25 + 8, pcb) << 8);
+			int vx_low_t = read_bits(8, 38, pcb) | (read_bits(5, 38 + 8, pcb) << 8);
+			int vx_high_t = read_bits(8, 51, pcb) | (read_bits(5, 51 + 8, pcb) << 8);
 
 			int all_ones = vx_low_s == 0x1FFF && vx_high_s == 0x1FFF && vx_low_t == 0x1FFF && vx_high_t == 0x1FFF;
 
@@ -346,12 +346,12 @@ void physical_to_symbolic(
 		else
 		{
 			// 3D void-extent
-			int vx_low_s = read_bits(9, 10, pcb.data);
-			int vx_high_s = read_bits(9, 19, pcb.data);
-			int vx_low_t = read_bits(9, 28, pcb.data);
-			int vx_high_t = read_bits(9, 37, pcb.data);
-			int vx_low_p = read_bits(9, 46, pcb.data);
-			int vx_high_p = read_bits(9, 55, pcb.data);
+			int vx_low_s = read_bits(9, 10, pcb);
+			int vx_high_s = read_bits(9, 19, pcb);
+			int vx_low_t = read_bits(9, 28, pcb);
+			int vx_high_t = read_bits(9, 37, pcb);
+			int vx_low_p = read_bits(9, 46, pcb);
+			int vx_high_p = read_bits(9, 55, pcb);
 
 			int all_ones = vx_low_s == 0x1FF && vx_high_s == 0x1FF && vx_low_t == 0x1FF && vx_high_t == 0x1FF && vx_low_p == 0x1FF && vx_high_p == 0x1FF;
 
@@ -383,7 +383,7 @@ void physical_to_symbolic(
 
 	int real_weight_count = is_dual_plane ? 2 * weight_count : weight_count;
 
-	int partition_count = read_bits(2, 11, pcb.data) + 1;
+	int partition_count = read_bits(2, 11, pcb) + 1;
 	promise(partition_count > 0);
 
 	scb.block_mode = static_cast<uint16_t>(block_mode);
@@ -391,7 +391,7 @@ void physical_to_symbolic(
 
 	for (int i = 0; i < 16; i++)
 	{
-		bswapped[i] = static_cast<uint8_t>(bitrev8(pcb.data[15 - i]));
+		bswapped[i] = static_cast<uint8_t>(bitrev8(pcb[15 - i]));
 	}
 
 	int bits_for_weights = get_ise_sequence_bitcount(real_weight_count, weight_quant_method);
@@ -432,14 +432,15 @@ void physical_to_symbolic(
 	int encoded_type_highpart_size = 0;
 	if (partition_count == 1)
 	{
-		color_formats[0] = read_bits(4, 13, pcb.data);
+		color_formats[0] = read_bits(4, 13, pcb);
 		scb.partition_index = 0;
 	}
 	else
 	{
 		encoded_type_highpart_size = (3 * partition_count) - 4;
 		below_weights_pos -= encoded_type_highpart_size;
-		int encoded_type = read_bits(6, 13 + PARTITION_INDEX_BITS, pcb.data) | (read_bits(encoded_type_highpart_size, below_weights_pos, pcb.data) << 6);
+		int encoded_type = read_bits(6, 13 + PARTITION_INDEX_BITS, pcb) |
+		                  (read_bits(encoded_type_highpart_size, below_weights_pos, pcb) << 6);
 		int baseclass = encoded_type & 0x3;
 		if (baseclass == 0)
 		{
@@ -469,7 +470,8 @@ void physical_to_symbolic(
 				bitpos += 2;
 			}
 		}
-		scb.partition_index = static_cast<uint16_t>(read_bits(6, 13, pcb.data) | (read_bits(PARTITION_INDEX_BITS - 6, 19, pcb.data) << 6));
+		scb.partition_index = static_cast<uint16_t>(read_bits(6, 13, pcb) |
+		                                            (read_bits(PARTITION_INDEX_BITS - 6, 19, pcb) << 6));
 	}
 
 	for (int i = 0; i < partition_count; i++)
@@ -515,7 +517,7 @@ void physical_to_symbolic(
 	scb.quant_mode = static_cast<quant_method>(color_quant_level);
 
 	uint8_t values_to_decode[32];
-	decode_ise(static_cast<quant_method>(color_quant_level), color_integer_count, pcb.data,
+	decode_ise(static_cast<quant_method>(color_quant_level), color_integer_count, pcb,
 	           values_to_decode, (partition_count == 1 ? 17 : 19 + PARTITION_INDEX_BITS));
 
 	int valuecount_to_decode = 0;
@@ -534,6 +536,6 @@ void physical_to_symbolic(
 	scb.plane2_component = -1;
 	if (is_dual_plane)
 	{
-		scb.plane2_component = static_cast<int8_t>(read_bits(2, below_weights_pos - 2, pcb.data));
+		scb.plane2_component = static_cast<int8_t>(read_bits(2, below_weights_pos - 2, pcb));
 	}
 }

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -242,6 +242,14 @@ struct vint8
 	}
 
 	/**
+	 * @brief Factory that returns a vector loaded from unaligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint8 load(const uint8_t* p)
+	{
+		return vint8(_mm256_lddqu_si256(reinterpret_cast<const __m256i*>(p)));
+	}
+
+	/**
 	 * @brief Factory that returns a vector loaded from 32B aligned memory.
 	 */
 	static ASTCENC_SIMD_INLINE vint8 loada(const int* p)

--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -1152,9 +1152,9 @@ ASTCENC_SIMD_INLINE vint8 interleave_rgba8(vint8 r, vint8 g, vint8 b, vint8 a)
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint8 data, vmask8 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(uint8_t* base, vint8 data, vmask8 mask)
 {
-	_mm256_maskstore_epi32(base, _mm256_castps_si256(mask.m), data.m);
+	_mm256_maskstore_epi32(reinterpret_cast<int*>(base), _mm256_castps_si256(mask.m), data.m);
 }
 
 /**

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -595,6 +595,14 @@ ASTCENC_SIMD_INLINE void store(vint4 a, int* p)
 }
 
 /**
+ * @brief Store a vector to an unaligned memory address.
+ */
+ASTCENC_SIMD_INLINE void store(vint4 a, uint8_t* p)
+{
+	std::memcpy(p, &a.m, sizeof(int) * 4);
+}
+
+/**
  * @brief Store lowest N (vector width) bytes into an unaligned address.
  */
 ASTCENC_SIMD_INLINE void store_nbytes(vint4 a, uint8_t* p)
@@ -1038,30 +1046,38 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
 }
 
 /**
+ * @brief Store a single vector lane to an unaligned address.
+ */
+ASTCENC_SIMD_INLINE void store_lane(uint8_t* base, int data)
+{
+	std::memcpy(base, &data, sizeof(int));
+}
+
+/**
  * @brief Store a vector, skipping masked lanes.
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(uint8_t* base, vint4 data, vmask4 mask)
 {
 	if (mask.lane<3>())
 	{
 		store(data, base);
 	}
-	else if (mask.lane<2>())
+	else if (mask.m[2])
 	{
-		base[0] = data.lane<0>();
-		base[1] = data.lane<1>();
-		base[2] = data.lane<2>();
+		store_lane(base + 0, data.lane<0>());
+		store_lane(base + 4, data.lane<1>());
+		store_lane(base + 8, data.lane<2>());
 	}
-	else if (mask.lane<1>())
+	else if (mask.m[1])
 	{
-		base[0] = data.lane<0>();
-		base[1] = data.lane<1>();
+		store_lane(base + 0, data.lane<0>());
+		store_lane(base + 4, data.lane<1>());
 	}
-	else if (mask.lane<0>())
+	else if (mask.m[0])
 	{
-		base[0] = data.lane<0>();
+		store_lane(base + 0, data.lane<0>());
 	}
 }
 

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -270,6 +270,16 @@ struct vint4
 	}
 
 	/**
+	 * @brief Factory that returns a vector loaded from unaligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 load(const uint8_t* p)
+	{
+		vint4 data;
+		std::memcpy(&data.m, p, 4 * sizeof(int));
+		return data;
+	}
+
+	/**
 	 * @brief Factory that returns a vector loaded from 16B aligned memory.
 	 */
 	static ASTCENC_SIMD_INLINE vint4 loada(const int* p)

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -1064,18 +1064,18 @@ ASTCENC_SIMD_INLINE void store_lanes_masked(uint8_t* base, vint4 data, vmask4 ma
 	{
 		store(data, base);
 	}
-	else if (mask.m[2])
+	else if (mask.lane<2>() != 0.0f)
 	{
 		store_lane(base + 0, data.lane<0>());
 		store_lane(base + 4, data.lane<1>());
 		store_lane(base + 8, data.lane<2>());
 	}
-	else if (mask.m[1])
+	else if (mask.lane<1>() != 0.0f)
 	{
 		store_lane(base + 0, data.lane<0>());
 		store_lane(base + 4, data.lane<1>());
 	}
-	else if (mask.m[0])
+	else if (mask.lane<0>() != 0.0f)
 	{
 		store_lane(base + 0, data.lane<0>());
 	}

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -276,6 +276,16 @@ struct vint4
 	}
 
 	/**
+	 * @brief Factory that returns a vector loaded from unaligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 load(const uint8_t* p)
+	{
+		vint4 data;
+		std::memcpy(&data.m, p, 4 * sizeof(int));
+		return data;
+	}
+
+	/**
 	 * @brief Factory that returns a vector loaded from 16B aligned memory.
 	 */
 	static ASTCENC_SIMD_INLINE vint4 loada(const int* p)

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -659,8 +659,7 @@ ASTCENC_SIMD_INLINE void store(vint4 a, int* p)
  */
 ASTCENC_SIMD_INLINE void store_nbytes(vint4 a, uint8_t* p)
 {
-	int* pi = reinterpret_cast<int*>(p);
-	*pi = a.m[0];
+	std::memcpy(p, a.m, sizeof(uint8_t) * 4);
 }
 
 /**

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -655,6 +655,14 @@ ASTCENC_SIMD_INLINE void store(vint4 a, int* p)
 }
 
 /**
+ * @brief Store a vector to an unaligned memory address.
+ */
+ASTCENC_SIMD_INLINE void store(vint4 a, uint8_t* p)
+{
+	std::memcpy(p, a.m, sizeof(int) * 4);
+}
+
+/**
  * @brief Store lowest N (vector width) bytes into an unaligned address.
  */
 ASTCENC_SIMD_INLINE void store_nbytes(vint4 a, uint8_t* p)
@@ -1152,11 +1160,20 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
 }
 
 /**
+ * @brief Store a single vector lane to an unaligned address.
+ */
+ASTCENC_SIMD_INLINE void store_lane(uint8_t* base, int data)
+{
+	std::memcpy(base, &data, sizeof(int));
+}
+
+/**
  * @brief Store a vector, skipping masked lanes.
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
+ * Input is a byte array of at least 4 bytes per unmasked entry.
  */
-ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(uint8_t* base, vint4 data, vmask4 mask)
 {
 	if (mask.m[3])
 	{
@@ -1164,18 +1181,18 @@ ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 	}
 	else if (mask.m[2])
 	{
-		base[0] = data.lane<0>();
-		base[1] = data.lane<1>();
-		base[2] = data.lane<2>();
+		store_lane(base + 0, data.lane<0>());
+		store_lane(base + 4, data.lane<1>());
+		store_lane(base + 8, data.lane<2>());
 	}
 	else if (mask.m[1])
 	{
-		base[0] = data.lane<0>();
-		base[1] = data.lane<1>();
+		store_lane(base + 0, data.lane<0>());
+		store_lane(base + 4, data.lane<1>());
 	}
 	else if (mask.m[0])
 	{
-		base[0] = data.lane<0>();
+		store_lane(base + 0, data.lane<0>());
 	}
 }
 

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -645,6 +645,14 @@ ASTCENC_SIMD_INLINE void store(vint4 a, int* p)
 }
 
 /**
+ * @brief Store a vector to an unaligned memory address.
+ */
+ASTCENC_SIMD_INLINE void store(vint4 a, uint8_t* p)
+{
+	std::memcpy(p, &a.m, sizeof(int) * 4);
+}
+
+/**
  * @brief Store lowest N (vector width) bytes into an unaligned address.
  */
 ASTCENC_SIMD_INLINE void store_nbytes(vint4 a, uint8_t* p)
@@ -1202,14 +1210,22 @@ ASTCENC_SIMD_INLINE vint4 interleave_rgba8(vint4 r, vint4 g, vint4 b, vint4 a)
 }
 
 /**
+ * @brief Store a single vector lane to an unaligned address.
+ */
+ASTCENC_SIMD_INLINE void store_lane(uint8_t* base, int data)
+{
+	std::memcpy(base, &data, sizeof(int));
+}
+
+/**
  * @brief Store a vector, skipping masked lanes.
  *
  * All masked lanes must be at the end of vector, after all non-masked lanes.
  */
-ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
+ASTCENC_SIMD_INLINE void store_lanes_masked(uint8_t* base, vint4 data, vmask4 mask)
 {
 #if ASTCENC_AVX >= 2
-	_mm_maskstore_epi32(base, _mm_castps_si128(mask.m), data.m);
+	_mm_maskstore_epi32(reinterpret_cast<int*>(base), _mm_castps_si128(mask.m), data.m);
 #else
 	// Note - we cannot use _mm_maskmoveu_si128 as the underlying hardware doesn't guarantee
 	// fault suppression on masked lanes so we can get page faults at the end of an image.
@@ -1217,20 +1233,20 @@ ASTCENC_SIMD_INLINE void store_lanes_masked(int* base, vint4 data, vmask4 mask)
 	{
 		store(data, base);
 	}
-	else if (mask.lane<2>() != 0.0f)
+	else if (mask.m[2])
 	{
-		base[0] = data.lane<0>();
-		base[1] = data.lane<1>();
-		base[2] = data.lane<2>();
+		store_lane(base + 0, data.lane<0>());
+		store_lane(base + 4, data.lane<1>());
+		store_lane(base + 8, data.lane<2>());
 	}
-	else if (mask.lane<1>() != 0.0f)
+	else if (mask.m[1])
 	{
-		base[0] = data.lane<0>();
-		base[1] = data.lane<1>();
+		store_lane(base + 0, data.lane<0>());
+		store_lane(base + 4, data.lane<1>());
 	}
-	else if (mask.lane<0>() != 0.0f)
+	else if (mask.m[0])
 	{
-		base[0] = data.lane<0>();
+		store_lane(base + 0, data.lane<0>());
 	}
 #endif
 }

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -39,6 +39,7 @@
 #endif
 
 #include <cstdio>
+#include <cstring>
 
 // ============================================================================
 // vfloat4 data type
@@ -290,6 +291,16 @@ struct vint4
 	static ASTCENC_SIMD_INLINE vint4 load1(const int* p)
 	{
 		return vint4(*p);
+	}
+
+	/**
+	 * @brief Factory that returns a vector loaded from unaligned memory.
+	 */
+	static ASTCENC_SIMD_INLINE vint4 load(const uint8_t* p)
+	{
+		vint4 data;
+		std::memcpy(&data.m, p, 4 * sizeof(int));
+		return data;
 	}
 
 	/**

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -298,9 +298,11 @@ struct vint4
 	 */
 	static ASTCENC_SIMD_INLINE vint4 load(const uint8_t* p)
 	{
-		vint4 data;
-		std::memcpy(&data.m, p, 4 * sizeof(int));
-		return data;
+#if ASTCENC_SSE >= 41
+		return vint4(_mm_lddqu_si128(reinterpret_cast<const __m128i*>(p)));
+#else
+		return vint4(_mm_loadu_si128(reinterpret_cast<const __m128i*>(p)));
+#endif
 	}
 
 	/**
@@ -1236,18 +1238,18 @@ ASTCENC_SIMD_INLINE void store_lanes_masked(uint8_t* base, vint4 data, vmask4 ma
 	{
 		store(data, base);
 	}
-	else if (mask.m[2])
+	else if (mask.lane<2>() != 0.0f)
 	{
 		store_lane(base + 0, data.lane<0>());
 		store_lane(base + 4, data.lane<1>());
 		store_lane(base + 8, data.lane<2>());
 	}
-	else if (mask.m[1])
+	else if (mask.lane<1>() != 0.0f)
 	{
 		store_lane(base + 0, data.lane<0>());
 		store_lane(base + 4, data.lane<1>());
 	}
-	else if (mask.m[0])
+	else if (mask.lane<0>() != 0.0f)
 	{
 		store_lane(base + 0, data.lane<0>());
 	}

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -1106,8 +1106,9 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 idx)
 	__m128i result = _mm_shuffle_epi8(t0.m, idxx);
 	return vint4(result);
 #else
-	alignas(ASTCENC_VECALIGN) uint8_t table[16];
-	storea(t0, reinterpret_cast<int*>(table +  0));
+	uint8_t table[16];
+
+	std::memcpy(table +  0, &t0.m, 4 * sizeof(int));
 
 	return vint4(table[idx.lane<0>()],
 	             table[idx.lane<1>()],
@@ -1133,9 +1134,10 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 idx)
 
 	return vint4(result);
 #else
-	alignas(ASTCENC_VECALIGN) uint8_t table[32];
-	storea(t0, reinterpret_cast<int*>(table +  0));
-	storea(t1, reinterpret_cast<int*>(table + 16));
+	uint8_t table[32];
+
+	std::memcpy(table +  0, &t0.m, 4 * sizeof(int));
+	std::memcpy(table + 16, &t1.m, 4 * sizeof(int));
 
 	return vint4(table[idx.lane<0>()],
 	             table[idx.lane<1>()],
@@ -1169,11 +1171,12 @@ ASTCENC_SIMD_INLINE vint4 vtable_8bt_32bi(vint4 t0, vint4 t1, vint4 t2, vint4 t3
 
 	return vint4(result);
 #else
-	alignas(ASTCENC_VECALIGN) uint8_t table[64];
-	storea(t0, reinterpret_cast<int*>(table +  0));
-	storea(t1, reinterpret_cast<int*>(table + 16));
-	storea(t2, reinterpret_cast<int*>(table + 32));
-	storea(t3, reinterpret_cast<int*>(table + 48));
+	uint8_t table[64];
+
+	std::memcpy(table +  0, &t0.m, 4 * sizeof(int));
+	std::memcpy(table + 16, &t1.m, 4 * sizeof(int));
+	std::memcpy(table + 32, &t2.m, 4 * sizeof(int));
+	std::memcpy(table + 48, &t3.m, 4 * sizeof(int));
 
 	return vint4(table[idx.lane<0>()],
 	             table[idx.lane<1>()],


### PR DESCRIPTION
This PR reduces use of `reinterpret_cast` in the core codec to minimize strict-aliasing violations. 

It is assumed that `reinterpret_cast` in the SIMD intrinsics headers are fine, as the types are tagged in the compiler implementation as "may alias".