### PR TITLE
Make unit tests more robust across different architectures

### DIFF
--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1969,10 +1969,17 @@ TEST(vint4, vtable_8bt_32bi_32entry)
 
 	vint4 result = vtable_8bt_32bi(table0p, table1p, index);
 
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	EXPECT_EQ(result.lane<0>(),  3);
 	EXPECT_EQ(result.lane<1>(),  4);
 	EXPECT_EQ(result.lane<2>(),  7);
 	EXPECT_EQ(result.lane<3>(), 28);
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	EXPECT_EQ(result.lane<0>(),  0);
+	EXPECT_EQ(result.lane<1>(),  7);
+	EXPECT_EQ(result.lane<2>(),  4);
+	EXPECT_EQ(result.lane<3>(), 31);
+#endif
 }
 
 /** @brief Test vint4 table permute. */
@@ -1990,10 +1997,17 @@ TEST(vint4, vtable_8bt_32bi_64entry)
 
 	vint4 result = vtable_8bt_32bi(table0p, table1p, table2p, table3p, index);
 
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	EXPECT_EQ(result.lane<0>(),  3);
 	EXPECT_EQ(result.lane<1>(),  4);
 	EXPECT_EQ(result.lane<2>(), 37);
 	EXPECT_EQ(result.lane<3>(), 60);
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	EXPECT_EQ(result.lane<0>(),  0);
+	EXPECT_EQ(result.lane<1>(),  7);
+	EXPECT_EQ(result.lane<2>(), 38);
+	EXPECT_EQ(result.lane<3>(), 63);
+#endif
 }
 
 /** @brief Test vint4 rgba byte interleave. */

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -423,10 +423,10 @@ TEST(vfloat4, vadd)
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	vfloat4 b(0.1f, 0.2f, 0.3f, 0.4f);
 	a = a + b;
-	EXPECT_EQ(a.lane<0>(), 1.0f + 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f + 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f + 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f + 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f + 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f + 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f + 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f + 0.4f);
 }
 
 /** @brief Test vfloat4 self-add. */
@@ -437,10 +437,10 @@ TEST(vfloat4, vselfadd1)
 
 	// Test increment by another variable
 	a += b;
-	EXPECT_EQ(a.lane<0>(), 1.0f + 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f + 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f + 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f + 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f + 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f + 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f + 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f + 0.4f);
 
 	// Test increment by an expression
 	a += b + b;
@@ -456,10 +456,10 @@ TEST(vfloat4, vsub)
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	vfloat4 b(0.1f, 0.2f, 0.3f, 0.4f);
 	a = a - b;
-	EXPECT_EQ(a.lane<0>(), 1.0f - 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f - 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f - 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f - 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f - 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f - 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f - 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f - 0.4f);
 }
 
 /** @brief Test vfloat4 mul. */
@@ -468,10 +468,10 @@ TEST(vfloat4, vmul)
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	vfloat4 b(0.1f, 0.2f, 0.3f, 0.4f);
 	a = a * b;
-	EXPECT_EQ(a.lane<0>(), 1.0f * 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f * 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f * 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f * 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f * 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f * 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f * 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f * 0.4f);
 }
 
 /** @brief Test vfloat4 mul. */
@@ -480,10 +480,10 @@ TEST(vfloat4, vsmul)
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	float b = 3.14f;
 	a = a * b;
-	EXPECT_EQ(a.lane<0>(), 1.0f * 3.14f);
-	EXPECT_EQ(a.lane<1>(), 2.0f * 3.14f);
-	EXPECT_EQ(a.lane<2>(), 3.0f * 3.14f);
-	EXPECT_EQ(a.lane<3>(), 4.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f * 3.14f);
 }
 
 /** @brief Test vfloat4 mul. */
@@ -492,10 +492,10 @@ TEST(vfloat4, svmul)
 	float a = 3.14f;
 	vfloat4 b(1.0f, 2.0f, 3.0f, 4.0f);
 	b = a * b;
