### PR TITLE
Zero-init partition candidate stack arrays

### DIFF
--- a/Source/astcenc_find_best_partitioning.cpp
+++ b/Source/astcenc_find_best_partitioning.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2025 Arm Limited
+// Copyright 2011-2026 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -587,11 +587,11 @@ unsigned int find_best_partition_candidates(
 
 	// Partitioning errors assuming uncorrelated-chrominance endpoints
 	float uncor_best_errors[TUNE_MAX_PARTITIONING_CANDIDATES];
-	unsigned int uncor_best_partitions[TUNE_MAX_PARTITIONING_CANDIDATES];
+	unsigned int uncor_best_partitions[TUNE_MAX_PARTITIONING_CANDIDATES] = {};
 
 	// Partitioning errors assuming same-chrominance endpoints
 	float samec_best_errors[TUNE_MAX_PARTITIONING_CANDIDATES];
-	unsigned int samec_best_partitions[TUNE_MAX_PARTITIONING_CANDIDATES];
+	unsigned int samec_best_partitions[TUNE_MAX_PARTITIONING_CANDIDATES] = {};
 
 	for (unsigned int i = 0; i < requested_candidates; i++)
 	{


### PR DESCRIPTION
The `find_best_partition_candidates()` function can use uninitialized data in the `uncor_best_partitions` and `samec_best_partitions` arrays as an index if most partition candidates fail to give a good result. Specifically, if fewer than `requested_candidates` result in an error that is lower than `ERROR_CALC_DEFAULT`, the tail of the array will not be initialized.

This is expected to be very unlikely in real use, where the data is a real texture and a large number of possible partition candidates are used, but it's possible if using a very restricted partition set with random texture data.

Fixes #618.