### PR TITLE
Fix clang20+ compilation

### DIFF
--- a/Source/cmake_core.cmake
+++ b/Source/cmake_core.cmake
@@ -229,7 +229,7 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_VENEER_TYPE)
                 $<${is_clangcl}:/fp:precise>
                 $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:contract>
                 $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.0>>:-Xclang -ffp-contract=fast>
-                $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-ffp-model=precise>
+                $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-fno-unsafe-math-optimizations>
                 $<${is_gnu_fe}:-ffp-contract=fast>)
     else()
         # For Visual Studio prior to 2022 (compiler < 19.30) /fp:strict
@@ -244,7 +244,7 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_VENEER_TYPE)
                 $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:precise>
                 $<${is_clangcl}:/fp:precise>
                 $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.0>>:-Xclang -ffp-contract=off>
-                $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-ffp-model=precise>
+                $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-fno-unsafe-math-optimizations>
                 $<${is_gnu_fe}:-ffp-contract=off>)
     endif()
 


### PR DESCRIPTION
Since clang 20 there is overriding-option check, which fails if both -ffp-model=precise and -ffp-contract=off are set (they are for AppleClang e.g.). Example https://godbolt.org/z/eWMn4c7z9

From clang docs: `precise Disables optimizations that are not value-safe on floating-point data, although FP contraction (FMA) is enabled (-ffp-contract=on). This is the default behavior. This value resets -fmath-errno to its target-dependent default.`

So, `-ffp-model=precise` = `-fno-unsafe-math-optimizations -ffp-contract=on` + reset -fmath-errno. But you don't use errno, that is why we can change `-ffp-model=precise` to -fno-unsafe-math-optimizations`