-	EXPECT_EQ(b.lane<0>(), 3.14f * 1.0f);
-	EXPECT_EQ(b.lane<1>(), 3.14f * 2.0f);
-	EXPECT_EQ(b.lane<2>(), 3.14f * 3.0f);
-	EXPECT_EQ(b.lane<3>(), 3.14f * 4.0f);
+	EXPECT_FLOAT_EQ(b.lane<0>(), 3.14f * 1.0f);
+	EXPECT_FLOAT_EQ(b.lane<1>(), 3.14f * 2.0f);
+	EXPECT_FLOAT_EQ(b.lane<2>(), 3.14f * 3.0f);
+	EXPECT_FLOAT_EQ(b.lane<3>(), 3.14f * 4.0f);
 }
 
 /** @brief Test vfloat4 div. */
@@ -504,10 +504,10 @@ TEST(vfloat4, vdiv)
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	vfloat4 b(0.1f, 0.2f, 0.3f, 0.4f);
 	a = a / b;
-	EXPECT_EQ(a.lane<0>(), 1.0f / 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f / 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f / 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f / 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f / 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f / 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f / 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f / 0.4f);
 }
 
 /** @brief Test vfloat4 div. */
@@ -516,10 +516,10 @@ TEST(vfloat4, vsdiv)
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	float b = 0.3f;
 	a = a / b;
-	EXPECT_EQ(a.lane<0>(), 1.0f / 0.3f);
-	EXPECT_EQ(a.lane<1>(), 2.0f / 0.3f);
-	EXPECT_EQ(a.lane<2>(), 3.0f / 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f / 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f / 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f / 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f / 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f / 0.3f);
 }
 
 /** @brief Test vfloat4 div. */
@@ -528,10 +528,10 @@ TEST(vfloat4, svdiv)
 	float a = 3.0f;
 	vfloat4 b(0.1f, 0.2f, 0.3f, 0.4f);
 	b = a / b;
-	EXPECT_EQ(b.lane<0>(), 3.0f / 0.1f);
-	EXPECT_EQ(b.lane<1>(), 3.0f / 0.2f);
-	EXPECT_EQ(b.lane<2>(), 3.0f / 0.3f);
-	EXPECT_EQ(b.lane<3>(), 3.0f / 0.4f);
+	EXPECT_FLOAT_EQ(b.lane<0>(), 3.0f / 0.1f);
+	EXPECT_FLOAT_EQ(b.lane<1>(), 3.0f / 0.2f);
+	EXPECT_FLOAT_EQ(b.lane<2>(), 3.0f / 0.3f);
+	EXPECT_FLOAT_EQ(b.lane<3>(), 3.0f / 0.4f);
 }
 
 /** @brief Test vfloat4 ceq. */
@@ -860,10 +860,10 @@ TEST(vfloat4, sqrt)
 {
 	vfloat4 a(1.0f, 2.0f, 3.0f, 4.0f);
 	vfloat4 r = sqrt(a);
-	EXPECT_EQ(r.lane<0>(), std::sqrt(1.0f));
-	EXPECT_EQ(r.lane<1>(), std::sqrt(2.0f));
-	EXPECT_EQ(r.lane<2>(), std::sqrt(3.0f));
-	EXPECT_EQ(r.lane<3>(), std::sqrt(4.0f));
+	EXPECT_FLOAT_EQ(r.lane<0>(), std::sqrt(1.0f));
+	EXPECT_FLOAT_EQ(r.lane<1>(), std::sqrt(2.0f));
+	EXPECT_FLOAT_EQ(r.lane<2>(), std::sqrt(3.0f));
+	EXPECT_FLOAT_EQ(r.lane<3>(), std::sqrt(4.0f));
 }
 
 /** @brief Test vfloat4 select. */
@@ -957,10 +957,10 @@ TEST(vfloat4, dot)
 	vfloat4 a1(1.0f, 2.0f, 4.0f, 8.0f);
 	vfloat4 b1(1.0f, 0.5f, 0.25f, 0.125f);
 	vfloat4 r1 = dot(a1, b1);
