### PR TITLE
Add optional compression progress callback

### DIFF
--- a/Docs/ChangeLog-4x.md
+++ b/Docs/ChangeLog-4x.md
@@ -32,6 +32,11 @@ The 4.7.0 release is a maintenance release.
     is stored to an 8-bit per component file format. This option must be set
     maually for compression (`-c*`) tool operation, as the desired decode mode
     cannot be reliably determined.
+  * **Feature:** Library configuration supports a new optional progress
+    reporting callback to be specified. This is called during compression to
+    to allow interactive tooling use cases to display incremental progress. The
+    command line tool uses this feature to show compression progress unless
+    `-silent` is used.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 4.6.1

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2020-2023 Arm Limited
+// Copyright 2020-2024 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -305,6 +305,13 @@ enum astcenc_type
 };
 
 /**
+ * @brief Function pointer type for progress reporting callback.
+ *
+ * Callbacks are notified periodically with a percentage completion.
+ */
+extern "C" typedef void (*astcenc_progress_callback)(float);
+
+/**
  * @brief Enable normal map compression.
  *
  * Input data will be treated a two component normal map, storing X and Y, and the codec will
@@ -565,6 +572,14 @@ struct astcenc_config
 	 * search is enabled. This option is ineffective for 3D block sizes.
 	 */
 	float tune_search_mode0_enable;
+
+	/**
+	 * @brief The progress callback, can be @c nullptr.
+	 *
+	 * If this is specified the codec will peridocially report progress for
+	 * compression and decompression as a percentage between 0 and 100.
+	 */
+	astcenc_progress_callback progress_callback;
 
 #if defined(ASTCENC_DIAGNOSTICS)
 	/**

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -305,9 +305,7 @@ enum astcenc_type
 };
 
 /**
- * @brief Function pointer type for progress reporting callback.
- *
- * Callbacks are notified periodically with a percentage completion.
+ * @brief Function pointer type for compression progress reporting callback.
  */
 extern "C" typedef void (*astcenc_progress_callback)(float);
 
@@ -577,7 +575,9 @@ struct astcenc_config
 	 * @brief The progress callback, can be @c nullptr.
 	 *
 	 * If this is specified the codec will peridocially report progress for
-	 * compression and decompression as a percentage between 0 and 100.
+	 * compression as a percentage between 0 and 100. The callback is called from one
+	 * of the compressor threads, so doing significant work in the callback will
+	 * reduce compression performance.
 	 */
 	astcenc_progress_callback progress_callback;
 

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2023 Arm Limited
+// Copyright 2011-2024 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -830,7 +830,7 @@ static void compress_image(
 	auto& temp_buffers = ctx.working_buffers[thread_index];
 
 	// Only the first thread actually runs the initializer
-	ctxo.manage_compress.init(block_count);
+	ctxo.manage_compress.init(block_count, ctx.config.progress_callback);
 
 	// Determine if we can use an optimized load function
 	bool needs_swz = (swizzle.r != ASTCENC_SWZ_R) || (swizzle.g != ASTCENC_SWZ_G) ||
@@ -1155,6 +1155,7 @@ astcenc_error astcenc_decompress_image(
 	unsigned int xblocks = (image_out.dim_x + block_x - 1) / block_x;
 	unsigned int yblocks = (image_out.dim_y + block_y - 1) / block_y;
 	unsigned int zblocks = (image_out.dim_z + block_z - 1) / block_z;
+	unsigned int block_count = zblocks * yblocks * xblocks;
 
 	int row_blocks = xblocks;
 	int plane_blocks = xblocks * yblocks;
@@ -1179,7 +1180,7 @@ astcenc_error astcenc_decompress_image(
 	}
 
 	// Only the first thread actually runs the initializer
-	ctxo->manage_decompress.init(zblocks * yblocks * xblocks);
+	ctxo->manage_decompress.init(block_count, nullptr);
 
 	// All threads run this processing loop until there is no work remaining
 	while (true)

--- a/Source/astcenc_internal_entry.h
+++ b/Source/astcenc_internal_entry.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2022 Arm Limited
+// Copyright 2011-2024 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -118,6 +118,18 @@ private:
 	/** @brief Number of tasks that need to be processed. */
 	unsigned int m_task_count;
 
+	/** @brief Progress callback (optional). */
+	astcenc_progress_callback m_callback;
+
+	/** @brief Lock used for callback synchronization. */
+	std::mutex m_callback_lock;
+
+	/** @brief Minimum progress before making a callback. */
+	float m_callback_min_diff;
+
+	/** @brief Last progress callback value. */
+	float m_callback_last_value;
+
 public:
 	/** @brief Create a new ParallelManager. */
 	ParallelManager()
@@ -138,6 +150,8 @@ public:
 		m_start_count = 0;
 		m_done_count = 0;
 		m_task_count = 0;
+		m_callback_last_value = 0.0f;
+		m_callback_min_diff = 1.0f;
 	}
 
 	/**
@@ -166,14 +180,20 @@ public:
 	 * initialization. Other threads will block and wait for it to complete.
 	 *
 	 * @param task_count   Total number of tasks needing processing.
+	 * @param callback     Function pointer for progress status callbacks.
 	 */
