### PR TITLE
Make -Werror and /WX optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ option(ASTCENC_UNITTEST "Enable astcenc builds with unit tests")
 option(ASTCENC_INVARIANCE "Enable astcenc floating point invariance" ON)
 option(ASTCENC_CLI "Enable build of astcenc command line tools" ON)
 option(ASTCENC_X86_GATHERS "Enable use of native x86 gathers" ON)
+option(ASTCENC_WERROR "Force builds to treat warnings as errors" ON)
 
 # Preflight for some macOS-specific build options
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")

--- a/Source/UnitTest/cmake_core.cmake
+++ b/Source/UnitTest/cmake_core.cmake
@@ -15,6 +15,8 @@
 #  under the License.
 #  ----------------------------------------------------------------------------
 
+include(../cmake_compiler.cmake)
+
 set(ASTCENC_TEST test-unit-${ASTCENC_ISA_SIMD})
 
 add_executable(${ASTCENC_TEST})
@@ -57,27 +59,34 @@ target_compile_options(${ASTCENC_TEST}
         $<$<PLATFORM_ID:Linux,Darwin>:-pthread>
 
         # MSVC compiler defines
-        $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+        $<${is_msvc_fe}:/EHsc>
+        $<$<AND:$<BOOL:${ASTCENC_WERROR}>,${is_msvc_fe}>:/WX>
+        $<${is_msvccl}:/wd4324>
 
         # G++ and Clang++ compiler defines
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wextra>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wpedantic>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wshadow>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-c++98-compat-pedantic>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-c++98-c++11-compat-pedantic>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-float-equal>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-overriding-option>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-unsafe-buffer-usage>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-switch-default>
+        $<${is_gnu_fe}:-Wall>
+        $<${is_gnu_fe}:-Wextra>
+        $<${is_gnu_fe}:-Wpedantic>
+        $<$<AND:$<BOOL:${ASTCENC_WERROR}>,${is_gnu_fe}>:-Werror>
+        $<${is_gnu_fe}:-Wshadow>
+        $<${is_gnu_fe}:-Wdouble-promotion>
+        $<${is_clang}:-Wdocumentation>
+
+        # Hide noise thrown up by Clang 10 and clang-cl
+        $<${is_gnu_fe}:-Wno-unknown-warning-option>
+        $<${is_gnu_fe}:-Wno-c++98-compat-pedantic>
+        $<${is_gnu_fe}:-Wno-c++98-c++11-compat-pedantic>
+        $<${is_gnu_fe}:-Wno-float-equal>
+        $<${is_gnu_fe}:-Wno-overriding-option>
+        $<${is_gnu_fe}:-Wno-unsafe-buffer-usage>
+        $<${is_clang}:-Wno-switch-default>
 
         # Ignore things that the googletest build triggers
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-unknown-warning-option>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-double-promotion>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-undef>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-reserved-identifier>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-global-constructors>)
+        $<${is_gnu_fe}:-Wno-unknown-warning-option>
+        $<${is_gnu_fe}:-Wno-double-promotion>
+        $<${is_gnu_fe}:-Wno-undef>
+        $<${is_gnu_fe}:-Wno-reserved-identifier>
+        $<${is_gnu_fe}:-Wno-global-constructors>)
 
 # Set up configuration for SIMD ISA builds
 if(${ASTCENC_ISA_SIMD} MATCHES "none")

--- a/Source/cmake_compiler.cmake
+++ b/Source/cmake_compiler.cmake
@@ -1,0 +1,37 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------
+#  Copyright 2020-2025 Arm Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy
+#  of the License at:
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#  ----------------------------------------------------------------------------
+
+# On CMake 3.25 or older CXX_COMPILER_FRONTEND_VARIANT is not always set
+if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "")
+    set(CMAKE_CXX_COMPILER_FRONTEND_VARIANT "${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+# Compiler accepts MSVC-style command line options
+set(is_msvc_fe "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>")
+# Compiler accepts GNU-style command line options
+set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
+# Compiler accepts AppleClang-style command line options, which is also GNU-style
+set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
+# Compiler accepts GNU-style command line options
+set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
+
+# Compiler is Visual Studio cl.exe
+set(is_msvccl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:MSVC>>")
+# Compiler is Visual Studio clangcl.exe
+set(is_clangcl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:Clang>>")
+# Compiler is upstream clang with the standard frontend
+set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")

--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020-2024 Arm Limited
+#  Copyright 2020-2025 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -19,26 +19,7 @@ set(ASTCENC_TARGET astc${ASTCENC_CODEC}-${ASTCENC_ISA_SIMD})
 
 project(${ASTCENC_TARGET})
 
-# On CMake 3.25 or older CXX_COMPILER_FRONTEND_VARIANT is not always set
-if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "")
-    set(CMAKE_CXX_COMPILER_FRONTEND_VARIANT "${CMAKE_CXX_COMPILER_ID}")
-endif()
-
-# Compiler accepts MSVC-style command line options
-set(is_msvc_fe "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>")
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
-# Compiler accepts AppleClang-style command line options, which is also GNU-style
-set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
-
-# Compiler is Visual Studio cl.exe
-set(is_msvccl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:MSVC>>")
-# Compiler is Visual Studio clangcl.exe
-set(is_clangcl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:Clang>>")
-# Compiler is upstream clang with the standard frontend
-set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
+include(cmake_compiler.cmake)
 
 add_library(${ASTCENC_TARGET}-static
     STATIC
@@ -164,14 +145,14 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_VENEER_TYPE)
 
             # MSVC compiler defines
             $<${is_msvc_fe}:/EHsc>
-            $<${is_msvc_fe}:/WX>
+            $<$<AND:$<BOOL:${ASTCENC_WERROR}>,${is_msvc_fe}>:/WX>
             $<${is_msvccl}:/wd4324>
 
             # G++ and Clang++ compiler defines
             $<${is_gnu_fe}:-Wall>
             $<${is_gnu_fe}:-Wextra>
             $<${is_gnu_fe}:-Wpedantic>
-            $<${is_gnu_fe}:-Werror>
+            $<$<AND:$<BOOL:${ASTCENC_WERROR}>,${is_gnu_fe}>:-Werror>
             $<${is_gnu_fe}:-Wshadow>
             $<${is_gnu_fe}:-Wdouble-promotion>
             $<${is_clang}:-Wdocumentation>


### PR DESCRIPTION
The current build forces warnings as errors, but this can make the build fragile when a
downstream project uses a different compiler which generates new warnings. 

This PR leaves warnings as errors on by default, but allows a user to turn it off in the 
CMake configuration step.