### PR TITLE
Fix missing cast warning

### DIFF
--- a/Source/astcenc_find_best_partitioning.cpp
+++ b/Source/astcenc_find_best_partitioning.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2023 Arm Limited
+// Copyright 2011-2024 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/Source/astcenc_find_best_partitioning.cpp
+++ b/Source/astcenc_find_best_partitioning.cpp
@@ -425,8 +425,8 @@ static unsigned int get_partition_ordering_by_mismatch_bits(
 	}
 
 	// Create a running sum from the histogram array
-	// Cells store previous values only; i.e. exclude self after sum
-	unsigned int sum = 0;
+	// Indices store previous values only; i.e. exclude self after sum
+	uint16_t sum = 0;
 	for (unsigned int i = 0; i < texel_count; i++)
 	{
 		uint16_t cnt = mscount[i];


### PR DESCRIPTION
Avoid precision loss compiler warning on MSVC cl.exe.

Fixes #470 

