### PR TITLE
Fixed astcenc.h for C builds and double definition of NOMINMAX

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -18,6 +18,8 @@ header.  We always recommend rebuilding your client-side code using the
 header from the same release to avoid compatibility issues.
 
 * **General:**
+  * **Improvement:** The interface header `astcenc.h` is now C compliant to
+    make it usable from C programs.
   * **Improvement:** Contexts using the same configuration can now share
     read-only data tables. This can significantly reduce the amount of memory
     needed for applications that parallelize by processing multiple images
@@ -26,6 +28,8 @@ header from the same release to avoid compatibility issues.
     support, now use a smaller `block_size_descriptor` by omitting fields that
     are only needed for compression. This reduces the size of a decompressor
     context by more than 10MB!
+  * **Bug fix:** Avoid double definition of `NOMINMAX` when compiling with
+    MinGW.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 5.3.0

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -182,9 +182,9 @@
 
 #if defined(ASTCENC_DYNAMIC_LIBRARY)
 	#if defined(_MSC_VER)
-		#define ASTCENC_PUBLIC extern "C" __declspec(dllexport)
+		#define ASTCENC_PUBLIC ASTCENC_EXTERN_C __declspec(dllexport)
 	#else
-		#define ASTCENC_PUBLIC extern "C" __attribute__ ((visibility ("default")))
+		#define ASTCENC_PUBLIC ASTCENC_EXTERN_C __attribute__ ((visibility ("default")))
 	#endif
 #else
 	#define ASTCENC_PUBLIC ASTCENC_EXTERN_C

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -169,8 +169,16 @@
 #ifndef ASTCENC_INCLUDED
 #define ASTCENC_INCLUDED
 
+#if defined(__cplusplus)
 #include <cstddef>
 #include <cstdint>
+#define ASTCENC_EXTERN_C extern "C"
+#else
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#define ASTCENC_EXTERN_C
+#endif
 
 #if defined(ASTCENC_DYNAMIC_LIBRARY)
 	#if defined(_MSC_VER)
@@ -179,7 +187,7 @@
 		#define ASTCENC_PUBLIC extern "C" __attribute__ ((visibility ("default")))
 	#endif
 #else
-	#define ASTCENC_PUBLIC
+	#define ASTCENC_PUBLIC ASTCENC_EXTERN_C
 #endif
 
 /* ============================================================================
@@ -284,13 +292,13 @@ enum astcenc_swz
 struct astcenc_swizzle
 {
 	/** @brief The red component selector. */
-	astcenc_swz r;
+	enum astcenc_swz r;
 	/** @brief The green component selector. */
-	astcenc_swz g;
+	enum astcenc_swz g;
 	/** @brief The blue component selector. */
-	astcenc_swz b;
+	enum astcenc_swz b;
 	/** @brief The alpha component selector. */
-	astcenc_swz a;
+	enum astcenc_swz a;
 };
 
 /**
@@ -309,7 +317,7 @@ enum astcenc_type
 /**
  * @brief Function pointer type for compression progress reporting callback.
  */
-extern "C" typedef void (*astcenc_progress_callback)(float);
+ASTCENC_EXTERN_C typedef void (*astcenc_progress_callback)(float);
 
 /**
  * @brief Enable normal map compression.
@@ -417,7 +425,7 @@ static const unsigned int ASTCENC_ALL_FLAGS =
 struct astcenc_config
 {
 	/** @brief The color profile. */
-	astcenc_profile profile;
+	enum astcenc_profile profile;
 
 	/** @brief The set of set flags. */
 	unsigned int flags;
@@ -612,7 +620,7 @@ struct astcenc_image
 	unsigned int dim_z;
 
 	/** @brief The data type per component. */
-	astcenc_type data_type;
+	enum astcenc_type data_type;
 
 	/** @brief The array of 2D slices, of length @c dim_z. */
 	void** data;