-	void init(unsigned int task_count)
+	void init(unsigned int task_count, astcenc_progress_callback callback)
 	{
 		std::lock_guard<std::mutex> lck(m_lock);
 		if (!m_init_done)
 		{
+			m_callback = callback;
 			m_task_count = task_count;
 			m_init_done = true;
+
+			// Report every 1% or 4096 blocks, whichever is larger, to avoid callback overhead
+			float min_diff = (4096.0f / static_cast<float>(task_count)) * 100.0f;
+			m_callback_min_diff = astc::max(min_diff, 1.0f);
 		}
 	}
 
@@ -212,12 +232,49 @@ public:
 	{
 		// Note: m_done_count cannot use an atomic without the mutex; this has a race between the
 		// update here and the wait() for other threads
-		std::unique_lock<std::mutex> lck(m_lock);
-		this->m_done_count += count;
-		if (m_done_count == m_task_count)
+		unsigned int local_count;
+		float local_last_value;
 		{
-			lck.unlock();
-			m_complete.notify_all();
+			std::unique_lock<std::mutex> lck(m_lock);
+			m_done_count += count;
+			local_count = m_done_count;
+			local_last_value = m_callback_last_value;
+
+			if (m_done_count == m_task_count)
+			{
+				// Ensure the progress bar hits 100%
+				if (m_callback)
+				{
+					std::unique_lock<std::mutex> cblck(m_callback_lock);
+					m_callback(100.0f);
+					m_callback_last_value = 100.0f;
+				}
+
+				lck.unlock();
+				m_complete.notify_all();
+			}
+		}
+
+		// Process progress callback if we have one
+		if (m_callback)
+		{
+			// Initial lockless test - have we progressed enough to emit?
+			float num = static_cast<float>(local_count);
+			float den = static_cast<float>(m_task_count);
+			float this_value =  (num / den) * 100.0f;
+			bool report_test = (this_value - local_last_value) > m_callback_min_diff;
+
+			// Recheck under lock, because another thread might report first
+			if (report_test)
+			{
+				std::unique_lock<std::mutex> cblck(m_callback_lock);
+				bool report_retest = (this_value - m_callback_last_value) > m_callback_min_diff;
+				if (report_retest)
+				{
+					m_callback(this_value);
+					m_callback_last_value = this_value;
+				}
+			}
 		}
 	}
 

--- a/jenkins/nightly.Jenkinsfile
+++ b/jenkins/nightly.Jenkinsfile
@@ -204,6 +204,8 @@ pipeline {
                   cd build_rel_arm64
                   cmake -G "Visual Studio 17 2022" -A ARM64 -T ClangCL -DASTCENC_ISA_NEON=ON -DASTCENC_PACKAGE=arm64-clangcl ..
                   msbuild astcencoder.sln -property:Configuration=Release
+                  msbuild PACKAGE.vcxproj -property:Configuration=Release
+                  msbuild INSTALL.vcxproj -property:Configuration=Release
                 '''
               }
             }


### PR DESCRIPTION
This PR adds support for an optional progress reporting callback function, which is used by compression to report incremental progress as an image is processed.

The callback function is called by one of the compression threads, so doing any significant work in the callback function will slow down compression performance. E.g. emitting a progress message to stdout on a test machine slows down -fast compression by ~3%.

The command line compressor will emit a progress bar when called from a terminal, unless invoked with -silent.