### PR TITLE
Prepare for 5.4 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020-2025 Arm Limited
+#  Copyright 2020-2026 Arm Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
@@ -25,7 +25,7 @@ if(MSVC)
     add_compile_options("/wd4324")
 endif()
 
-project(astcencoder VERSION 5.3.0)
+project(astcencoder VERSION 5.4.0)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -9,7 +9,7 @@ clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 <!-- ---------------------------------------------------------------------- -->
 ## 5.4.0
 
-**Status:** In development.
+**Status:** May 2026
 
 The 5.4.0 release is a minor feature release.
 
@@ -33,6 +33,8 @@ header from the same release to avoid compatibility issues.
     with a 256-bit vector width. See [Building.md](Building.md) for details.
   * **Bug fix:** Avoid double definition of `NOMINMAX` when compiling with
     MinGW.
+  * **Bug fix:** Improve compiler option compatibility with Clang 20, which
+    gives warnings if later options override floating point model options.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 5.3.0

--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -14,7 +14,7 @@ clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 The 5.4.0 release is a minor feature release.
 
 This release includes changes to the public interface in the `astcenc.h`
-header.  We always recommend rebuilding your client-side code using the
+header. We always recommend rebuilding your client-side code using the
 header from the same release to avoid compatibility issues.
 
 * **General:**
@@ -29,12 +29,16 @@ header from the same release to avoid compatibility issues.
     are only needed for compression. This reduces the size of a decompressor
     context by more than 10MB!
   * **Optimization:** A SIMD backend for the RISC-V Vector extensions has been
-    added, and is auto-selected when compiling an `ASTCENC_ISA_NONE` for a core
-    with a 256-bit vector width. See [Building.md](Building.md) for details.
-  * **Bug fix:** Avoid double definition of `NOMINMAX` when compiling with
-    MinGW.
-  * **Bug fix:** Improve compiler option compatibility with Clang 20, which
-    gives warnings if later options override floating point model options.
+    added, and is auto-selected when configured with `ASTCENC_ISA_NONE` and a
+    core with a 256-bit vector width. See [Building.md](Building.md) for
+    details.
+  * **Bug fix:** Avoid using an undefined `quant_weight` value if all one
+    partition trials return an error block.
+  * **Bug fix:** Remove remaining instances of type aliasing through unions.
+  * **Bug fix:** Avoid compiler double definition warning for `NOMINMAX` when
+    compiling with MinGW.
+  * **Bug fix:** Avoid compiler floating point model override warning when
+    compiling with Clang 20.
 
 <!-- ---------------------------------------------------------------------- -->
 ## 5.3.0
@@ -64,7 +68,7 @@ The 5.3.0 release is a minor maintenance release.
 The 5.2.0 release is a minor maintenance release.
 
 This release includes changes to the public interface in the `astcenc.h`
-header.  We always recommend rebuilding your client-side code using the
+header. We always recommend rebuilding your client-side code using the
 header from the same release to avoid compatibility issues.
 
 * **General:**

--- a/README.md
+++ b/README.md
@@ -108,13 +108,15 @@ The `4.x` branch is a stable branch for the older 4.x release series. It is no
 longer under active development, but is a supported branch that continues to
 get back-ported bug fixes.
 
-The `1.x`, `2.x`, and `3.x` branches are stable branches for older releases.
-They are no longer under active development or getting bug fixes.
+The `1.x`, `2.x`, and `3.x` branches are legacy branches for older releases.
+They are no longer under active development or getting security or bug fixes,
+and are scheduled for deletion at the end of August 2026. We recommend that
+developers using an old branch migrate to using the latest 5.x series stable
+release tag.
 
 Any other branches you might find are development branches for new features or
 optimizations, so might be interesting to play with but should be considered
 transient and unstable.
-
 
 # Getting started
 


### PR DESCRIPTION
Prepare for a 5.4 stable release, updating readme, changelog, and CMake project version. 