### PR TITLE
use size_t for decompress size check to avoid overflow

### DIFF
--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -1215,7 +1215,7 @@ astcenc_error astcenc_decompress_image(
 	int plane_blocks = xblocks * yblocks;
 
 	// Check we have enough output space (16 bytes per block)
-	size_t size_needed = xblocks * yblocks * zblocks * 16;
+	size_t size_needed = static_cast<size_t>(xblocks) * yblocks * zblocks * 16;
 	if (data_len < size_needed)
 	{
 		return ASTCENC_ERR_OUT_OF_MEM;


### PR DESCRIPTION
Decoding an .astc whose header gives a large texel size (dims and block size come straight from the file in load_cimage) lets xblocks*yblocks*zblocks*16 wrap in 32-bit before it widens to size_t. A 262144x16384 image at 4x4 is 2^28 blocks, so the byte count is 2^32 and the computed size_needed truncates to 0. The data_len < size_needed guard then passes for a 16-byte payload and the decode loop walks data + i*16 well past the buffer. Doing the multiply in size_t keeps the check honest.