@@ -627,7 +635,7 @@ struct astcenc_image
 struct astcenc_block_info
 {
 	/** @brief The block encoding color profile. */
-	astcenc_profile profile;
+	enum astcenc_profile profile;
 
 	/** @brief The number of texels in the X dimension. */
 	unsigned int block_x;
@@ -712,14 +720,14 @@ struct astcenc_block_info
  * @return @c ASTCENC_SUCCESS on success, or an error if the inputs are invalid
  * either individually, or in combination.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_config_init(
-	astcenc_profile profile,
+ASTCENC_PUBLIC enum astcenc_error astcenc_config_init(
+	enum astcenc_profile profile,
 	unsigned int block_x,
 	unsigned int block_y,
 	unsigned int block_z,
 	float quality,
 	unsigned int flags,
-	astcenc_config* config);
+	struct astcenc_config* config);
 
 /**
  * @brief Allocate a new codec context based on a config.
@@ -748,11 +756,11 @@ ASTCENC_PUBLIC astcenc_error astcenc_config_init(
  *
  * @return @c ASTCENC_SUCCESS on success, or an error if context creation failed.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_context_alloc(
-	const astcenc_config* config,
+ASTCENC_PUBLIC enum astcenc_error astcenc_context_alloc(
+	const struct astcenc_config* config,
 	unsigned int thread_count,
-	astcenc_context** context,
-	const astcenc_context* parent_context);
+	struct astcenc_context** context,
+	const struct astcenc_context* parent_context);
 
 /**
  * @brief Compress an image.
@@ -772,10 +780,10 @@ ASTCENC_PUBLIC astcenc_error astcenc_context_alloc(
  *
  * @return @c ASTCENC_SUCCESS on success, or an error if compression failed.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_compress_image(
-	astcenc_context* context,
-	astcenc_image* image,
-	const astcenc_swizzle* swizzle,
+ASTCENC_PUBLIC enum astcenc_error astcenc_compress_image(
+	struct astcenc_context* context,
+	struct astcenc_image* image,
+	const struct astcenc_swizzle* swizzle,
 	uint8_t* data_out,
 	size_t data_len,
 	unsigned int thread_index);
@@ -793,8 +801,8 @@ ASTCENC_PUBLIC astcenc_error astcenc_compress_image(
  *
  * @return @c ASTCENC_SUCCESS on success, or an error if reset failed.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_compress_reset(
-	astcenc_context* context);
+ASTCENC_PUBLIC enum astcenc_error astcenc_compress_reset(
+	struct astcenc_context* context);
 
 /**
  * @brief Cancel any pending compression operation.
@@ -807,8 +815,8 @@ ASTCENC_PUBLIC astcenc_error astcenc_compress_reset(
  *
  * @return @c ASTCENC_SUCCESS on success, or an error if cancellation failed.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_compress_cancel(
-	astcenc_context* context);
+ASTCENC_PUBLIC enum astcenc_error astcenc_compress_cancel(
+	struct astcenc_context* context);
 
 /**
  * @brief Decompress an image.
@@ -822,12 +830,12 @@ ASTCENC_PUBLIC astcenc_error astcenc_compress_cancel(
  *
  * @return @c ASTCENC_SUCCESS on success, or an error if decompression failed.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_decompress_image(
-	astcenc_context* context,
+ASTCENC_PUBLIC enum astcenc_error astcenc_decompress_image(
+	struct astcenc_context* context,
 	const uint8_t* data,
 	size_t data_len,
-	astcenc_image* image_out,
-	const astcenc_swizzle* swizzle,
+	struct astcenc_image* image_out,
+	const struct astcenc_swizzle* swizzle,
 	unsigned int thread_index);
 
 /**
@@ -843,8 +851,8 @@ ASTCENC_PUBLIC astcenc_error astcenc_decompress_image(
  *
  * @return @c ASTCENC_SUCCESS on success, or an error if reset failed.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_decompress_reset(
-	astcenc_context* context);
+ASTCENC_PUBLIC enum astcenc_error astcenc_decompress_reset(
+	struct astcenc_context* context);
 
 /**
  * Free the compressor context.
@@ -852,7 +860,7 @@ ASTCENC_PUBLIC astcenc_error astcenc_decompress_reset(
  * @param context   The codec context.
  */
 ASTCENC_PUBLIC void astcenc_context_free(
-	astcenc_context* context);
+	struct astcenc_context* context);
 
 /**
  * @brief Provide a high level summary of a block's encoding.
@@ -868,10 +876,10 @@ ASTCENC_PUBLIC void astcenc_context_free(
  *         function will return success even if the block itself was an error block encoding, as the
  *         decode was correctly handled.
  */
