### PR TITLE
Add more tests to GitHub Actions

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,5 +1,5 @@
 name: Build and test
-run-name: Build and test \#${{ github.event.number }}
+run-name: Build and test PR${{ github.event.number }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,5 +1,5 @@
-name: build-test
-run-name: Build and test
+name: Build and test
+run-name: Build and test ${{ github.event.number }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -64,7 +64,7 @@ jobs:
         run: ctest
         working-directory: build_rel
 
-  build-macos:
+  build-macos-x64:
     name: Build and test on MacOS
     runs-on: macos-12
     steps:
@@ -87,10 +87,47 @@ jobs:
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DASTCENC_UNIVERSAL_BUILD=OFF -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON ..
           make -j4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Python Tests
+        run: |
+          python ./Test/astc_test_image.py --test-set Small --test-quality medium
+
+  build-macos-arm64:
+    name: Build and test on MacOS
+    runs-on: macos-14-arm64
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Build R
+        run: |
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNIVERSAL_BUILD=ON -DASTCENC_PACKAGE=x64 ..
+          make install package -j4
+
+      - name: Build D
+        run: |
+          mkdir build_dbg
+          cd build_dbg
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DASTCENC_UNIVERSAL_BUILD=ON ..
+          make -j4
+
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
-          name: astcenc-macos-x64
+          name: astcenc-macos-universal
           path: |
             build_rel/*.zip
             build_rel/*.zip.sha256
@@ -107,7 +144,7 @@ jobs:
 
       - name: Python Tests
         run: |
-          python ./Test/astc_test_image.py --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --encoder=universal --test-set Small --test-quality medium
 
   build-windows-msvc:
     name: Build and test on Windows MSVC

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -149,8 +149,8 @@ jobs:
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
 
-  build-macos-arm64-clang:
-    name: Build and test on MacOS arm64 Clang
+  build-macos-universal-clang:
+    name: Build and test on MacOS universal Clang
     runs-on: macos-14
     steps:
       - name: Git checkout

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-ubuntu-x64-clang:
-    name: Build and test on Ubuntu x64 Clang
+    name: Ubuntu x64 Clang
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Build R
+      - name: Build release
         run: |
           export CXX=clang++
           mkdir build_rel
@@ -25,7 +25,7 @@ jobs:
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
-      - name: Build D
+      - name: Build debug
         run: |
           export CXX=clang++
           mkdir build_dbg
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_functional.py --encoder=none
           python ./Test/astc_test_functional.py --encoder=sse2
@@ -60,12 +60,12 @@ jobs:
           python ./Test/astc_test_image.py --encoder=none --test-set Small --test-quality medium
           python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small --test-quality medium
 
-      - name: Unit tests
+      - name: Run unit tests
         run: ctest
         working-directory: build_rel
 
   build-ubuntu-x64-gcc:
-    name: Build and test on Ubuntu x64 GCC
+    name: Ubuntu x64 GCC
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
@@ -73,7 +73,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Build R
+      - name: Build release
         run: |
           export CXX=g++
           mkdir build_rel
@@ -81,7 +81,7 @@ jobs:
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
-      - name: Build D
+      - name: Build debug
         run: |
           export CXX=g++
           mkdir build_dbg
@@ -108,12 +108,12 @@ jobs:
           python ./Test/astc_test_image.py --encoder=none --test-set Small --test-quality medium
           python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small --test-quality medium
 
-      - name: Unit tests
+      - name: Run unit tests
         run: ctest
         working-directory: build_rel
 
   build-macos-x64-clang:
-    name: Build and test on MacOS x64 Clang
+    name: macOS x64 Clang
     runs-on: macos-12
     steps:
       - name: Git checkout
@@ -121,14 +121,14 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Build R
+      - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNIVERSAL_BUILD=OFF -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
-      - name: Build D
+      - name: Build debug
         run: |
           mkdir build_dbg
           cd build_dbg
@@ -145,12 +145,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
 
   build-macos-universal-clang:
-    name: Build and test on MacOS universal Clang
+    name: macOS universal Clang
     runs-on: macos-14
     steps:
       - name: Git checkout
@@ -158,14 +158,14 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Build R
+      - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNIVERSAL_BUILD=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
-      - name: Build D
+      - name: Build debug
         run: |
           mkdir build_dbg
           cd build_dbg
@@ -190,12 +190,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_image.py --encoder=universal --test-set Small --test-quality medium
 
   build-windows-x64-msvc:
-    name: Build and test on Windows x64 MSVC
+    name: Windows x64 MSVC
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -206,7 +206,7 @@ jobs:
       - name: Setup Visual Studio x86_6
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Build R
+      - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
@@ -214,7 +214,7 @@ jobs:
           nmake install package
         shell: cmd
 
-      - name: Build D
+      - name: Build debug
         run: |
           mkdir build_dbg
           cd build_dbg
@@ -233,13 +233,13 @@ jobs:
           pip install numpy Pillow
         shell: cmd
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
         shell: cmd
 
   build-windows-x64-clangcl:
-    name: Build and test on Windows x64 ClangCL
+    name: Windows x64 ClangCL
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -250,7 +250,7 @@ jobs:
       - name: Setup Visual Studio x86_6
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Build R
+      - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
@@ -260,7 +260,7 @@ jobs:
           msbuild INSTALL.vcxproj -property:Configuration=Release
         shell: cmd
 
-      - name: Build D
+      - name: Build debug
         run: |
           mkdir build_dbg
           cd build_dbg
@@ -287,13 +287,13 @@ jobs:
           pip install numpy Pillow
         shell: cmd
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
         shell: cmd
 
   build-windows-arm64-clangcl:
-    name: Build and test on Windows arm64 ClangCL
+    name: Windows arm64 ClangCL
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -306,7 +306,7 @@ jobs:
         with:
           arch: x86_arm64
 
-      - name: Build R
+      - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
@@ -316,7 +316,7 @@ jobs:
           msbuild INSTALL.vcxproj -property:Configuration=Release
         shell: cmd
 
-      - name: Build D
+      - name: Build debug
         run: |
           mkdir build_dbg
           cd build_dbg

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -151,7 +151,7 @@ jobs:
 
   build-macos-arm64-clang:
     name: Build and test on MacOS arm64 Clang
-    runs-on: macos-14-arm64
+    runs-on: macos-14
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -57,8 +57,8 @@ jobs:
           python ./Test/astc_test_functional.py --encoder=sse2
           python ./Test/astc_test_functional.py --encoder=sse4.1
           python ./Test/astc_test_functional.py --encoder=avx2
-          python ./Test/astc_test_image.py --encoder=none --test-set Small --test-quality medium
-          python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --encoder=none --test-set Small
+          python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small
 
       - name: Run unit tests
         run: ctest
@@ -105,8 +105,8 @@ jobs:
           python ./Test/astc_test_functional.py --encoder=sse2
           python ./Test/astc_test_functional.py --encoder=sse4.1
           python ./Test/astc_test_functional.py --encoder=avx2
-          python ./Test/astc_test_image.py --encoder=none --test-set Small --test-quality medium
-          python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --encoder=none --test-set Small
+          python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small
 
       - name: Run unit tests
         run: ctest
@@ -147,7 +147,7 @@ jobs:
 
       - name: Run system tests
         run: |
-          python ./Test/astc_test_image.py --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --test-set Small
 
   build-macos-universal-clang:
     name: macOS universal Clang
@@ -192,7 +192,7 @@ jobs:
 
       - name: Run system tests
         run: |
-          python ./Test/astc_test_image.py --encoder=universal --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --encoder=universal --test-set Small
 
   build-windows-x64-msvc:
     name: Windows x64 MSVC
@@ -235,7 +235,7 @@ jobs:
 
       - name: Run system tests
         run: |
-          python ./Test/astc_test_image.py --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --test-set Small
         shell: cmd
 
   build-windows-x64-clangcl:
@@ -289,7 +289,7 @@ jobs:
 
       - name: Run system tests
         run: |
-          python ./Test/astc_test_image.py --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --test-set Small
         shell: cmd
 
   build-windows-arm64-clangcl:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,5 +1,5 @@
 name: Build and test
-run-name: Build and test ${{ github.event.number }}
+run-name: Build and test \#${{ github.event.number }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -8,8 +8,8 @@ on:
       - main
 
 jobs:
-  build-ubuntu:
-    name: Build and test on Ubuntu
+  build-ubuntu-x64-clang:
+    name: Build and test on Ubuntu x64 Clang
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_functional.py --encoder=none
           python ./Test/astc_test_functional.py --encoder=sse2
@@ -60,12 +60,60 @@ jobs:
           python ./Test/astc_test_image.py --encoder=none --test-set Small --test-quality medium
           python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small --test-quality medium
 
-      - name: ctest
+      - name: Unit tests
         run: ctest
         working-directory: build_rel
 
-  build-macos-x64:
-    name: Build and test on MacOS x64
+  build-ubuntu-x64-gcc:
+    name: Build and test on Ubuntu x64 GCC
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Build R
+        run: |
+          export CXX=g++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
+          make install package -j4
+
+      - name: Build D
+        run: |
+          export CXX=g++
+          mkdir build_dbg
+          cd build_dbg
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON ..
+          make -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Python rests
+        run: |
+          python ./Test/astc_test_functional.py --encoder=none
+          python ./Test/astc_test_functional.py --encoder=sse2
+          python ./Test/astc_test_functional.py --encoder=sse4.1
+          python ./Test/astc_test_functional.py --encoder=avx2
+          python ./Test/astc_test_image.py --encoder=none --test-set Small --test-quality medium
+          python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small --test-quality medium
+
+      - name: Unit tests
+        run: ctest
+        working-directory: build_rel
+
+  build-macos-x64-clang:
+    name: Build and test on MacOS x64 Clang
     runs-on: macos-12
     steps:
       - name: Git checkout
@@ -97,12 +145,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
 
-  build-macos-arm64:
-    name: Build and test on MacOS arm64
+  build-macos-arm64-clang:
+    name: Build and test on MacOS arm64 Clang
     runs-on: macos-14-arm64
     steps:
       - name: Git checkout
@@ -142,12 +190,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_image.py --encoder=universal --test-set Small --test-quality medium
 
-  build-windows-msvc:
-    name: Build and test on Windows MSVC
+  build-windows-x64-msvc:
+    name: Build and test on Windows x64 MSVC
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -157,13 +205,15 @@ jobs:
 
       - name: Setup Visual Studio x86_6
         uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build R
         run: |
           mkdir build_rel
           cd build_rel
-          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64-cl ..
+          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           nmake install package
         shell: cmd
+
       - name: Build D
         run: |
           mkdir build_dbg
@@ -171,12 +221,6 @@ jobs:
           cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Debug -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON ..
           nmake
         shell: cmd
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: astcenc-windows-x64-cl
-          path: build_rel/*.zip
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -189,13 +233,13 @@ jobs:
           pip install numpy Pillow
         shell: cmd
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
         shell: cmd
 
-  build-windows-ClangCL:
-    name: Build and test on Windows ClangCL
+  build-windows-x64-clangcl:
+    name: Build and test on Windows x64 ClangCL
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -205,15 +249,17 @@ jobs:
 
       - name: Setup Visual Studio x86_6
         uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build R
         run: |
           mkdir build_rel
           cd build_rel
-          cmake -G "Visual Studio 17 2022" -T ClangCL -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64-clangcl ..
+          cmake -G "Visual Studio 17 2022" -T ClangCL -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           msbuild astcencoder.sln -property:Configuration=Release
           msbuild PACKAGE.vcxproj -property:Configuration=Release
           msbuild INSTALL.vcxproj -property:Configuration=Release
         shell: cmd
+
       - name: Build D
         run: |
           mkdir build_dbg
@@ -222,31 +268,10 @@ jobs:
           msbuild astcencoder.sln -property:Configuration=Debug
         shell: cmd
 
-      - name: Setup Visual Studio arm64
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x86_arm64
-      - name: Build R
-        run: |
-          mkdir build_rel_arm64
-          cd build_rel_arm64
-          cmake -G "Visual Studio 17 2022" -A ARM64 -T ClangCL -DASTCENC_ISA_NEON=ON -DASTCENC_PACKAGE=arm64-clangcl ..
-          msbuild astcencoder.sln -property:Configuration=Release
-          msbuild PACKAGE.vcxproj -property:Configuration=Release
-          msbuild INSTALL.vcxproj -property:Configuration=Release
-        shell: cmd
-      - name: Build D
-        run: |
-          mkdir build_dbg_arm64
-          cd build_dbg_arm64
-          cmake -G "Visual Studio 17 2022" -A ARM64 -T ClangCL -DASTCENC_ISA_NEON=ON ..
-          msbuild astcencoder.sln -property:Configuration=Debug
-        shell: cmd
-
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
-          name: astcenc-windows-multi-clangcl
+          name: astcenc-windows-x64
           path: |
             build_rel/*.zip
             build_rel_arm64/*.zip
@@ -262,7 +287,46 @@ jobs:
           pip install numpy Pillow
         shell: cmd
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
         shell: cmd
+
+  build-windows-arm64-clangcl:
+    name: Build and test on Windows arm64 ClangCL
+    runs-on: windows-2022
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Setup Visual Studio arm64
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86_arm64
+
+      - name: Build R
+        run: |
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Visual Studio 17 2022" -A ARM64 -T ClangCL -DASTCENC_ISA_NEON=ON -DASTCENC_PACKAGE=arm64-clangcl ..
+          msbuild astcencoder.sln -property:Configuration=Release
+          msbuild PACKAGE.vcxproj -property:Configuration=Release
+          msbuild INSTALL.vcxproj -property:Configuration=Release
+        shell: cmd
+
+      - name: Build D
+        run: |
+          mkdir build_dbg
+          cd build_dbg
+          cmake -G "Visual Studio 17 2022" -A ARM64 -T ClangCL -DASTCENC_ISA_NEON=ON ..
+          msbuild astcencoder.sln -property:Configuration=Debug
+        shell: cmd
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: astcenc-windows-arm64
+          path: |
+            build_rel/*.zip

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -65,7 +65,7 @@ jobs:
         working-directory: build_rel
 
   build-macos-x64:
-    name: Build and test on MacOS
+    name: Build and test on MacOS x64
     runs-on: macos-12
     steps:
       - name: Git checkout
@@ -102,7 +102,7 @@ jobs:
           python ./Test/astc_test_image.py --test-set Small --test-quality medium
 
   build-macos-arm64:
-    name: Build and test on MacOS
+    name: Build and test on MacOS arm64
     runs-on: macos-14-arm64
     steps:
       - name: Git checkout

--- a/.github/workflows/post_weekly_release.yaml
+++ b/.github/workflows/post_weekly_release.yaml
@@ -63,7 +63,7 @@ jobs:
             --strip-path ${GITHUB_WORKSPACE}
 
   build-ubuntu-x64:
-    name: Build and test on Ubuntu x64
+    name: Ubuntu x64
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
@@ -71,7 +71,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Build R
+      - name: Build release
         run: |
           export CXX=clang++
           mkdir build_rel
@@ -97,13 +97,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_functional.py
           python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small
 
   build-macos-universal:
-    name: Build and test on macOS universal
+    name: macOS universal
     runs-on: macos-14
     steps:
       - name: Git checkout
@@ -111,7 +111,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Build R
+      - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
@@ -136,12 +136,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --encoder universal
 
   build-windows-multi:
-    name: Build and test on Windows multi
+    name: Windows multi
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Visual Studio x64
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Build R x64
+      - name: Build release x64
         run: |
           mkdir build_rel
           cd build_rel
@@ -167,7 +167,7 @@ jobs:
         with:
           arch: x86_arm64
 
-      - name: Build R arm64
+      - name: Build release arm64
         run: |
           mkdir build_rel_arm64
           cd build_rel_arm64
@@ -198,7 +198,7 @@ jobs:
           pip install numpy Pillow
         shell: cmd
 
-      - name: Python tests
+      - name: Run system tests
         run: |
           python ./Test/astc_test_image.py --test-set Small
         shell: cmd

--- a/.github/workflows/post_weekly_release.yaml
+++ b/.github/workflows/post_weekly_release.yaml
@@ -1,5 +1,5 @@
 name: post-weekly-release
-run-name: Build, test, generate signed artefacts and optionally prepare release
+run-name: Build, test, generate signed artifacts and optionally prepare release
 
 on:
   workflow_dispatch:
@@ -15,17 +15,18 @@ jobs:
 
   coverity:
     if: ${{ (!startsWith(github.event.ref, 'refs/tags/')) && (github.repository_owner == 'Arm-software') }}
-    name: Run Coverity Static Analysis
+    name: Run Coverity static analysis
     runs-on: [self-hosted-ubuntu-latest-x64]
     steps:
       - name: Clean workspace
         uses: AutoModality/action-clean@v1
+
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           submodules: 'true'
 
-      - name: Coverity Preparation
+      - name: Coverity preparation
         run: |
           export PATH=$PATH:/usr/local/cov-analysis/bin
           mkdir build_cov
@@ -34,19 +35,19 @@ jobs:
           cov-configure --config ${GITHUB_WORKSPACE}/coverity.conf --template --compiler cc --comptype gcc
           cov-configure --config ${GITHUB_WORKSPACE}/coverity.conf --template --compiler c++ --comptype g++
 
-      - name: Coverity Build
+      - name: Coverity build
         run: |
           export PATH=$PATH:/usr/local/cov-analysis/bin
           cd build_cov
           cov-build --config ${GITHUB_WORKSPACE}/coverity.conf --dir ${GITHUB_WORKSPACE}/intermediate make install
 
-      - name: Coverity Analyse
+      - name: Coverity analyze
         run: |
           export PATH=$PATH:/usr/local/cov-analysis/bin
           cd build_cov
           cov-analyze --dir ${GITHUB_WORKSPACE}/intermediate
 
-      - name: Coverity Upload
+      - name: Coverity upload
         env:
           COVERITY_KEY: ${{ secrets.COVERITY_KEY }}
         run: |
@@ -61,8 +62,8 @@ jobs:
             --auth-key-file ../coverity.key \
             --strip-path ${GITHUB_WORKSPACE}
 
-  build-ubuntu:
-    name: Build and test on Ubuntu
+  build-ubuntu-x64:
+    name: Build and test on Ubuntu x64
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
@@ -77,14 +78,6 @@ jobs:
           cd build_rel
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
-
-      - name: Build D
-        run: |
-          export CXX=clang++
-          mkdir build_dbg
-          cd build_dbg
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_DECOMPRESSOR=ON ..
-          make -j4
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
@@ -104,14 +97,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_functional.py
           python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small
 
-  build-macos:
-    name: Build and test on MacOS
-    runs-on: macos-12
+  build-macos-universal:
+    name: Build and test on macOS universal
+    runs-on: macos-14
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -143,12 +136,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_image.py --test-set Small --encoder universal
 
-  build-windows-msvc-ClangCL:
-    name: Build and test on Windows MSVC
+  build-windows-multi:
+    name: Build and test on Windows multi
     runs-on: windows-2022
     steps:
       - name: Git checkout
@@ -156,9 +149,10 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Setup Visual Studio x86_64
+      - name: Setup Visual Studio x64
         uses: ilammy/msvc-dev-cmd@v1
-      - name: Build R x86_64
+
+      - name: Build R x64
         run: |
           mkdir build_rel
           cd build_rel
@@ -172,6 +166,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86_arm64
+
       - name: Build R arm64
         run: |
           mkdir build_rel_arm64
@@ -203,7 +198,7 @@ jobs:
           pip install numpy Pillow
         shell: cmd
 
-      - name: Python Tests
+      - name: Python tests
         run: |
           python ./Test/astc_test_image.py --test-set Small
         shell: cmd
@@ -212,10 +207,11 @@ jobs:
     if: github.repository_owner == 'Arm-software'
     name: Sign Windows and Mac
     runs-on: [self-hosted-ubuntu-latest-x64]
-    needs: [build-macos, build-windows-msvc-ClangCL]
+    needs: [build-macos-universal, build-windows-multi]
     steps:
       - name: Clean workspace
         uses: AutoModality/action-clean@v1
+
       - name: Checkout signing code
         env:
           SIGNING_REPO_URL: ${{ secrets.SIGNING_REPO_URL }}
@@ -232,19 +228,19 @@ jobs:
           . ./cs/bin/activate
           pip install -i https://${ARTIFACTORY_USER}:${ARTIFACTORY_APIKEY}@${ARTIFACTORY_FQDN}/artifactory/api/pypi/dsgcore.pypi/simple code-signer-client
 
+      - name: Download macOS binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: astcenc-macos-universal
+          path: mac
+
       - name: Download Windows binaries
         uses: actions/download-artifact@v4
         with:
           name: astcenc-windows-multi-cl
           path: windows
 
-      - name: Download Mac binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: astcenc-macos-universal
-          path: mac
-
-      - name: Sign and notarize Mac
+      - name: Sign macOS binaries
         env:
           CODESIGNER_USER: ${{ secrets.CODESIGNER_USER }}
         run: |
@@ -269,7 +265,7 @@ jobs:
             windows/*
             mac/*
 
-      - name: Tidy intermediate artefacts
+      - name: Tidy intermediate artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
           name: |
@@ -280,7 +276,7 @@ jobs:
     if: ${{ (startsWith(github.event.ref, 'refs/tags/')) && (github.repository_owner == 'Arm-software') }}
     name: Prepare release
     runs-on: ubuntu-22.04
-    needs: [sign-binaries, build-ubuntu]
+    needs: [sign-binaries, build-ubuntu-x64]
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -290,6 +286,7 @@ jobs:
         with:
           name: signed-binaries
           path: prepare-release
+
       - name: Download Linux binaries
         uses: actions/download-artifact@v4
         with:
@@ -327,7 +324,7 @@ jobs:
           body_path: prepare-release/release_body.md
           draft: true
 
-      - name: Attach artefacts
+      - name: Attach artifacts
         uses: AButler/upload-release-assets@v3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Test/astc_test_image.py
+++ b/Test/astc_test_image.py
@@ -211,8 +211,16 @@ def run_test_set(encoder, testRef, testSet, quality, blockSizes, testRuns,
                 refResult = testRef.get_matching_record(res)
                 res.set_status(determine_result(image, refResult, res))
 
-                res.tTimeRel = refResult.tTime / res.tTime
-                res.cTimeRel = refResult.cTime / res.cTime
+                try:
+                    res.tTimeRel = refResult.tTime / res.tTime
+                except ZeroDivisionError:
+                    res.tTimeRel = float('NaN')
+
+                try:
+                    res.cTimeRel = refResult.cTime / res.cTime
+                except ZeroDivisionError:
+                    res.cTimeRel = float('NaN')
+
                 res.psnrRel = res.psnr - refResult.psnr
 
                 res = format_result(image, refResult, res)


### PR DESCRIPTION
This PR updates the GitHub Actions builds:

* Add GCC tests to the Ubuntu test runs for new PRs.
* Add arm64 to the macOS test runs for new PRs.
* Add universal builds to the macOS test runs for new PRs.
* Enable more Small test set quality modes for new PRs.
* Minor cleanups of the YAML to make it a bit easier to read.