### PR TITLE
[DEBUGINFRA-1130] Only run static analysis and code signing in Arm-software org

### DIFF
--- a/.github/workflows/post_weekly_release.yaml
+++ b/.github/workflows/post_weekly_release.yaml
@@ -14,7 +14,9 @@ on:
 jobs:
 
   coverity:
-    if: ${{ !startsWith(github.event.ref, 'refs/tags/') }}
+    if: |
+      ${{ !startsWith(github.event.ref, 'refs/tags/') }} &&
+      github.repository_owner == 'Arm-software'
     name: Run Coverity Static Analysis
     runs-on: [self-hosted-ubuntu-latest-x64]
     steps:
@@ -209,6 +211,7 @@ jobs:
         shell: cmd
 
   sign-binaries:
+    if: github.repository_owner == 'Arm-software'
     name: Sign Windows and Mac
     runs-on: [self-hosted-ubuntu-latest-x64]
     needs: [build-macos, build-windows-msvc-ClangCL]
@@ -276,7 +279,9 @@ jobs:
             astcenc-macos-universal
 
   prepare-release:
-    if: ${{ startsWith(github.event.ref, 'refs/tags/') }}
+    if: |
+      ${{ startsWith(github.event.ref, 'refs/tags/') }} &&
+      github.repository_owner == "Arm-software"
     name: Prepare release
     runs-on: ubuntu-22.04
     needs: [sign-binaries, build-ubuntu]

--- a/.github/workflows/post_weekly_release.yaml
+++ b/.github/workflows/post_weekly_release.yaml
@@ -14,9 +14,7 @@ on:
 jobs:
 
   coverity:
-    if: |
-      ${{ !startsWith(github.event.ref, 'refs/tags/') }} &&
-      github.repository_owner == 'Arm-software'
+    if: ${{ (!startsWith(github.event.ref, 'refs/tags/')) && (github.repository_owner == 'Arm-software') }}
     name: Run Coverity Static Analysis
     runs-on: [self-hosted-ubuntu-latest-x64]
     steps:
@@ -279,9 +277,7 @@ jobs:
             astcenc-macos-universal
 
   prepare-release:
-    if: |
-      ${{ startsWith(github.event.ref, 'refs/tags/') }} &&
-      github.repository_owner == "Arm-software"
+    if: ${{ (startsWith(github.event.ref, 'refs/tags/')) && (github.repository_owner == 'Arm-software') }}
     name: Prepare release
     runs-on: ubuntu-22.04
     needs: [sign-binaries, build-ubuntu]


### PR DESCRIPTION
Prevent forked repositories attempting to run static analysis and code signing.