### PR TITLE
Add arm64 runner

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -8,6 +8,116 @@ on:
       - main
 
 jobs:
+  build-ubuntu-arm64-clang:
+    name: Ubuntu arm64 Clang
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Install ImageMagick
+        run: sudo apt install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=clang++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_SVE_256=ON -DASTCENC_ISA_NONE=ON -DASTCENC_PACKAGE=arm64 ..
+          make install package -j4
+
+      - name: Build debug
+        run: |
+          export CXX=clang++
+          mkdir build_dbg
+          cd build_dbg
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_SVE_256=ON -DASTCENC_ISA_NONE=ON ..
+          make -j4
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: astcenc-linux-arm64
+          path: |
+            build_rel/*.zip
+            build_rel/*.zip.sha256
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        # GitHub is using Cobalt-100, which has 128-bit SVE so we cannot test sve_256 here
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_functional.py --encoder sve_128
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+          python ./Test/astc_test_image.py --encoder sve_128 --test-set Small
+
+      - name: Run unit tests
+        # GitHub is using Cobalt-100, which has 128-bit SVE so we cannot test sve_256 here
+        run: ctest -E test-unit-sve_256 --rerun-failed --output-on-failure
+        working-directory: build_rel
+
+  build-ubuntu-arm64-gcc:
+    name: Ubuntu arm64 GCC
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Install ImageMagick
+        run: sudo apt install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=g++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_NONE=ON -DASTCENC_PACKAGE=arm64 ..
+          make install package -j4
+
+      - name: Build debug
+        run: |
+          export CXX=clang++
+          mkdir build_dbg
+          cd build_dbg
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_NONE=ON ..
+          make -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+
+      - name: Run unit tests
+        run: ctest --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-ubuntu-x64-clang:
     name: Ubuntu x64 Clang
     runs-on: ubuntu-22.04
@@ -22,7 +132,7 @@ jobs:
           export CXX=clang++
           mkdir build_rel
           cd build_rel
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
       - name: Build debug
@@ -61,7 +171,7 @@ jobs:
           python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
 
       - name: Run unit tests
-        run: ctest
+        run: ctest --rerun-failed --output-on-failure
         working-directory: build_rel
 
   build-ubuntu-x64-gcc:
@@ -78,7 +188,7 @@ jobs:
           export CXX=g++
           mkdir build_rel
           cd build_rel
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
       - name: Build debug
@@ -109,7 +219,7 @@ jobs:
           python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
 
       - name: Run unit tests
-        run: ctest
+        run: ctest --rerun-failed --output-on-failure
         working-directory: build_rel
 
   build-macos-x64-clang:
@@ -125,7 +235,7 @@ jobs:
         run: |
           mkdir build_rel
           cd build_rel
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNIVERSAL_BUILD=OFF -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_UNIVERSAL_BUILD=OFF -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
       - name: Build debug
@@ -149,6 +259,10 @@ jobs:
         run: |
           python ./Test/astc_test_image.py  --encoder sse4.1 --test-set Small
 
+      - name: Run unit tests
+        run: ctest -E test-unit-avx2 --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-macos-universal-clang:
     name: macOS universal Clang
     runs-on: macos-14
@@ -162,7 +276,7 @@ jobs:
         run: |
           mkdir build_rel
           cd build_rel
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNIVERSAL_BUILD=ON -DASTCENC_PACKAGE=x64 ..
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_UNIVERSAL_BUILD=ON -DASTCENC_PACKAGE=x64 ..
           make install package -j4
 
       - name: Build debug
@@ -194,6 +308,10 @@ jobs:
         run: |
           python ./Test/astc_test_image.py --encoder universal --test-set Small
 
+      - name: Run unit tests
+        run: ctest -E test-unit-avx2 --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-windows-x64-msvc:
     name: Windows x64 MSVC
     runs-on: windows-2022
@@ -203,14 +321,14 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Setup Visual Studio x86_6
+      - name: Setup Visual Studio x86_64
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
-          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
+          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           nmake install package
         shell: cmd
 
@@ -238,6 +356,10 @@ jobs:
           python ./Test/astc_test_image.py --test-set Small
         shell: cmd
 
+      - name: Run unit tests
+        run: ctest -C Release --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-windows-x64-clangcl:
     name: Windows x64 ClangCL
     runs-on: windows-2022
@@ -247,14 +369,14 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Setup Visual Studio x86_6
+      - name: Setup Visual Studio x86_64
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build release
         run: |
           mkdir build_rel
           cd build_rel
-          cmake -G "Visual Studio 17 2022" -T ClangCL -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
+          cmake -G "Visual Studio 17 2022" -T ClangCL -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_PACKAGE=x64 ..
           msbuild astcencoder.sln -property:Configuration=Release
           msbuild PACKAGE.vcxproj -property:Configuration=Release
           msbuild INSTALL.vcxproj -property:Configuration=Release
@@ -264,7 +386,7 @@ jobs:
         run: |
           mkdir build_dbg
           cd build_dbg
-          cmake -G "Visual Studio 17 2022" -T ClangCL -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON ..
+          cmake -G "Visual Studio 17 2022" -T ClangCL -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON ..
           msbuild astcencoder.sln -property:Configuration=Debug
         shell: cmd
 
@@ -291,6 +413,10 @@ jobs:
         run: |
           python ./Test/astc_test_image.py --test-set Small
         shell: cmd
+
+      - name: Run unit tests
+        run: ctest -C Release --rerun-failed --output-on-failure
+        working-directory: build_rel
 
   build-windows-arm64-clangcl:
     name: Windows arm64 ClangCL

--- a/.github/workflows/post_weekly_release.yaml
+++ b/.github/workflows/post_weekly_release.yaml
@@ -62,6 +62,49 @@ jobs:
             --auth-key-file ../coverity.key \
             --strip-path ${GITHUB_WORKSPACE}
 
+ build-ubuntu-arm64:
+    name: Ubuntu arm64
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Build release
+        run: |
+          export CXX=clang++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_SVE_256=ON -DASTCENC_PACKAGE=arm64 ..
+          make install package -j4
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: astcenc-linux-arm64
+          path: |
+            build_rel/*.zip
+            build_rel/*.zip.sha256
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        # GitHub is using Cobalt-100, which has 128-bit SVE so we cannot test sve_256 here
+        run: |
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_functional.py --encoder sve_128
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+          python ./Test/astc_test_image.py --encoder sve_128 --test-set Small
+
   build-ubuntu-x64:
     name: Ubuntu x64
     runs-on: ubuntu-22.04
@@ -100,7 +143,7 @@ jobs:
       - name: Run system tests
         run: |
           python ./Test/astc_test_functional.py
-          python ./Test/astc_test_image.py --encoder=all-x86 --test-set Small
+          python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
 
   build-macos-universal:
     name: macOS universal
@@ -149,7 +192,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Setup Visual Studio x64
+      - name: Setup Visual Studio x86_64
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build release x64
@@ -287,10 +330,16 @@ jobs:
           name: signed-binaries
           path: prepare-release
 
-      - name: Download Linux binaries
+      - name: Download Linux x86_64 binaries
         uses: actions/download-artifact@v4
         with:
           name: astcenc-linux-x86_64
+          path: prepare-release
+
+      - name: Download Linux arm64 binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: astcenc-linux-arm64
           path: prepare-release
 
       - name: Flatten file structure

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Test/Images/Scratch*
 # Test output
 TestOutput
 /*.xlsx
+/*.jpg
 /*.json
 /*.log
 /*.txt

--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -18,6 +18,9 @@ header.  We always recommend rebuilding your client-side code using the
 header from the same release to avoid compatibility issues.
 
 * **General:**
+  * **Feature:** Arm64 builds for Linux added to the GitHub Actions builds, and
+    Arm64 binaries for NEON, 128-bit SVE 128 and 256-bit SVE added to release
+    builds.
   * **Feature:** Added a new codec API, `astcenc_compress_cancel()`, which can
     be used to cancel an in-flight compression. This is designed to help make
     it easier to integrate the codec into an interactive user interface that

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020-2024 Arm Limited
+#  Copyright 2020-2025 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -104,6 +104,19 @@ if(${ASTCENC_UNITTEST})
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
     set(CMAKE_OSX_ARCHITECTURES x86_64;arm64)
     add_subdirectory(GoogleTest)
+
+    # Workaround GoogleTest CRT selection issue issue
+    # See https://github.com/google/googletest/issues/4067
+    set_property(
+        TARGET gtest
+            PROPERTY
+                MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+    set_property(
+        TARGET gtest_main
+            PROPERTY
+                MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
     enable_testing()
     add_subdirectory(UnitTest)
 endif()

--- a/Source/UnitTest/cmake_core.cmake
+++ b/Source/UnitTest/cmake_core.cmake
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020-2024 Arm Limited
+#  Copyright 2020-2025 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -27,12 +27,16 @@ if(${ASTCENC_CLI})
             INTERPROCEDURAL_OPTIMIZATION_RELEASE True)
 endif()
 
+# Use a static runtime on MSVC builds (ignored on non-MSVC compilers)
+set_property(TARGET ${ASTCENC_TEST}
+    PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 target_sources(${ASTCENC_TEST}
     PRIVATE
         test_simd.cpp
         test_softfloat.cpp
-        test_decode.cpp
-        ../astcenc_mathlib_softfloat.cpp)
+        test_decode.cpp)
 
 target_include_directories(${ASTCENC_TEST}
     PRIVATE
@@ -60,6 +64,8 @@ target_compile_options(${ASTCENC_TEST}
         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-c++98-c++11-compat-pedantic>
         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-float-equal>
         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-overriding-option>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-unsafe-buffer-usage>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-switch-default>
 
         # Ignore things that the googletest build triggers
         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-unknown-warning-option>
@@ -170,5 +176,3 @@ target_link_libraries(${ASTCENC_TEST}
 
 add_test(NAME ${ASTCENC_TEST}
          COMMAND ${ASTCENC_TEST})
-
-install(TARGETS ${ASTCENC_TEST})

--- a/Source/UnitTest/test_simd.cpp
+++ b/Source/UnitTest/test_simd.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2020-2024 Arm Limited
+// Copyright 2020-2025 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -36,7 +36,7 @@ namespace astcenc
  *
  * The value of @c a is stored to lane 0 (LSB) in the SIMD register.
  */
