### PR TITLE
Add codec API to cancel a compression

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -6,6 +6,22 @@ release of the 5.x series.
 All performance data on this page is measured on an Intel Core i5-9600K
 clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 
+<!-- ---------------------------------------------------------------------- -->
+## 5.2.0
+
+**Status:** In development.
+
+The 5.2.0 release is a minor maintenance release.
+
+This release includes changes to the public interface in the `astcenc.h`
+header.  We always recommend rebuilding your client-side code using the
+header from the same release to avoid compatibility issues.
+
+* **General:**
+  * **Feature:** Added a new codec API, `astcenc_compress_cancel()`, which can
+    be used to cancel an in-flight compression. This is designed to help make
+    it easier to integrate the codec into an interactive user interface that
+    can respond to user events with low latency.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 5.1.0
@@ -56,4 +72,4 @@ set.
 
 - - -
 
-_Copyright © 2022-2024, Arm Limited and contributors. All rights reserved._
+_Copyright © 2022-2025, Arm Limited and contributors. All rights reserved._

--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -22,6 +22,9 @@ header from the same release to avoid compatibility issues.
     be used to cancel an in-flight compression. This is designed to help make
     it easier to integrate the codec into an interactive user interface that
     can respond to user events with low latency.
+  * **Bug fix:** Removed incorrect `static` variable qualifier, which could
+    result in an incorrect `tune_mse_overshoot` heuristic threshold being used
+    if a user ran multiple concurrent compressions with different settings.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 5.1.0

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2020-2024 Arm Limited
+// Copyright 2020-2025 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -782,6 +782,20 @@ ASTCENC_PUBLIC astcenc_error astcenc_compress_image(
  * @return @c ASTCENC_SUCCESS on success, or an error if reset failed.
  */
 ASTCENC_PUBLIC astcenc_error astcenc_compress_reset(
+	astcenc_context* context);
+
+/**
+ * @brief Cancel any pending compression operation.
+ *
+ * The caller must behave as if the compression completed normally, even though the data will be
+ * undefined. They are still responsible for synchronizing threads in the worker thread pool, and
+ * must call reset before starting another compression.
+ *
+ * @param context   Codec context.
+ *
+ * @return @c ASTCENC_SUCCESS on success, or an error if cancellation failed.
+ */
+ASTCENC_PUBLIC astcenc_error astcenc_compress_cancel(
 	astcenc_context* context);
 
 /**


### PR DESCRIPTION
Adds a codec API entry point to cancel an inflight compression. 

Fixes #535 