### PR TITLE
Refactor overflow checks to use library code

### DIFF
--- a/Source/astcenc_compute_variance.cpp
+++ b/Source/astcenc_compute_variance.cpp
@@ -34,28 +34,6 @@
 #include <cassert>
 
 /**
- * @brief Get the number of blocks in an single image dimension.
- *
- * @param dim_img   The image dimension, in pixels.
- * @param dim_blk   The block dimension, in pixels.
- *
- * @return The number of blocks needed in this dimension.
- */
-static size_t get_block_count(size_t dim_img, size_t dim_blk)
-{
-	// Computation done this way to avoid overflowing size_t max
-	size_t blocks = dim_img / dim_blk;
-
-	// Is there a residual partial block?
-	if (dim_img != (blocks * dim_blk))
-	{
-		blocks++;
-	}
-
-	return blocks;
-}
-
-/**
  * @brief Generate a prefix-sum array using the Brent-Kung algorithm.
  *
  * This will take an input array of the form:
@@ -572,8 +550,8 @@ size_t init_compute_averages(
 	ag.work_memory_size = 2 * max_padsize_xy * max_padsize_xy * max_padsize_z;
 
 	// The parallel task count
-	size_t tasks_z = get_block_count(size_z, max_blk_size_z);
-	size_t tasks_y = get_block_count(size_y, max_blk_size_xy);
+	size_t tasks_z = astc::get_block_count_safe(size_z, max_blk_size_z);
+	size_t tasks_y = astc::get_block_count_safe(size_y, max_blk_size_xy);
 	return tasks_z * tasks_y;
 }
 

--- a/Source/astcenc_entry.cpp
+++ b/Source/astcenc_entry.cpp
@@ -24,8 +24,9 @@
 #include <new>
 
 #include "astcenc.h"
-#include "astcenc_internal_entry.h"
 #include "astcenc_diagnostic_trace.h"
+#include "astcenc_internal_entry.h"
+#include "astcenc_mathlib.h"
 
 /**
  * @brief Record of the quality tuning parameter values.
@@ -134,28 +135,6 @@ static const std::array<astcenc_preset_config, 6> preset_configs_low {{
 }};
 
 /**
- * @brief Get the number of blocks in an single image dimension.
- *
- * @param dim_img   The image dimension, in pixels.
- * @param dim_blk   The block dimension, in pixels.
- *
- * @return The number of blocks needed in this dimension.
- */
-static size_t get_block_count(size_t dim_img, size_t dim_blk)
-{
-	// Computation done this way to avoid overflowing size_t max
-	size_t blocks = dim_img / dim_blk;
-
-	// Is there a residual partial block?
-	if (dim_img != (blocks * dim_blk))
-	{
-		blocks++;
-	}
-
-	return blocks;
-}
-
-/**
  * @brief Get the total number of texels in an image.
  *
  * This function validates that the total size would fit in a size_t and returns
@@ -168,29 +147,23 @@ static size_t get_block_count(size_t dim_img, size_t dim_blk)
  * @return The number of texels in the image, or zero if total size would not
  *         fit into a size_t.
  */