-vfloat8 vfloat8_lit(
+static vfloat8 vfloat8_lit(
 	float a, float b, float c, float d,
 	float e, float f, float g, float h
 ) {
@@ -52,7 +52,7 @@ vfloat8 vfloat8_lit(
  *
  * The value of @c a is stored to lane 0 (LSB) in the SIMD register.
  */
-vint8 vint8_lit(
+static vint8 vint8_lit(
 	int a, int b, int c, int d,
 	int e, int f, int g, int h
 ) {
@@ -2742,7 +2742,7 @@ TEST(vfloat8, store)
 	vfloat8 a(f32_data);
 
 	alignas(32) float ra[9];
-	storea(a, ra + 1);
+	store(a, ra + 1);
 
 	EXPECT_EQ(ra[1], 0.0f);
 	EXPECT_EQ(ra[2], 1.0f);
@@ -2760,7 +2760,7 @@ TEST(vfloat8, storea)
 	vfloat8 a(f32_data);
 
 	alignas(32) float ra[8];
-	store(a, ra);
+	storea(a, ra);
 
 	EXPECT_EQ(ra[0], 0.0f);
 	EXPECT_EQ(ra[1], 1.0f);

--- a/Test/astc_test_functional.py
+++ b/Test/astc_test_functional.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-# Copyright 2020-2023 Arm Limited
+# Copyright 2020-2025 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy
@@ -2183,7 +2183,7 @@ def main():
 
     parser = argparse.ArgumentParser()
 
-    coders = ["none", "neon", "sse2", "sse4.1", "avx2"]
+    coders = ["none", "neon", "sve_128", "sve_256", "sse2", "sse4.1", "avx2"]
     parser.add_argument("--encoder", dest="encoder", default="avx2",
                         choices=coders, help="test encoder variant")
     args = parser.parse_known_args()


### PR DESCRIPTION
GitHub has new Armv9 runners available in GitHub Actions, so this enables them for our builds.

Fixes #540.
Fixes #523.