### PR TITLE
Reject inactive partitionings in physical_to_symbolic decode

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -17,6 +17,9 @@ The 5.5.0 release is a minor maintenance release.
   * **Update:** Update stb_image to v1.30.
   * **Update:** Update Wuffs to v0.3.4.
   * **Update:** Update TinyEXR to v1.0.13.
+  * **Improvement:** Decompressing a block using an unsupported partition index
+    when using `ASTCENC_FLG_SELF_DECOMPRESS_ONLY` now returns the standard
+    block error color.
   * **Bug fix:** Core library now correctly detects LDR error blocks when
     compiled for AVX2 and returns max magenta rather than black.
   * **Bug fix:** Front-end wrapper now uses C++ RAII to manage lifetime of

--- a/Source/UnitTest/test_decode.cpp
+++ b/Source/UnitTest/test_decode.cpp
@@ -373,8 +373,7 @@ TEST(decompress, self_decompress_unsupported_partition)
 	status = astcenc_decompress_image(context, data, 16, &image, &swizzle, 0);
 	EXPECT_EQ(status, ASTCENC_SUCCESS);
 
-	// An absent partitioning must decode as an error color block (magenta),
-	// not index past the partitioning table.
+	// An absent partitioning must decode as error color block (magenta for LDR)
 	for (int i = 0; i < 8 * 8; i++)
 	{
 		EXPECT_EQ(output[4 * i + 0], 0xFF);

--- a/Source/UnitTest/test_decode.cpp
+++ b/Source/UnitTest/test_decode.cpp
@@ -335,8 +335,8 @@ TEST(decompress, context_inherit)
 	astcenc_context_free(parent_context);
 }
 
-/** @brief Decode a foreign partitioning with a self-decompress-only context. */
-TEST(decompress, self_decompress_foreign_partition)
+/** @brief Decode an unsupported partitioning with a self-decompress-only context. */
+TEST(decompress, self_decompress_unsupported_partition)
 {
 	astcenc_error status;
 	astcenc_config config;
@@ -353,9 +353,9 @@ TEST(decompress, self_decompress_foreign_partition)
 		0xB0, 0xF1, 0x1E, 0x6A, 0x4F, 0x96, 0xC6, 0xBC
 	};
 
-	uint8_t output[8*8*4];
 	astcenc_config_init(ASTCENC_PRF_LDR, 8, 8, 1, ASTCENC_PRE_FASTEST,
-	                    ASTCENC_FLG_DECOMPRESS_ONLY | ASTCENC_FLG_SELF_DECOMPRESS_ONLY, &config);
+	                    ASTCENC_FLG_DECOMPRESS_ONLY | ASTCENC_FLG_SELF_DECOMPRESS_ONLY,
+	                    &config);
 
 	status = astcenc_context_alloc(&config, 1, &context, nullptr);
 	EXPECT_EQ(status, ASTCENC_SUCCESS);
@@ -365,6 +365,8 @@ TEST(decompress, self_decompress_foreign_partition)
 	image.dim_y = 8;
 	image.dim_z = 1;
 	image.data_type = ASTCENC_TYPE_U8;
+
+	uint8_t output[8 * 8 * 4];
 	uint8_t* slices = output;
 	image.data = reinterpret_cast<void**>(&slices);
 

--- a/Source/UnitTest/test_decode.cpp
+++ b/Source/UnitTest/test_decode.cpp
@@ -335,4 +335,53 @@ TEST(decompress, context_inherit)
 	astcenc_context_free(parent_context);
 }
 
+/** @brief Decode a foreign partitioning with a self-decompress-only context. */
+TEST(decompress, self_decompress_foreign_partition)
+{
+	astcenc_error status;
+	astcenc_config config;
+	astcenc_context* context;
+
+	static const astcenc_swizzle swizzle {
+		ASTCENC_SWZ_R, ASTCENC_SWZ_G, ASTCENC_SWZ_B, ASTCENC_SWZ_A
+	};
+
+	// A 3-partition block. An 8x8 fastest self-decompress-only context keeps no
+	// 3-partition tables, so this selects a partitioning that is not present.
+	uint8_t data[16] {
+		0xCF, 0x50, 0x80, 0x64, 0x84, 0xCD, 0xD8, 0xB7,
+		0xB0, 0xF1, 0x1E, 0x6A, 0x4F, 0x96, 0xC6, 0xBC
+	};
+
+	uint8_t output[8*8*4];
+	astcenc_config_init(ASTCENC_PRF_LDR, 8, 8, 1, ASTCENC_PRE_FASTEST,
+	                    ASTCENC_FLG_DECOMPRESS_ONLY | ASTCENC_FLG_SELF_DECOMPRESS_ONLY, &config);
+
+	status = astcenc_context_alloc(&config, 1, &context, nullptr);
+	EXPECT_EQ(status, ASTCENC_SUCCESS);
+
+	astcenc_image image;
+	image.dim_x = 8;
+	image.dim_y = 8;
+	image.dim_z = 1;
+	image.data_type = ASTCENC_TYPE_U8;
+	uint8_t* slices = output;
+	image.data = reinterpret_cast<void**>(&slices);
+
+	status = astcenc_decompress_image(context, data, 16, &image, &swizzle, 0);
+	EXPECT_EQ(status, ASTCENC_SUCCESS);
+
+	// An absent partitioning must decode as an error color block (magenta),
+	// not index past the partitioning table.
+	for (int i = 0; i < 8 * 8; i++)
+	{
+		EXPECT_EQ(output[4 * i + 0], 0xFF);
+		EXPECT_EQ(output[4 * i + 1], 0x00);
+		EXPECT_EQ(output[4 * i + 2], 0xFF);
+		EXPECT_EQ(output[4 * i + 3], 0xFF);
+	}
+
+	astcenc_context_free(context);
+}
+
 }

