### PR TITLE
Suppress unused variable warn on unknown platforms

### DIFF
--- a/Source/astcenccli_platform_dependents.cpp
+++ b/Source/astcenccli_platform_dependents.cpp
@@ -196,6 +196,8 @@ void set_thread_name(
 	pthread_setname_np(pthread_self(), name);
 #elif defined(__APPLE__)
 	pthread_setname_np(name);
+#else
+	(void)name;
 #endif
 }
 


### PR DESCRIPTION
Fixes #524