### PR TITLE
Using MRSSE for HDR error calculations

### DIFF
--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -633,6 +633,7 @@ static float compress_symbolic_block_for_partition_1plane(
 
 				if (errorval < best_errorval_in_scb)
 				{
+					trace_add_data("select", "1");
 					best_errorval_in_scb = errorval;
 					workscb.errorval = errorval;
 					scb = workscb;
@@ -681,6 +682,7 @@ static float compress_symbolic_block_for_partition_1plane(
 
 			if (errorval < best_errorval_in_scb)
 			{
+				trace_add_data("select", "1");
 				best_errorval_in_scb = errorval;
 				workscb.errorval = errorval;
 				scb = workscb;
@@ -967,6 +969,7 @@ static float compress_symbolic_block_for_partition_2planes(
 
 				if (errorval < best_errorval_in_scb)
 				{
+					trace_add_data("select", "1");
 					best_errorval_in_scb = errorval;
 					workscb.errorval = errorval;
 					scb = workscb;
@@ -1016,6 +1019,7 @@ static float compress_symbolic_block_for_partition_2planes(
 
 			if (errorval < best_errorval_in_scb)
 			{
+				trace_add_data("select", "1");
 				best_errorval_in_scb = errorval;
 				workscb.errorval = errorval;
 				scb = workscb;

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -368,8 +368,9 @@ static float compress_symbolic_block_for_partition_1plane(
 
 	int max_weight_quant = astc::min(static_cast<int>(QUANT_32), quant_limit);
 
+	bool is_hdr = (config.profile == ASTCENC_PRF_HDR) || (config.profile == ASTCENC_PRF_HDR_RGB_LDR_A);
 	auto compute_difference = &compute_symbolic_block_difference_1plane;
-	if ((partition_count == 1) && !(config.flags & ASTCENC_FLG_MAP_RGBM))
+	if ((partition_count == 1) && !(config.flags & ASTCENC_FLG_MAP_RGBM) && !is_hdr)
 	{
 		compute_difference = &compute_symbolic_block_difference_1plane_1partition;
 	}

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -633,7 +633,6 @@ static float compress_symbolic_block_for_partition_1plane(
 
 				if (errorval < best_errorval_in_scb)
 				{
-					trace_add_data("select", "1");
 					best_errorval_in_scb = errorval;
 					workscb.errorval = errorval;
 					scb = workscb;
@@ -682,7 +681,6 @@ static float compress_symbolic_block_for_partition_1plane(
 
 			if (errorval < best_errorval_in_scb)
 			{
-				trace_add_data("select", "1");
 				best_errorval_in_scb = errorval;
 				workscb.errorval = errorval;
 				scb = workscb;
@@ -969,7 +967,6 @@ static float compress_symbolic_block_for_partition_2planes(
 
 				if (errorval < best_errorval_in_scb)
 				{
-					trace_add_data("select", "1");
 					best_errorval_in_scb = errorval;
 					workscb.errorval = errorval;
 					scb = workscb;
@@ -1019,7 +1016,6 @@ static float compress_symbolic_block_for_partition_2planes(
 
 			if (errorval < best_errorval_in_scb)
 			{
-				trace_add_data("select", "1");
 				best_errorval_in_scb = errorval;
 				workscb.errorval = errorval;
 				scb = workscb;

--- a/Source/astcenc_decompress_symbolic.cpp
+++ b/Source/astcenc_decompress_symbolic.cpp
@@ -354,7 +354,7 @@ float compute_symbolic_block_difference_2plane(
 	                       ep0, ep1);
 
 	vmask4 u8_mask = get_u8_component_mask(config.profile, blk);
-	vmask4 lns_mask(rgb_lns, rgb_lns, rgb_lns, a_lns);
+	bool any_lns = rgb_lns || a_lns;
 
 	// Unpack and compute error for each texel in the partition
 	unsigned int texel_count = bsd.texel_count;
@@ -403,8 +403,9 @@ float compute_symbolic_block_difference_2plane(
 		// Convert this relative sum of squared error for HDR to avoid light
 		// channels dominating the error calculations.
 		// See https://fgiesen.wordpress.com/2024/11/14/mrsse/
-		if (any(lns_mask))
+		if (any_lns)
 		{
+			// TODO: Divisor could be precomputed at load time
 			error = error / (dot(oldColor, oldColor) + 1e-10f);
 		}
 
@@ -460,7 +461,7 @@ float compute_symbolic_block_difference_1plane(
 		                       rgb_lns, a_lns,
 		                       ep0, ep1);
 
-		vmask4 lns_mask(rgb_lns, rgb_lns, rgb_lns, a_lns);
+		bool any_lns = rgb_lns || a_lns;
 
 		// Unpack and compute error for each texel in the partition
 		unsigned int texel_count = pi.partition_texel_count[i];
@@ -510,8 +511,9 @@ float compute_symbolic_block_difference_1plane(
 			// Convert this relative sum of squared error for HDR to avoid light
 			// channels dominating the error calculations
 			// See https://fgiesen.wordpress.com/2024/11/14/mrsse/
-			if (any(lns_mask))
+			if (any_lns)
 			{
+				// TODO: Divisor could be precomputed at load time
 				error = error / (dot(oldColor, oldColor) + 1e-10f);
 			}
 


### PR DESCRIPTION
*Status:*

Suspect I have the wrong end of the stick here - MRSEE on log values is still going to be incorrect. For MRSEE to make sense we need to use linear colors, diving in/out of LNS encoding when we need to test quantization. This is going to end up a lot more expensive ...

*Description*

HDR texture values are stored logarithmically.

Using absolute sum of squares on the logarithmic values (the existing behaviour on main) causes the compressor to spend too much effort preserving imperceptible shifts in dark channel values at the expense of bright values in the same block. This performs poorly in blocks with sharp luminance changes (dark texels in a bright block) and in blocks with saturated color values (dark channels in bright pixels).

Using absolute sum of squares on linearized HDR values (attempted by the first patch in this PR) avoids the compressor fixating on dark values, but instead causes the compressor to spend too much effort preserving bright values. This is because the errors in the bright channels can be orders of magnitude bigger than the errors in the dark channels, and dark values can end up quantizing close to black.

Using relative sum of square on the logarithmic values, proposed by Ryg in the blog below, encourages the compressor to find a balance of relative error across the whole block, favoring neither light nor dark channels. Blog: https://fgiesen.wordpress.com/2024/11/14/mrsse/ .

This is a perceptual error metric for HDR textures, so we expect that this will make the mPSNR score worse because we are no longer optimizing for absolute error. Test failures in HDR textures are therefore expected, and LDR textures are not affected.

- [ ] Suspect MRSSE needs to be in linear space, so try that ...
- [ ] Consider using MRSSE during iterative refinement. It's currently only used in final block check.
- [ ] If good, we need to regenerate test reference scores before merging so Actions keeps working. 