--- a/Source/astcenc_partition_tables.cpp
+++ b/Source/astcenc_partition_tables.cpp
@@ -399,9 +399,9 @@ static void build_partition_table_for_one_partition_count(
 	bsd.partitioning_count_all[partition_count - 1] = 0;
 
 	// Mark all partitionings as unused; the loops below overwrite the entries
-	// that are actually kept. Partitionings dropped in self-decompress mode, or
-	// whole tables skipped by the cutoff below, must retain this known-bad value
-	// so that decoding a foreign block does not index a stale offset.
+	// that are actually kept. Partitionings dropped in self-decompress mode
+	// must retain this known-bad value so that decoding an unknown raw
+	// partition index does not result in a bad packed index.
 	for (unsigned int i = 0; i < BLOCK_MAX_PARTITIONINGS; i++)
 	{
 		bsd.partitioning_packed_index[partition_count - 2][i] = BLOCK_BAD_PARTITIONING;

--- a/Source/astcenc_partition_tables.cpp
+++ b/Source/astcenc_partition_tables.cpp
@@ -398,6 +398,15 @@ static void build_partition_table_for_one_partition_count(
 	bsd.partitioning_count_selected[partition_count - 1] = 0;
 	bsd.partitioning_count_all[partition_count - 1] = 0;
 
+	// Mark all partitionings as unused; the loops below overwrite the entries
+	// that are actually kept. Partitionings dropped in self-decompress mode, or
+	// whole tables skipped by the cutoff below, must retain this known-bad value
+	// so that decoding a foreign block does not index a stale offset.
+	for (unsigned int i = 0; i < BLOCK_MAX_PARTITIONINGS; i++)
+	{
+		bsd.partitioning_packed_index[partition_count - 2][i] = BLOCK_BAD_PARTITIONING;
+	}
+
 	// Skip tables larger than config max partition count if we can omit modes
 	if (can_omit_partitionings && (partition_count > partition_count_cutoff))
 	{

--- a/Source/astcenc_symbolic_physical.cpp
+++ b/Source/astcenc_symbolic_physical.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // ----------------------------------------------------------------------------
-// Copyright 2011-2023 Arm Limited
+// Copyright 2011-2026 Arm Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -478,9 +478,10 @@ void physical_to_symbolic(
 
 		// Reject blocks selecting a partitioning that is not present in this
 		// block size descriptor. A SELF_DECOMPRESS_ONLY context drops the
-		// partitionings its compressor never emits, so a foreign or malformed
-		// block can reference an inactive entry; decoding it would index past
-		// the partitioning table.
+		// partitionings its compressor never emits, so a texture compressed
+		// with a different context can reference an inactive entry. This is an
+		// API contract break from the application, and should not happen in
+		// valid usage.
 		if (bsd.partitioning_packed_index[partition_count - 2][scb.partition_index] == BLOCK_BAD_PARTITIONING)
 		{
 			scb.block_type = SYM_BTYPE_ERROR;

--- a/Source/astcenc_symbolic_physical.cpp
+++ b/Source/astcenc_symbolic_physical.cpp
@@ -475,6 +475,17 @@ void physical_to_symbolic(
 			}
 		}
 		scb.partition_index = static_cast<uint16_t>(read_bits(10, 13, pcb));
+
+		// Reject blocks selecting a partitioning that is not present in this
+		// block size descriptor. A SELF_DECOMPRESS_ONLY context drops the
+		// partitionings its compressor never emits, so a foreign or malformed
+		// block can reference an inactive entry; decoding it would index past
+		// the partitioning table.
+		if (bsd.partitioning_packed_index[partition_count - 2][scb.partition_index] == BLOCK_BAD_PARTITIONING)
+		{
+			scb.block_type = SYM_BTYPE_ERROR;
+			return;
+		}
 	}
 
 	for (int i = 0; i < partition_count; i++)


### PR DESCRIPTION
**Out-of-bounds partition lookup when decoding foreign blocks in self-decompress mode**

While decoding data with a context created using `ASTCENC_FLG_SELF_DECOMPRESS_ONLY`, I followed a block whose decoded partition index pointed at a partitioning the context had dropped, and watched `get_partition_info()` run off the end of the partitioning table. The header documents `partitioning_packed_index` as holding `BLOCK_BAD_PARTITIONING` for inactive entries, and `block_mode_packed_index` is duly cleared to its bad value before the tables are built, but the partitioning array is never initialised; omitted entries, and the whole 3/4-partition tables skipped by the count cutoff, keep stale offsets that `physical_to_symbolic()` reads back without any check.

The consequence is a read past the partitioning table and then an out-of-bounds write into the per-block colour arrays through the garbage texel indices, with only a debug-only assert standing in the way, so release builds either decode rubbish or crash on a hostile texture. The documented contract is that foreign input comes back as a magenta/NaN error block, so I mirrored the existing block-mode handling: clear the index to `BLOCK_BAD_PARTITIONING` up front and bail out with `SYM_BTYPE_ERROR` when a block selects an inactive partitioning. Self-produced data is untouched, since the compressor only ever emits partitionings it kept.
