### PR TITLE
Update KodakMnt test set 5.0 reference benchmarks

### DIFF
--- a/Test/Images/KodakMnt/astc_reference-5.0-avx2_fast_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-avx2_fast_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,44.1743,0.7460,0.4157,22.7034
-KodakMnt,5x5,ldr-rgb-montage.png,40.1533,0.6132,0.3014,31.3092
-KodakMnt,6x6,ldr-rgb-montage.png,37.0133,0.6654,0.3419,27.6004
-KodakMnt,8x8,ldr-rgb-montage.png,32.9785,0.7271,0.4131,22.8421
-KodakMnt,12x12,ldr-rgb-montage.png,28.8664,0.5981,0.2938,32.1207
+KodakMnt,4x4,ldr-rgb-montage.png,44.1743,0.7071,0.3984,23.6888
+KodakMnt,5x5,ldr-rgb-montage.png,40.1533,0.5896,0.2857,33.0271
+KodakMnt,6x6,ldr-rgb-montage.png,37.0133,0.6220,0.3219,29.3164
+KodakMnt,8x8,ldr-rgb-montage.png,32.9785,0.6904,0.3947,23.9101
+KodakMnt,12x12,ldr-rgb-montage.png,28.8664,0.5681,0.2793,33.7895

--- a/Test/Images/KodakMnt/astc_reference-5.0-avx2_fastest_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-avx2_fastest_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,43.7477,0.5659,0.2598,36.3268
-KodakMnt,5x5,ldr-rgb-montage.png,39.8949,0.5197,0.2152,43.8443
-KodakMnt,6x6,ldr-rgb-montage.png,36.8759,0.5404,0.2331,40.4837
-KodakMnt,8x8,ldr-rgb-montage.png,32.8335,0.5920,0.2942,32.0758
-KodakMnt,12x12,ldr-rgb-montage.png,28.7346,0.5093,0.2078,45.4159
+KodakMnt,4x4,ldr-rgb-montage.png,43.7477,0.5636,0.2585,36.5014
+KodakMnt,5x5,ldr-rgb-montage.png,39.8949,0.5063,0.2147,43.9609
+KodakMnt,6x6,ldr-rgb-montage.png,36.8759,0.5302,0.2331,40.4835
+KodakMnt,8x8,ldr-rgb-montage.png,32.8335,0.5912,0.2940,32.0961
+KodakMnt,12x12,ldr-rgb-montage.png,28.7346,0.4980,0.2088,45.1927

--- a/Test/Images/KodakMnt/astc_reference-5.0-avx2_medium_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-avx2_medium_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,44.7845,3.1253,2.7619,3.4169
-KodakMnt,5x5,ldr-rgb-montage.png,40.7188,1.8916,1.5418,6.1208
-KodakMnt,6x6,ldr-rgb-montage.png,37.5042,1.6052,1.2774,7.3878
-KodakMnt,8x8,ldr-rgb-montage.png,33.5449,1.9150,1.5981,5.9051
-KodakMnt,12x12,ldr-rgb-montage.png,29.5428,1.7982,1.4864,6.3492
+KodakMnt,4x4,ldr-rgb-montage.png,44.7845,2.2409,1.9263,4.8991
+KodakMnt,5x5,ldr-rgb-montage.png,40.7188,1.6466,1.3433,7.0252
+KodakMnt,6x6,ldr-rgb-montage.png,37.5042,1.4268,1.1332,8.3277
+KodakMnt,8x8,ldr-rgb-montage.png,33.5449,1.7147,1.4024,6.7291
+KodakMnt,12x12,ldr-rgb-montage.png,29.5428,1.6262,1.3304,7.0937