-	EXPECT_EQ(r1.lane<0>(), 4.0f);
-	EXPECT_EQ(r1.lane<1>(), 4.0f);
-	EXPECT_EQ(r1.lane<2>(), 4.0f);
-	EXPECT_EQ(r1.lane<3>(), 4.0f);
+	EXPECT_FLOAT_EQ(r1.lane<0>(), 4.0f);
+	EXPECT_FLOAT_EQ(r1.lane<1>(), 4.0f);
+	EXPECT_FLOAT_EQ(r1.lane<2>(), 4.0f);
+	EXPECT_FLOAT_EQ(r1.lane<3>(), 4.0f);
 
 	// These values will fail to add to the same value if reassociated
 	float l0 =          141.2540435791015625f;
@@ -973,7 +973,10 @@ TEST(vfloat4, dot)
 	vfloat4 r2 = dot(a2, b2);
 
 	// Test that reassociation causes a failure with the numbers we chose
+    // Note: The i387 coprocessor makes this test fail
+#ifndef __i386__
 	EXPECT_FALSE(any(r2 == vfloat4(l0 + l1 + l2 + l3)));
+#endif
 
 	// Test that the sum works, for the association pattern we want used
 	EXPECT_TRUE(all(r2 == vfloat4((l0 + l2) + (l1 + l3))));
@@ -985,7 +988,7 @@ TEST(vfloat4, dot_s)
 	vfloat4 a1(1.0f, 2.0f, 4.0f, 8.0f);
 	vfloat4 b1(1.0f, 0.5f, 0.25f, 0.125f);
 	float r1 = dot_s(a1, b1);
-	EXPECT_EQ(r1, 4.0f);
+	EXPECT_FLOAT_EQ(r1, 4.0f);
 
 	// These values will fail to add to the same value if reassociated
 	float l0 =          141.2540435791015625f;
@@ -998,10 +1001,13 @@ TEST(vfloat4, dot_s)
 	float r2 = dot_s(a2, b2);
 
 	// Test that reassociation causes a failure with the numbers we chose
+    // Note: The i387 coprocessor makes this test fail
+#ifndef __i386__
 	EXPECT_NE(r2, l0 + l1 + l2 + l3);
+#endif
 
 	// Test that the sum works, for the association pattern we want used
-	EXPECT_EQ(r2, (l0 + l2) + (l1 + l3));
+	EXPECT_FLOAT_EQ(r2, (l0 + l2) + (l1 + l3));
 }
 
 /** @brief Test vfloat4 dot3. */
@@ -1010,10 +1016,10 @@ TEST(vfloat4, dot3)
 	vfloat4 a(1.0f, 2.0f, 4.0f, 8.0f);
 	vfloat4 b(1.0f, 0.5f, 0.25f, 0.125f);
 	vfloat4 r = dot3(a, b);
-	EXPECT_EQ(r.lane<0>(), 3.0f);
-	EXPECT_EQ(r.lane<1>(), 3.0f);
-	EXPECT_EQ(r.lane<2>(), 3.0f);
-	EXPECT_EQ(r.lane<3>(), 0.0f);
+	EXPECT_FLOAT_EQ(r.lane<0>(), 3.0f);
+	EXPECT_FLOAT_EQ(r.lane<1>(), 3.0f);
+	EXPECT_FLOAT_EQ(r.lane<2>(), 3.0f);
+	EXPECT_FLOAT_EQ(r.lane<3>(), 0.0f);
 }
 
 /** @brief Test vfloat4 dot3_s. */
@@ -1022,7 +1028,7 @@ TEST(vfloat4, dot3_s)
 	vfloat4 a(1.0f, 2.0f, 4.0f, 8.0f);
 	vfloat4 b(1.0f, 0.5f, 0.25f, 0.125f);
 	float r = dot3_s(a, b);
-	EXPECT_EQ(r, 3.0f);
+	EXPECT_FLOAT_EQ(r, 3.0f);
 }
 
 /** @brief Test vfloat4 normalize. */
@@ -2150,14 +2156,14 @@ TEST(vfloat8, vadd)
 	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
 	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
 	a = a + b;
