### PR TITLE
Update to latest GitHub Actions plugins

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -40,7 +40,7 @@ jobs:
           make -j4
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-linux-arm64
           path: |
@@ -48,7 +48,7 @@ jobs:
             build_rel/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -105,7 +105,7 @@ jobs:
           make -j4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -153,7 +153,7 @@ jobs:
           make -j4
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-linux-x64
           path: |
@@ -161,7 +161,7 @@ jobs:
             build_rel/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -209,7 +209,7 @@ jobs:
           make -j4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -236,7 +236,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -255,7 +255,7 @@ jobs:
           make -j4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -277,7 +277,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -296,7 +296,7 @@ jobs:
           make -j4
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-macos-universal
           path: |
@@ -304,7 +304,7 @@ jobs:
             build_rel/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -326,7 +326,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -350,7 +350,7 @@ jobs:
         shell: cmd
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -374,7 +374,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -400,7 +400,7 @@ jobs:
         shell: cmd
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-windows-x64
           path: |
@@ -408,7 +408,7 @@ jobs:
             build_rel_arm64/*.zip
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -432,7 +432,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -460,7 +460,7 @@ jobs:
         shell: cmd
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-windows-arm64
           path: |

--- a/.github/workflows/post_weekly_release.yaml
+++ b/.github/workflows/post_weekly_release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: AutoModality/action-clean@v1
 
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -86,7 +86,7 @@ jobs:
           make install package -j4
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-linux-arm64
           path: |
@@ -94,7 +94,7 @@ jobs:
             build_rel/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -127,7 +127,7 @@ jobs:
           make install package -j4
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-linux-x86_64
           path: |
@@ -135,7 +135,7 @@ jobs:
             build_rel/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -154,7 +154,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -166,7 +166,7 @@ jobs:
           make install package -j4
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-macos-universal
           path: |
@@ -174,7 +174,7 @@ jobs:
             build_rel/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -192,7 +192,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -225,7 +225,7 @@ jobs:
         shell: cmd
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astcenc-windows-multi-cl
           path: |
@@ -235,7 +235,7 @@ jobs:
             build_rel_arm64/*.zip.sha256
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -276,13 +276,13 @@ jobs:
           pip install -i https://${ARTIFACTORY_USER}:${ARTIFACTORY_APIKEY}@${ARTIFACTORY_FQDN}/artifactory/api/pypi/dsgcore.pypi/simple code-signer-client
 
       - name: Download macOS binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: astcenc-macos-universal
           path: mac
 
       - name: Download Windows binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: astcenc-windows-multi-cl
           path: windows
@@ -305,7 +305,7 @@ jobs:
           for ZIPFILE in *.zip; do python3 ../signing/windows-client-wrapper.py -b ${GITHUB_RUN_NUMBER} -t ${ARTIFACTORY_APIKEY} ${ZIPFILE}; done
 
       - name: Upload signed binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: signed-binaries
           path: |
@@ -313,7 +313,7 @@ jobs:
             mac/*
 
       - name: Tidy intermediate artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             astcenc-windows-multi-cl
@@ -326,22 +326,22 @@ jobs:
     needs: [sign-binaries, build-ubuntu-x64]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download signed binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: signed-binaries
           path: prepare-release
 
       - name: Download Linux x86_64 binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: astcenc-linux-x86_64
           path: prepare-release
 
       - name: Download Linux arm64 binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: astcenc-linux-arm64
           path: prepare-release


### PR DESCRIPTION
This update moves things towards latest actions plugins to support Node.js 24, as Node.js 20 is getting deprecated. Not all third-party plugins have Node.js 24 support yet, so may be further updates needed.