### PR TITLE
Remove unnecessary config field sets

### DIFF
--- a/Utils/Example/astc_api_example.cpp
+++ b/Utils/Example/astc_api_example.cpp
@@ -79,10 +79,6 @@ int main(int argc, char **argv)
 	// ------------------------------------------------------------------------
 	// Initialize the default configuration for the block size and quality
 	astcenc_config config;
-	config.block_x = block_x;
-	config.block_y = block_y;
-	config.profile = profile;
-
 	astcenc_error status;
 	status = astcenc_config_init(profile, block_x, block_y, block_z, quality, 0, &config);
 	if (status != ASTCENC_SUCCESS)

--- a/Utils/Example/astc_api_example.cpp
+++ b/Utils/Example/astc_api_example.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2021 Arm Limited
+// Copyright 2021-2024 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Remove unnecessary field setting from the example project, as it's 
overwritten by the astcenc_config_init() call anyway.

Fixes #531 