-	EXPECT_EQ(a.lane<0>(), 1.0f + 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f + 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f + 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f + 0.4f);
-	EXPECT_EQ(a.lane<4>(), 5.0f + 0.5f);
-	EXPECT_EQ(a.lane<5>(), 6.0f + 0.6f);
-	EXPECT_EQ(a.lane<6>(), 7.0f + 0.7f);
-	EXPECT_EQ(a.lane<7>(), 8.0f + 0.8f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f + 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f + 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f + 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f + 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<4>(), 5.0f + 0.5f);
+	EXPECT_FLOAT_EQ(a.lane<5>(), 6.0f + 0.6f);
+	EXPECT_FLOAT_EQ(a.lane<6>(), 7.0f + 0.7f);
+	EXPECT_FLOAT_EQ(a.lane<7>(), 8.0f + 0.8f);
 }
 
 /** @brief Test vfloat8 sub. */
@@ -2166,14 +2172,14 @@ TEST(vfloat8, vsub)
 	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
 	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
 	a = a - b;
-	EXPECT_EQ(a.lane<0>(), 1.0f - 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f - 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f - 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f - 0.4f);
-	EXPECT_EQ(a.lane<4>(), 5.0f - 0.5f);
-	EXPECT_EQ(a.lane<5>(), 6.0f - 0.6f);
-	EXPECT_EQ(a.lane<6>(), 7.0f - 0.7f);
-	EXPECT_EQ(a.lane<7>(), 8.0f - 0.8f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f - 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f - 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f - 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f - 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<4>(), 5.0f - 0.5f);
+	EXPECT_FLOAT_EQ(a.lane<5>(), 6.0f - 0.6f);
+	EXPECT_FLOAT_EQ(a.lane<6>(), 7.0f - 0.7f);
+	EXPECT_FLOAT_EQ(a.lane<7>(), 8.0f - 0.8f);
 }
 
 /** @brief Test vfloat8 mul. */
@@ -2182,14 +2188,14 @@ TEST(vfloat8, vmul)
 	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
 	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
 	a = a * b;
-	EXPECT_EQ(a.lane<0>(), 1.0f * 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f * 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f * 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f * 0.4f);
-	EXPECT_EQ(a.lane<4>(), 5.0f * 0.5f);
-	EXPECT_EQ(a.lane<5>(), 6.0f * 0.6f);
-	EXPECT_EQ(a.lane<6>(), 7.0f * 0.7f);
-	EXPECT_EQ(a.lane<7>(), 8.0f * 0.8f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f * 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f * 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f * 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f * 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<4>(), 5.0f * 0.5f);
+	EXPECT_FLOAT_EQ(a.lane<5>(), 6.0f * 0.6f);
+	EXPECT_FLOAT_EQ(a.lane<6>(), 7.0f * 0.7f);
+	EXPECT_FLOAT_EQ(a.lane<7>(), 8.0f * 0.8f);
 }
 
 /** @brief Test vfloat8 mul. */
@@ -2198,14 +2204,14 @@ TEST(vfloat8, vsmul)
 	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
 	float b = 3.14f;
 	a = a * b;
-	EXPECT_EQ(a.lane<0>(), 1.0f * 3.14f);
-	EXPECT_EQ(a.lane<1>(), 2.0f * 3.14f);
-	EXPECT_EQ(a.lane<2>(), 3.0f * 3.14f);
-	EXPECT_EQ(a.lane<3>(), 4.0f * 3.14f);
-	EXPECT_EQ(a.lane<4>(), 5.0f * 3.14f);
-	EXPECT_EQ(a.lane<5>(), 6.0f * 3.14f);
-	EXPECT_EQ(a.lane<6>(), 7.0f * 3.14f);
-	EXPECT_EQ(a.lane<7>(), 8.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<4>(), 5.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<5>(), 6.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<6>(), 7.0f * 3.14f);
+	EXPECT_FLOAT_EQ(a.lane<7>(), 8.0f * 3.14f);
 }
 
 /** @brief Test vfloat8 mul. */
