### PR TITLE
A faster NEON vmask any() and all()

### DIFF
--- a/Source/astcenc_vecmathlib_common_4.h
+++ b/Source/astcenc_vecmathlib_common_4.h
@@ -33,26 +33,6 @@
 #include <cstdio>
 
 // ============================================================================
-// vmask4 operators and functions
-// ============================================================================
-
-/**
- * @brief True if any lanes are enabled, false otherwise.
- */
-ASTCENC_SIMD_INLINE bool any(vmask4 a)
-{
-	return mask(a) != 0;
-}
-
-/**
- * @brief True if all lanes are enabled, false otherwise.
- */
-ASTCENC_SIMD_INLINE bool all(vmask4 a)
-{
-	return mask(a) == 0xF;
-}
-
-// ============================================================================
 // vint4 operators and functions
 // ============================================================================
 

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2019-2023 Arm Limited
+// Copyright 2019-2024 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -411,6 +411,22 @@ ASTCENC_SIMD_INLINE unsigned int mask(vmask4 a)
 	return vaddvq_u32(vshlq_u32(tmp, shift));
 }
 
+/**
+ * @brief True if any lanes are enabled, false otherwise.
+ */
+ASTCENC_SIMD_INLINE bool any(vmask4 a)
+{
+	return vmaxvq_u32(a.m) != 0;
+}
+
+/**
+ * @brief True if all lanes are enabled, false otherwise.
+ */
+ASTCENC_SIMD_INLINE bool all(vmask4 a)
+{
+	return vminvq_u32(a.m) != 0;
+}
+
 // ============================================================================
 // vint4 operators and functions
 // ============================================================================

--- a/Source/astcenc_vecmathlib_none_4.h
+++ b/Source/astcenc_vecmathlib_none_4.h
@@ -418,6 +418,22 @@ ASTCENC_SIMD_INLINE unsigned int mask(vmask4 a)
 	       ((a.m[3] >> 28) & 0x8);
 }
 
+/**
+ * @brief True if any lanes are enabled, false otherwise.
+ */
+ASTCENC_SIMD_INLINE bool any(vmask4 a)
+{
+	return mask(a) != 0;
+}
+
+/**
+ * @brief True if all lanes are enabled, false otherwise.
+ */
+ASTCENC_SIMD_INLINE bool all(vmask4 a)
+{
+	return mask(a) == 0xF;
+}
+
 // ============================================================================
 // vint4 operators and functions
 // ============================================================================

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -428,6 +428,22 @@ ASTCENC_SIMD_INLINE unsigned int mask(vmask4 a)
 	return static_cast<unsigned int>(_mm_movemask_ps(a.m));
 }
 
+/**
+ * @brief True if any lanes are enabled, false otherwise.
+ */
+ASTCENC_SIMD_INLINE bool any(vmask4 a)
+{
+	return mask(a) != 0;
+}
+
+/**
+ * @brief True if all lanes are enabled, false otherwise.
+ */
+ASTCENC_SIMD_INLINE bool all(vmask4 a)
+{
+	return mask(a) == 0xF;
+}
+
 // ============================================================================
 // vint4 operators and functions
 // ============================================================================


### PR DESCRIPTION
This PR changes the NEON implementation of the any() and all() vmask functions to use simple horizontal min/max operations, rather than a test against a specific mask bit pattern, which NEON does not support natively.

Performance impact on Apple M1:
* A 350 byte reduction in binary size.
* A 0.3% improvement to encode performance (Kodak -medium).
* A 5% improvement to decode performance.

Fixes #482 