-ASTCENC_PUBLIC astcenc_error astcenc_get_block_info(
-	astcenc_context* context,
+ASTCENC_PUBLIC enum astcenc_error astcenc_get_block_info(
+	struct astcenc_context* context,
 	const uint8_t data[16],
-	astcenc_block_info* info);
+	struct astcenc_block_info* info);
 
 /**
  * @brief Get a printable string for specific status code.
@@ -881,6 +889,6 @@ ASTCENC_PUBLIC astcenc_error astcenc_get_block_info(
  * @return A human readable nul-terminated string.
  */
 ASTCENC_PUBLIC const char* astcenc_get_error_string(
-	astcenc_error status);
+	enum astcenc_error status);
 
 #endif

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -586,7 +586,7 @@ struct astcenc_config
 	/**
 	 * @brief The progress callback, can be @c nullptr.
 	 *
-	 * If this is specified the codec will peridocially report progress for
+	 * If this is specified the codec will periodically report progress for
 	 * compression as a percentage between 0 and 100. The callback is called from one
 	 * of the compressor threads, so doing significant work in the callback will
 	 * reduce compression performance.

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -170,14 +170,16 @@
 #define ASTCENC_INCLUDED
 
 #if defined(__cplusplus)
-#include <cstddef>
-#include <cstdint>
-#define ASTCENC_EXTERN_C extern "C"
+	#include <cstddef>
+	#include <cstdint>
+
+	#define ASTCENC_EXTERN_C extern "C"
 #else
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
-#define ASTCENC_EXTERN_C
+	#include <stddef.h>
+	#include <stdint.h>
+	#include <stdbool.h>
+
+	#define ASTCENC_EXTERN_C
 #endif
 
 #if defined(ASTCENC_DYNAMIC_LIBRARY)

--- a/Source/astcenccli_platform_dependents.cpp
+++ b/Source/astcenccli_platform_dependents.cpp
@@ -38,7 +38,9 @@
 #if defined(_WIN32) && !defined(__CYGWIN__)
 
 #define WIN32_LEAN_AND_MEAN
+#if !defined(NOMINMAX)
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <Processthreadsapi.h>
 #include <algorithm>

--- a/Source/astcenccli_platform_dependents.cpp
+++ b/Source/astcenccli_platform_dependents.cpp
@@ -38,9 +38,11 @@
 #if defined(_WIN32) && !defined(__CYGWIN__)
 
 #define WIN32_LEAN_AND_MEAN
+
 #if !defined(NOMINMAX)
-#define NOMINMAX
+	#define NOMINMAX
 #endif
+
 #include <windows.h>
 #include <Processthreadsapi.h>
 #include <algorithm>

--- a/Source/astcenccli_platform_dependents.cpp
+++ b/Source/astcenccli_platform_dependents.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2024 Arm Limited
+// Copyright 2011-2026 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Firstly, i could not determine if full C compatibility was intended for this repository, so i want to apologize if it was not.

## issues

- `<astcenc.h>`  unconditionally includes `<cstddef>` and `<cstdint>` which are C++ exclusive headers.
- the struct and union definitions in `<astcenc.h>` are not typedef'd to global scope which makes most struct and function definitions ill-formed in a C context
- `extern "C"` is used unconditionally in `<astcenc.h>` with `ASTCENC_DYNAMIC_LIBRARY` which is also invalid C
- NOMINMAX is defined twice under my build system (`ninja 1.11.1` + `MinGW UCRT64 gcc 15.1.0`)

These changes are ABI BREAKING since C++ name mangling/linkage for all API exposed functions in `<astcenc.h>` get disabled with this commit. 

## changes

- wrapped c++ only includes `<cstddef>` and `<cstdint>` around `#if defined(__cplusplus)`, use C compat versions otherwise
- additionally included `<stdbool.h>` for C builds
- added ASTCENC_EXTERN_C macro that evaluates to `extern "c"` only for C++ builds
- wrapped `#define NOMINMAX` into a guard that prevents double definitions

Perhaps i should add a "ASTCENC_C_COMPAT" flag to the CMake build file to avoid a forced ABI change for all users?

I have tested building the library with these changes on both C and C++ compilers with success. I am open to any other approach that the maintainers prefer, if C compatibility IS intended :)