@@ -2214,14 +2220,14 @@ TEST(vfloat8, svmul)
 	float a = 3.14f;
 	vfloat8 b(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
 	b = a * b;
-	EXPECT_EQ(b.lane<0>(), 3.14f * 1.0f);
-	EXPECT_EQ(b.lane<1>(), 3.14f * 2.0f);
-	EXPECT_EQ(b.lane<2>(), 3.14f * 3.0f);
-	EXPECT_EQ(b.lane<3>(), 3.14f * 4.0f);
-	EXPECT_EQ(b.lane<4>(), 3.14f * 5.0f);
-	EXPECT_EQ(b.lane<5>(), 3.14f * 6.0f);
-	EXPECT_EQ(b.lane<6>(), 3.14f * 7.0f);
-	EXPECT_EQ(b.lane<7>(), 3.14f * 8.0f);
+	EXPECT_FLOAT_EQ(b.lane<0>(), 3.14f * 1.0f);
+	EXPECT_FLOAT_EQ(b.lane<1>(), 3.14f * 2.0f);
+	EXPECT_FLOAT_EQ(b.lane<2>(), 3.14f * 3.0f);
+	EXPECT_FLOAT_EQ(b.lane<3>(), 3.14f * 4.0f);
+	EXPECT_FLOAT_EQ(b.lane<4>(), 3.14f * 5.0f);
+	EXPECT_FLOAT_EQ(b.lane<5>(), 3.14f * 6.0f);
+	EXPECT_FLOAT_EQ(b.lane<6>(), 3.14f * 7.0f);
+	EXPECT_FLOAT_EQ(b.lane<7>(), 3.14f * 8.0f);
 }
 
 /** @brief Test vfloat8 div. */
@@ -2230,14 +2236,14 @@ TEST(vfloat8, vdiv)
 	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
 	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
 	a = a / b;
-	EXPECT_EQ(a.lane<0>(), 1.0f / 0.1f);
-	EXPECT_EQ(a.lane<1>(), 2.0f / 0.2f);
-	EXPECT_EQ(a.lane<2>(), 3.0f / 0.3f);
-	EXPECT_EQ(a.lane<3>(), 4.0f / 0.4f);
-	EXPECT_EQ(a.lane<4>(), 5.0f / 0.5f);
-	EXPECT_EQ(a.lane<5>(), 6.0f / 0.6f);
-	EXPECT_EQ(a.lane<6>(), 7.0f / 0.7f);
-	EXPECT_EQ(a.lane<7>(), 8.0f / 0.8f);
+	EXPECT_FLOAT_EQ(a.lane<0>(), 1.0f / 0.1f);
+	EXPECT_FLOAT_EQ(a.lane<1>(), 2.0f / 0.2f);
+	EXPECT_FLOAT_EQ(a.lane<2>(), 3.0f / 0.3f);
+	EXPECT_FLOAT_EQ(a.lane<3>(), 4.0f / 0.4f);
+	EXPECT_FLOAT_EQ(a.lane<4>(), 5.0f / 0.5f);
+	EXPECT_FLOAT_EQ(a.lane<5>(), 6.0f / 0.6f);
+	EXPECT_FLOAT_EQ(a.lane<6>(), 7.0f / 0.7f);
+	EXPECT_FLOAT_EQ(a.lane<7>(), 8.0f / 0.8f);
 }
 
 /** @brief Test vfloat8 div. */
@@ -2247,14 +2253,14 @@ TEST(vfloat8, vsdiv)
 	float b = 3.14f;
 	vfloat8 r = a / b;
 
-	EXPECT_EQ(r.lane<0>(), 0.1f / 3.14f);
-	EXPECT_EQ(r.lane<1>(), 0.2f / 3.14f);
-	EXPECT_EQ(r.lane<2>(), 0.3f / 3.14f);
-	EXPECT_EQ(r.lane<3>(), 0.4f / 3.14f);
-	EXPECT_EQ(r.lane<4>(), 0.5f / 3.14f);
-	EXPECT_EQ(r.lane<5>(), 0.6f / 3.14f);
-	EXPECT_EQ(r.lane<6>(), 0.7f / 3.14f);
-	EXPECT_EQ(r.lane<7>(), 0.8f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<0>(), 0.1f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<1>(), 0.2f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<2>(), 0.3f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<3>(), 0.4f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<4>(), 0.5f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<5>(), 0.6f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<6>(), 0.7f / 3.14f);
+	EXPECT_FLOAT_EQ(r.lane<7>(), 0.8f / 3.14f);
 }
 
 /** @brief Test vfloat8 div. */
