### PR TITLE
Add missing low clamp when storing negative color values to a unorm8 texture

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -7,6 +7,18 @@ All performance data on this page is measured on an Intel Core i5-9600K
 clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 
 <!-- ---------------------------------------------------------------------- -->
+## 5.5.0
+
+**Status:** In development.
+
+The 5.5.0 release is a minor maintenance release.
+
+* **General:**
+  * **Bug fix:** Add missing low-clamp when storing decompressed HDR data into
+    a UNORM8 image. Prior to this fix, output colors would be incorrect if a
+    HDR void-extent block contained a negative FP16 color value.
+
+<!-- ---------------------------------------------------------------------- -->
 ## 5.4.0
 
 **Status:** May 2026

--- a/Docs/Testing.md
+++ b/Docs/Testing.md
@@ -134,13 +134,14 @@ Run test commands through Valgrind:
 
     valgrind --tool=memcheck --track-origins=yes <command>
 
-# OSS Fuzz
+# OSS-Fuzz
 
 ASTC-Encoder has been integrated into the Google OSS-Fuzz program, which
 performs API fuzz testing on a Google-hosted CI infrastructure.
 
 Our OSS-Fuzz test harnesses can be found in the
-[/Source/Fuzzers](../Source/Fuzzers/) directory.
+[/Source/Fuzzers](../Source/Fuzzers/) directory, and we have some short
+[documentation](TestingOSSFuzz.md) about how to run the fuzzers locally.
 
 The OSS-Fuzz Project is hosted on GitHub at [google/oss-fuzz][1].
 

--- a/Docs/TestingOSSFuzz.md
+++ b/Docs/TestingOSSFuzz.md
@@ -1,0 +1,69 @@
+# Testing OSS-Fuzz
+
+ASTC-Encoder has been integrated into the Google OSS-Fuzz program, which
+performs API fuzz testing on a Google-hosted CI infrastructure.
+
+This page is a set of summary instructions explaining how to locally reproduce
+failures reported by OSS-Fuzz on a Linux machine. Full documentation is
+provided by the OSS-Fuzz project [documentation pages][1].
+
+[1]: https://google.github.io/oss-fuzz/
+
+## Prerequisites
+
+Install Docker:
+
+```sh
+sudo apt  install docker.io
+sudo usermod -aG docker $USER
+```
+
+You will need to log out and log in again for the group changes to take effect.
+
+# Running Python-based CLI functional tests
+
+Checkout the OSS-Fuzz project:
+
+```sh
+git clone --depth=1 https://github.com/google/oss-fuzz.git
+cd oss-fuzz
+```
+
+Download the standard Docker images with the tools pre-integrated:
+
+```sh
+python3 infra/helper.py pull_images
+```
+
+Build the Docker image and the fuzzers for astcenc.
+
+> [!NOTE]
+> Fuzzers are built for a specific sanitizer, so you will need to build and run
+> the fuzzers multiple times if you want coverage of both ASAN and UBSAN.
+
+```sh
+python3 infra/helper.py build_image astc-encoder
+
+# Build using clean checkout in the container
+python3 infra/helper.py build_fuzzers astc-encoder
+
+# Build using local checkout mounted into the container
+python3 infra/helper.py build_fuzzers astc-encoder /mnt/c/work/projects/astcenc/Source --sanitizer <address,undefined, etc>
+```
+
+Run a reproducer testcase downloaded from OSS Fuzz:
+
+```sh
+python3 infra/helper.py reproduce astc-encoder <fuzz_target> <testcase>
+```
+
+Sometimes reproducers are intermittent and do not always reproduce. Running the
+the test scenario in a loop can be a useful way to try and make it reproduce.
+
+```sh
+while python3 infra/helper.py reproduce astc-encoder <fuzz_target> <testcase>; do :; done
+```
+
+- - -
+
+_Copyright © 2026, Arm Limited and contributors._

--- a/Source/Fuzzers/build.sh
+++ b/Source/Fuzzers/build.sh
@@ -2,7 +2,7 @@
 
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------
-#  Copyright 2020-2021 Arm Limited
+#  Copyright 2020-2026 Arm Limited
 #  Copyright 2020 Google Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -20,12 +20,12 @@
 
 # This script is invoked by oss-fuzz from <root>/Source/
 
-# Generate a dummy version header (normally built by CMake variable expansion)
+# Generate a dummy version header (normally built by CMake)
 echo "#pragma once" > astcenccli_version.h
 echo "#define VERSION_STRING \"0.0.0\"" >> astcenccli_version.h
 echo "#define YEAR_STRING \"2021\"" >> astcenccli_version.h
 
-# Build the core project for fuzz tests to link against
+# Build codec library
 for source in ./*.cpp; do
   BASE="${source##*/}"
   BASE="${BASE%.cpp}"
@@ -36,20 +36,20 @@ for source in ./*.cpp; do
       -DASTCENC_SSE=0 \
       -DASTCENC_AVX=0 \
       -DASTCENC_POPCNT=0 \
-      -I. -std=c++14 -mfpmath=sse -msse2 -fno-strict-aliasing -O0 -g \
+      -I. -std=c++17 -mfpmath=sse -msse2 -fno-strict-aliasing -g \
       $source \
       -o ${BASE}.o
 done
 
 ar -qc libastcenc.a *.o
 
-# Build project local fuzzers
+# Build fuzzers
 for fuzzer in ./Fuzzers/fuzz_*.cpp; do
   $CXX $CXXFLAGS \
       -DASTCENC_SSE=0 \
       -DASTCENC_AVX=0 \
       -DASTCENC_POPCNT=0 \
-      -I. -std=c++14 $fuzzer $LIB_FUZZING_ENGINE ./libastcenc.a \
+      -I. -std=c++17 $fuzzer $LIB_FUZZING_ENGINE ./libastcenc.a \
       -o $OUT/$(basename -s .cpp $fuzzer)
 done
 

--- a/Source/astcenc_image.cpp
+++ b/Source/astcenc_image.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2024 Arm Limited
+// Copyright 2011-2026 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -388,10 +388,13 @@ void store_image_block(
 					vfloat data_b(blk.data_b + idx);
 					vfloat data_a(blk.data_a + idx);
 
-					vint data_ri = float_to_int_rtn(min(data_r, 1.0f) * 255.0f);
-					vint data_gi = float_to_int_rtn(min(data_g, 1.0f) * 255.0f);
-					vint data_bi = float_to_int_rtn(min(data_b, 1.0f) * 255.0f);
-					vint data_ai = float_to_int_rtn(min(data_a, 1.0f) * 255.0f);
+					// Clamp values to [0.0, 1.0] range before unorm conversion
+					//   - Values > 1.0 are possible for all HDR blocks
+					//   - Values < 0.0 are possible for HDR void-extent blocks
+					vint data_ri = float_to_int_rtn(clampzo(data_r) * 255.0f);
+					vint data_gi = float_to_int_rtn(clampzo(data_g) * 255.0f);
+					vint data_bi = float_to_int_rtn(clampzo(data_b) * 255.0f);
+					vint data_ai = float_to_int_rtn(clampzo(data_a) * 255.0f);
 
 					if (needs_swz)
 					{


### PR DESCRIPTION
This change also includes some minor improvements to the OSS-Fuzz build script and associated project-specific usage documentation. 

Fixes #611 