### PR TITLE
Use -flto=auto for GCC builds

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -17,8 +17,12 @@
 
 # Overwrite the LTO flags to force fat LTO; worth 3-4% performance
 # See https://gitlab.kitware.com/cmake/cmake/-/issues/16808
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND ${ASTCENC_CLI})
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND ${ASTCENC_CLI})
     set(CMAKE_CXX_COMPILE_OPTIONS_IPO "-flto")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${ASTCENC_CLI})
+    set(CMAKE_CXX_COMPILE_OPTIONS_IPO "-flto=auto")
 endif()
 
 if(${ASTCENC_DECOMPRESSOR})


### PR DESCRIPTION
GCC generates log warnings if you use -flto without a core count 
parameter, so modify the build to specify an auto core count.

Fixes #560 