### PR TITLE
Use SVE widening loads for vint4(uint8_t*)

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -24,6 +24,8 @@ The 5.1.0 release is a maintenance release.
     byte-to-int index conversion.
   * **Optimization:** Added improved intrinsics sequence for SSE and AVX2
     `hmin()` and `hmax()`.
+  * **Optimization:** Added improved intrinsics sequence for `vint4(uint8_t*)`
+    on systems implementing Arm SVE.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 5.0.0

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -194,10 +194,15 @@ struct vint4
 	 */
 	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
 	{
-		// Cast is safe - NEON loads are allowed to be unaligned
-		uint32x2_t t8 = vld1_dup_u32(reinterpret_cast<const uint32_t*>(p));
-		uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
-		m = vreinterpretq_s32_u32(vmovl_u16(t16));
+#if ASTCENC_SVE == 0
+	// Cast is safe - NEON loads are allowed to be unaligned
+	uint32x2_t t8 = vld1_dup_u32(reinterpret_cast<const uint32_t*>(p));
+	uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
+	m = vreinterpretq_s32_u32(vmovl_u16(t16));
+#else
+	svint32_t data = svld1ub_s32(svptrue_pat_b32(SV_VL4), p);
+	m = svget_neonq(data);
+#endif
 	}
 
 	/**


### PR DESCRIPTION
Use SVE predicated widening loads for vint4() values constructed
from an array of byte values in memory.

Improves compressor performance by ~1.5% on Neoverse V2
with 128-bit SVE.

Fixes #509 
