### PR TITLE
Add missing <limits> include

### DIFF
--- a/Source/astcenc_internal.h
+++ b/Source/astcenc_internal.h
@@ -29,6 +29,7 @@
 	#include <cstdio>
 #endif
 #include <cstdlib>
+#include <limits>
 
 #include "astcenc.h"
 #include "astcenc_mathlib.h"


### PR DESCRIPTION
This fixes build errors with GCC-13