--- a/Test/Images/KodakMnt/astc_reference-5.0-avx2_thorough_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-avx2_thorough_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,45.0189,5.4711,5.1346,1.8380
-KodakMnt,5x5,ldr-rgb-montage.png,40.8857,5.4303,5.1093,1.8471
-KodakMnt,6x6,ldr-rgb-montage.png,37.6931,5.7213,5.3962,1.7489
-KodakMnt,8x8,ldr-rgb-montage.png,33.7200,5.8013,5.4830,1.7212
-KodakMnt,12x12,ldr-rgb-montage.png,29.7824,6.6119,6.2957,1.4990
+KodakMnt,4x4,ldr-rgb-montage.png,45.0189,5.2531,4.9455,1.9083
+KodakMnt,5x5,ldr-rgb-montage.png,40.8857,5.2261,4.9238,1.9167
+KodakMnt,6x6,ldr-rgb-montage.png,37.6931,5.3839,5.0744,1.8598
+KodakMnt,8x8,ldr-rgb-montage.png,33.7200,5.4298,5.1173,1.8442
+KodakMnt,12x12,ldr-rgb-montage.png,29.7824,6.1131,5.8115,1.6239

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse2_fast_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse2_fast_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,44.1743,0.8906,0.5496,17.1702
-KodakMnt,5x5,ldr-rgb-montage.png,40.1533,0.7506,0.4155,22.7116
-KodakMnt,6x6,ldr-rgb-montage.png,37.0133,0.8262,0.4960,19.0261
-KodakMnt,8x8,ldr-rgb-montage.png,32.9785,0.9572,0.6270,15.0514
-KodakMnt,12x12,ldr-rgb-montage.png,28.8664,0.7592,0.4275,22.0770
+KodakMnt,4x4,ldr-rgb-montage.png,44.1743,0.8799,0.5485,17.2039
+KodakMnt,5x5,ldr-rgb-montage.png,40.1533,0.7461,0.4132,22.8411
+KodakMnt,6x6,ldr-rgb-montage.png,37.0133,0.8257,0.4959,19.0311
+KodakMnt,8x8,ldr-rgb-montage.png,32.9785,0.9457,0.6241,15.1205
+KodakMnt,12x12,ldr-rgb-montage.png,28.8664,0.7529,0.4286,22.0172

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse2_fastest_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse2_fastest_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,43.7477,0.7028,0.3617,26.0898
-KodakMnt,5x5,ldr-rgb-montage.png,39.8949,0.6492,0.3167,29.7940
-KodakMnt,6x6,ldr-rgb-montage.png,36.8759,0.6963,0.3639,25.9330
-KodakMnt,8x8,ldr-rgb-montage.png,32.8335,0.8023,0.4660,20.2502
-KodakMnt,12x12,ldr-rgb-montage.png,28.7346,0.6419,0.3180,29.6780
+KodakMnt,4x4,ldr-rgb-montage.png,43.7477,0.6933,0.3596,26.2449
+KodakMnt,5x5,ldr-rgb-montage.png,39.8949,0.6468,0.3157,29.8968
+KodakMnt,6x6,ldr-rgb-montage.png,36.8759,0.6923,0.3648,25.8665
+KodakMnt,8x8,ldr-rgb-montage.png,32.8335,0.7963,0.4654,20.2757
+KodakMnt,12x12,ldr-rgb-montage.png,28.7346,0.6451,0.3193,29.5573

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse2_medium_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse2_medium_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,44.7845,2.9579,2.6204,3.6014
-KodakMnt,5x5,ldr-rgb-montage.png,40.7188,2.3357,1.9928,4.7356
-KodakMnt,6x6,ldr-rgb-montage.png,37.5042,2.1065,1.7676,5.3390
-KodakMnt,8x8,ldr-rgb-montage.png,33.5449,2.5821,2.2446,4.2044
-KodakMnt,12x12,ldr-rgb-montage.png,29.5428,2.3605,2.0177,4.6772
+KodakMnt,4x4,ldr-rgb-montage.png,44.7845,2.9607,2.6194,3.6028
+KodakMnt,5x5,ldr-rgb-montage.png,40.7188,2.3316,1.9925,4.7363
+KodakMnt,6x6,ldr-rgb-montage.png,37.5042,2.1007,1.7677,5.3387
+KodakMnt,8x8,ldr-rgb-montage.png,33.5449,2.5814,2.2435,4.2065
+KodakMnt,12x12,ldr-rgb-montage.png,29.5428,2.3465,2.0179,4.6767

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse2_thorough_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse2_thorough_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,45.0189,7.0570,6.7105,1.4063
-KodakMnt,5x5,ldr-rgb-montage.png,40.8857,7.4929,7.1522,1.3195
-KodakMnt,6x6,ldr-rgb-montage.png,37.6931,8.0373,7.6877,1.2276
-KodakMnt,8x8,ldr-rgb-montage.png,33.7200,8.3487,8.0143,1.1775
-KodakMnt,12x12,ldr-rgb-montage.png,29.7824,9.0183,8.6819,1.0870
+KodakMnt,4x4,ldr-rgb-montage.png,45.0189,7.0507,6.7077,1.4069
+KodakMnt,5x5,ldr-rgb-montage.png,40.8857,7.4875,7.1526,1.3194
+KodakMnt,6x6,ldr-rgb-montage.png,37.6931,8.0151,7.6687,1.2306
+KodakMnt,8x8,ldr-rgb-montage.png,33.7200,8.3528,8.0197,1.1768
+KodakMnt,12x12,ldr-rgb-montage.png,29.7824,9.0239,8.6866,1.0864

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_fast_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_fast_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,44.1743,0.7941,0.4667,20.2194
-KodakMnt,5x5,ldr-rgb-montage.png,40.1533,0.6700,0.3489,27.0469
-KodakMnt,6x6,ldr-rgb-montage.png,37.0133,0.7407,0.4156,22.7067
-KodakMnt,8x8,ldr-rgb-montage.png,32.9785,0.8604,0.5424,17.3978
-KodakMnt,12x12,ldr-rgb-montage.png,28.8664,0.7075,0.3847,24.5343
+KodakMnt,4x4,ldr-rgb-montage.png,44.1743,0.7660,0.4503,20.9562
+KodakMnt,5x5,ldr-rgb-montage.png,40.1533,0.6470,0.3387,27.8665
+KodakMnt,6x6,ldr-rgb-montage.png,37.0133,0.7151,0.4058,23.2556
+KodakMnt,8x8,ldr-rgb-montage.png,32.9785,0.8159,0.5181,18.2138
+KodakMnt,12x12,ldr-rgb-montage.png,28.8664,0.6792,0.3723,25.3455

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_fastest_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_fastest_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,43.7477,0.6263,0.3036,31.0847
-KodakMnt,5x5,ldr-rgb-montage.png,39.8949,0.5846,0.2661,35.4692
-KodakMnt,6x6,ldr-rgb-montage.png,36.8759,0.6193,0.3046,30.9847
-KodakMnt,8x8,ldr-rgb-montage.png,32.8335,0.7123,0.3999,23.5976
-KodakMnt,12x12,ldr-rgb-montage.png,28.7346,0.5995,0.2866,32.9308
+KodakMnt,4x4,ldr-rgb-montage.png,43.7477,0.6137,0.2935,32.1588
+KodakMnt,5x5,ldr-rgb-montage.png,39.8949,0.5660,0.2585,36.5007
+KodakMnt,6x6,ldr-rgb-montage.png,36.8759,0.6029,0.2949,32.0017
+KodakMnt,8x8,ldr-rgb-montage.png,32.8335,0.6923,0.3848,24.5237
+KodakMnt,12x12,ldr-rgb-montage.png,28.7346,0.5741,0.2763,34.1614

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_medium_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_medium_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,44.7845,2.5814,2.2499,4.1944
-KodakMnt,5x5,ldr-rgb-montage.png,40.7188,1.9913,1.6632,5.6742
-KodakMnt,6x6,ldr-rgb-montage.png,37.5042,1.8307,1.4947,6.3137
-KodakMnt,8x8,ldr-rgb-montage.png,33.5449,2.7301,2.3689,3.9837
-KodakMnt,12x12,ldr-rgb-montage.png,29.5428,2.4119,2.0814,4.5342
+KodakMnt,4x4,ldr-rgb-montage.png,44.7845,2.5068,2.1790,4.3309
+KodakMnt,5x5,ldr-rgb-montage.png,40.7188,1.9172,1.6044,5.8820
+KodakMnt,6x6,ldr-rgb-montage.png,37.5042,1.7332,1.4235,6.6296
+KodakMnt,8x8,ldr-rgb-montage.png,33.5449,2.1636,1.8504,5.1001
+KodakMnt,12x12,ldr-rgb-montage.png,29.5428,2.0699,1.7660,5.3437