-static size_t get_texels_count(size_t texels_x, size_t texels_y, size_t texels_z)
-{
-	// If any dimensions are zero return early to avoid later divide by zero
-	if ((!texels_x) || (!texels_y) || (!texels_z))
+static size_t get_texels_count(
+	size_t texels_x,
+	size_t texels_y,
+	size_t texels_z
+) {
+	bool overflow { false };
+
+	// Compute texel count
+	size_t texels_count = astc::mul_safe(texels_x, texels_y, overflow);
+	texels_count = astc::mul_safe(texels_count, texels_z, overflow);
+
+	if (overflow)
 	{
 		return 0;
 	}
 
-	// Overflow in x*y
-	size_t texels_xy = texels_x * texels_y;
-	if ((texels_xy / texels_y) != texels_x)
-	{
-		return 0;
-	}
-
-	// Overflow in xy*z
-	size_t texels_xyz = texels_xy * texels_z;
-	if ((texels_xyz / texels_z) != texels_xy)
-	{
-		return 0;
-	}
-
-	return texels_xyz;
+	return texels_count;
 }
 
 /**
@@ -206,36 +179,26 @@ static size_t get_texels_count(size_t texels_x, size_t texels_y, size_t texels_z
  * @return The number of blocks in the image, or zero if total size would not
  *         fit into a size_t.
  */
-static size_t get_blocks_count(size_t blocks_x, size_t blocks_y, size_t blocks_z)
-{
-	// If any dimensions are zero return early to avoid later divide by zero
-	if ((!blocks_x) || (!blocks_y) || (!blocks_z))
+static size_t get_blocks_count(
+	size_t blocks_x,
+	size_t blocks_y,
+	size_t blocks_z
+) {
+	bool overflow { false };
+
+	// Compute block count
+	size_t blocks_count = astc::mul_safe(blocks_x, blocks_y, overflow);
+	blocks_count = astc::mul_safe(blocks_count, blocks_z, overflow);
+
+	// Also compute byte count, but we only use overflow and not the result
+	astc::mul_safe(blocks_count, 16, overflow);
+
+	if (overflow)
 	{
 		return 0;
 	}
 
-	// Overflow in x*y
-	size_t blocks_xy = blocks_x * blocks_y;
-	if ((blocks_xy / blocks_y) != blocks_x)
-	{
-		return 0;
-	}
-
-	// Overflow in xy*z
-	size_t blocks_xyz = blocks_xy * blocks_z;
-	if ((blocks_xyz / blocks_z) != blocks_xy)
-	{
-		return 0;
-	}
-
-	// Overflow in bytes
-	size_t block_bytes = blocks_xyz * 16;
-	if ((block_bytes / 16) != blocks_xyz)
-	{
-		return 0;
-	}
-
-	return blocks_xyz;
+	return blocks_count;
 }
 
 /**
@@ -947,9 +910,9 @@ static void compress_image(
 	size_t dim_y = image.dim_y;
 	size_t dim_z = image.dim_z;
 
-	size_t blocks_x = get_block_count(dim_x, block_x);
-	size_t blocks_y = get_block_count(dim_y, block_y);
-	size_t blocks_z = get_block_count(dim_z, block_z);
+	size_t blocks_x = astc::get_block_count_safe(dim_x, block_x);
+	size_t blocks_y = astc::get_block_count_safe(dim_y, block_y);
+	size_t blocks_z = astc::get_block_count_safe(dim_z, block_z);
 
 	size_t block_count = get_blocks_count(blocks_x, blocks_y, blocks_z);
 	// Should never fail here - tested in caller before calling here
@@ -1199,9 +1162,9 @@ astcenc_error astcenc_compress_image(
 	size_t block_y = ctx->config.block_y;
 	size_t block_z = ctx->config.block_z;
 
-	size_t blocks_x = get_block_count(dim_x, block_x);
-	size_t blocks_y = get_block_count(dim_y, block_y);
-	size_t blocks_z = get_block_count(dim_z, block_z);
+	size_t blocks_x = astc::get_block_count_safe(dim_x, block_x);
+	size_t blocks_y = astc::get_block_count_safe(dim_y, block_y);
+	size_t blocks_z = astc::get_block_count_safe(dim_z, block_z);
 
 	size_t block_count = get_blocks_count(blocks_x, blocks_y, blocks_z);
 	// Cumulative block sizes would overflow a size_t
@@ -1347,9 +1310,9 @@ astcenc_error astcenc_decompress_image(
 	size_t block_y = ctx->config.block_y;
 	size_t block_z = ctx->config.block_z;
 
-	size_t blocks_x = get_block_count(dim_x, block_x);
-	size_t blocks_y = get_block_count(dim_y, block_y);
-	size_t blocks_z = get_block_count(dim_z, block_z);
+	size_t blocks_x = astc::get_block_count_safe(dim_x, block_x);
+	size_t blocks_y = astc::get_block_count_safe(dim_y, block_y);
+	size_t blocks_z = astc::get_block_count_safe(dim_z, block_z);
 
 	size_t block_count = get_blocks_count(blocks_x, blocks_y, blocks_z);
 	// Cumulative block sizes would overflow a size_t

--- a/Source/astcenc_mathlib.h
+++ b/Source/astcenc_mathlib.h
@@ -478,14 +478,14 @@ static inline float frexp(float v, int* expo)
  *
  * This function is implemented to indicate if overflow has occurred, which may
  * occur when input values are not trusted. Implementation is obviously slower
- * than one that does not do this, so don't do use for values we know will
- * not overflow.
+ * than one that does not do this, so don't use for values we know cannot
+ * overflow.
  *
  * Overflow signaling is sticky, so calling code can check at the end of a
  * sequence of multiplies.
  *
- * @param         val_a      The input value.
- * @param         val_b      The output exponent.
+ * @param         val_a      The first value to multiply.
+ * @param         val_b      The second value to multiply.
  * @param[in,out] overflow   Did previous or this calculation overflow?
  *
  * @return The multiplication result, which may have overflowed.
@@ -505,8 +505,8 @@ static inline size_t mul_safe(
  *
  * This function is implemented so that intermediate values will not overflow,
  * which may occur when input values are not trusted. Implementation is
- * obviously slower than one that does not do this, so don't do use for
- * values we know will not overflow.
+ * obviously slower than one that does not do this, so don't use for values
+ * we know cannot overflow.
  *
  * @param dim_axis    The axis dimension, in pixels.
  * @param dim_block   The block dimension, in pixels.

--- a/Source/astcenc_mathlib.h
+++ b/Source/astcenc_mathlib.h
@@ -474,6 +474,62 @@ static inline float frexp(float v, int* expo)
 }
 
 /**
+ * @brief Compute the product of two sizes.
+ *
+ * This function is implemented to indicate if overflow has occurred, which may
+ * occur when input values are not trusted. Implementation is obviously slower
+ * than one that does not do this, so don't do use for values we know will
+ * not overflow.
+ *
+ * Overflow signaling is sticky, so calling code can check at the end of a
+ * sequence of multiplies.
+ *
+ * @param         val_a      The input value.
+ * @param         val_b      The output exponent.
+ * @param[in,out] overflow   Did previous or this calculation overflow?
+ *
+ * @return The multiplication result, which may have overflowed.
+ */
+static inline size_t mul_safe(
+	size_t val_a,
+	size_t val_b,
+	bool& overflow
+) {
+	size_t result = val_a * val_b;
+	overflow = overflow || ((val_b != 0) && ((result / val_b) != val_a));
+	return result;
+}
+
+/**
+ * @brief Get the number of blocks along a single axis.
+ *
+ * This function is implemented so that intermediate values will not overflow,
+ * which may occur when input values are not trusted. Implementation is
+ * obviously slower than one that does not do this, so don't do use for
+ * values we know will not overflow.
+ *
+ * @param dim_axis    The axis dimension, in pixels.
+ * @param dim_block   The block dimension, in pixels.
+ *
+ * @return The number of blocks needed in this dimension.
+ */
+static inline size_t get_block_count_safe(
+	size_t dim_axis,
+	size_t dim_block
+) {
+	// Compute number of whole blocks
+	size_t blocks = dim_axis / dim_block;
+
+	// Add in any residual partial block
+	if (dim_axis != (dim_block * blocks))
+	{
+		blocks++;
+	}
+
+	return blocks;
+}
+
+/**
  * @brief Initialize the seed structure for a random number generator.
  *
  * Important note: For the purposes of ASTC we want sets of random numbers to

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -2541,16 +2541,11 @@ int load_cimage(
 	size_t blocks_z = (dim_z + block_z - 1) / block_z;
 
 	// This can overflow if dim_* sizes are large
-	bool overflow = false;
+	bool overflow { false };
 
-	size_t data_size_xy = blocks_x * blocks_y;
-	overflow = overflow || ((data_size_xy / blocks_y) != blocks_x);
-
-	size_t data_size_xyz = data_size_xy * blocks_z;
-	overflow = overflow || ((data_size_xyz / blocks_z) != data_size_xy);
-
-	size_t data_size = data_size_xyz * 16;
-	overflow = overflow || ((data_size / 16) != data_size_xyz);
+	size_t data_size = astc::mul_safe(blocks_x, blocks_y, overflow);
+	data_size = astc::mul_safe(data_size, blocks_z, overflow);
+	data_size = astc::mul_safe(data_size, 16, overflow);
 
 	if (overflow)
 	{


### PR DESCRIPTION
Refactors overflow checks to use library code, as it's used in enough places to justify it.