### PR TITLE
Fix issues flagged by fuzz testing

### DIFF
--- a/Source/Fuzzers/fuzz_astc_decompress.cpp
+++ b/Source/Fuzzers/fuzz_astc_decompress.cpp
@@ -44,14 +44,14 @@ extern "C" int LLVMFuzzerTestOneInput(
 	// Randomize quality
 	float quality = fdp.ConsumeFloatingPointInRange<float>(ASTCENC_PRE_FASTEST, ASTCENC_PRE_EXHAUSTIVE);
 
-	// Randomize flags
+	// Randomize flags, but constrain to be safe with arbitrary input data
 	unsigned int flags = fdp.ConsumeIntegralInRange<unsigned int>(0, ASTCENC_ALL_FLAGS);
+	flags &= ~ASTCENC_FLG_SELF_DECOMPRESS_ONLY;
 
-	// Ensure we don't use flags incompatible with decompress-only if we were to use that,
-	// but here we are using a general context.
 	astcenc_config config;
 	astcenc_error status = astcenc_config_init(profile, block_x, block_y, block_z, quality, flags, &config);
-	if (status != ASTCENC_SUCCESS) {
+	if (status != ASTCENC_SUCCESS)
+	{
 		return 0;
 	}
 

--- a/Source/astcenc.h
+++ b/Source/astcenc.h
@@ -121,7 +121,7 @@
  * When using the normal map compression mode ASTC will store normals as a two component X+Y map.
  * Input images must contain unit-length normalized and should be passed in using a two component
  * swizzle. The astcenc command line tool defaults to an RRRG swizzle, but some developers prefer
- * to use GGGR for compatability with BC5n which will work just as well. The Z component can be
+ * to use GGGR for compatibility with BC5n which will work just as well. The Z component can be
  * recovered programmatically in shader code, using knowledge that the vector is unit length and
  * that Z must be positive for a tangent-space normal map.
  *

--- a/Source/astcenc_compress_symbolic.cpp
+++ b/Source/astcenc_compress_symbolic.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2025 Arm Limited
+// Copyright 2011-2026 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -430,7 +430,6 @@ static float compress_symbolic_block_for_partition_1plane(
 	//     * Compute number of bits needed for the quantized weights
 	//     * Generate an optimized set of quantized weights
 	//     * Compute quantization errors for the mode
-
 
 	static const int8_t free_bits_for_partition_count[4] {
 		115 - 4, 111 - 4 - PARTITION_INDEX_BITS, 108 - 4 - PARTITION_INDEX_BITS, 105 - 4 - PARTITION_INDEX_BITS
@@ -1304,8 +1303,11 @@ void compress_block(
 		    1, 0,  scb, tmpbuf, QUANT_32);
 
 		// Record the quant level so we can use the filter later searches
-		const auto& bm = bsd.get_block_mode(scb.block_mode);
-		quant_limit = bm.get_weight_quant_mode();
+		if (scb.block_type != SYM_BTYPE_ERROR)
+		{
+			const auto& bm = bsd.get_block_mode(scb.block_mode);
+			quant_limit = bm.get_weight_quant_mode();
+		}
 
 		best_errorvals_for_pcount[0] = astc::min(best_errorvals_for_pcount[0], errorval);
 		if (errorval < (error_threshold * errorval_mult[i]))


### PR DESCRIPTION
One fuzzer issue with a missing constraint causing false positives.

One minor bug that can cause an undefined value to be read by the weight quant limiting heuristic if all one partition block trials resulted in error blocks. This limit was only used for filtering, so it could result in later searches with two or more partitions searching less of the search space than they should, causing a drop in image quality. It is unlikely to occur in real images because it is unlikely that all one partition trials result in error blocks.