--- a/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_thorough_results.csv
+++ b/Test/Images/KodakMnt/astc_reference-5.0-sse4.1_thorough_results.csv
@@ -1,6 +1,6 @@
 Image Set,Block Size,Name,PSNR,Total Time,Coding Time,Coding Rate
-KodakMnt,4x4,ldr-rgb-montage.png,45.0189,5.9416,5.6273,1.6770
-KodakMnt,5x5,ldr-rgb-montage.png,40.8857,6.1718,5.8514,1.6128
-KodakMnt,6x6,ldr-rgb-montage.png,37.6931,6.5923,6.2803,1.5027
-KodakMnt,8x8,ldr-rgb-montage.png,33.7200,7.0359,6.7198,1.4044
-KodakMnt,12x12,ldr-rgb-montage.png,29.7824,7.9646,7.6450,1.2344
+KodakMnt,4x4,ldr-rgb-montage.png,45.0189,5.9395,5.6199,1.6792
+KodakMnt,5x5,ldr-rgb-montage.png,40.8857,6.1619,5.8439,1.6149
+KodakMnt,6x6,ldr-rgb-montage.png,37.6931,6.5811,6.2664,1.5060
+KodakMnt,8x8,ldr-rgb-montage.png,33.7200,7.0245,6.7093,1.4066
+KodakMnt,12x12,ldr-rgb-montage.png,29.7824,7.9643,7.6477,1.2340


### PR DESCRIPTION
Update test reference - benchmarking machine seems to have been doing something
else when running the original 5.x numbers so performance is lower than it should be. 