@@ -2264,14 +2270,14 @@ TEST(vfloat8, svdiv)
 	vfloat8 b(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f);
 	vfloat8 r = a / b;
 
-	EXPECT_EQ(r.lane<0>(), 3.14f / 0.1f);
-	EXPECT_EQ(r.lane<1>(), 3.14f / 0.2f);
-	EXPECT_EQ(r.lane<2>(), 3.14f / 0.3f);
-	EXPECT_EQ(r.lane<3>(), 3.14f / 0.4f);
-	EXPECT_EQ(r.lane<4>(), 3.14f / 0.5f);
-	EXPECT_EQ(r.lane<5>(), 3.14f / 0.6f);
-	EXPECT_EQ(r.lane<6>(), 3.14f / 0.7f);
-	EXPECT_EQ(r.lane<7>(), 3.14f / 0.8f);
+	EXPECT_FLOAT_EQ(r.lane<0>(), 3.14f / 0.1f);
+	EXPECT_FLOAT_EQ(r.lane<1>(), 3.14f / 0.2f);
+	EXPECT_FLOAT_EQ(r.lane<2>(), 3.14f / 0.3f);
+	EXPECT_FLOAT_EQ(r.lane<3>(), 3.14f / 0.4f);
+	EXPECT_FLOAT_EQ(r.lane<4>(), 3.14f / 0.5f);
+	EXPECT_FLOAT_EQ(r.lane<5>(), 3.14f / 0.6f);
+	EXPECT_FLOAT_EQ(r.lane<6>(), 3.14f / 0.7f);
+	EXPECT_FLOAT_EQ(r.lane<7>(), 3.14f / 0.8f);
 }
 
 /** @brief Test vfloat8 ceq. */
@@ -2602,14 +2608,14 @@ TEST(vfloat8, sqrt)
 {
 	vfloat8 a(1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f);
 	vfloat8 r = sqrt(a);
-	EXPECT_EQ(r.lane<0>(), std::sqrt(1.0f));
-	EXPECT_EQ(r.lane<1>(), std::sqrt(2.0f));
-	EXPECT_EQ(r.lane<2>(), std::sqrt(3.0f));
-	EXPECT_EQ(r.lane<3>(), std::sqrt(4.0f));
-	EXPECT_EQ(r.lane<4>(), std::sqrt(1.0f));
-	EXPECT_EQ(r.lane<5>(), std::sqrt(2.0f));
-	EXPECT_EQ(r.lane<6>(), std::sqrt(3.0f));
-	EXPECT_EQ(r.lane<7>(), std::sqrt(4.0f));
+	EXPECT_FLOAT_EQ(r.lane<0>(), std::sqrt(1.0f));
+	EXPECT_FLOAT_EQ(r.lane<1>(), std::sqrt(2.0f));
+	EXPECT_FLOAT_EQ(r.lane<2>(), std::sqrt(3.0f));
+	EXPECT_FLOAT_EQ(r.lane<3>(), std::sqrt(4.0f));
+	EXPECT_FLOAT_EQ(r.lane<4>(), std::sqrt(1.0f));
+	EXPECT_FLOAT_EQ(r.lane<5>(), std::sqrt(2.0f));
+	EXPECT_FLOAT_EQ(r.lane<6>(), std::sqrt(3.0f));
+	EXPECT_FLOAT_EQ(r.lane<7>(), std::sqrt(4.0f));
 }
 
 /** @brief Test vfloat8 select. */


### PR DESCRIPTION
This PR deals with a few architectural idiosyncrasies that came up in Debian:

- The index lookups are sensitive to endianness
- Floating point equality comparisons are generally considered flaky, which is why GTest provides `EXPECT_FLOAT_EQ`. The i387 coprocessor with its internal 80 bit extended precision makes things especially awkward.
