### PR TITLE
fix out-of-bounds write in store_dds_uncompressed_image for 3d ldr

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -7,6 +7,17 @@ All performance data on this page is measured on an Intel Core i5-9600K
 clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 
 <!-- ---------------------------------------------------------------------- -->
+## 5.6.0
+
+**Status:** In development
+
+The 5.6.0 release is a minor maintenance release.
+
+* **Command line tool updates:**
+  * **Bug fix:** Fixed incorrect plane stride when writing an uncompressed 3D
+    LDR image to a DDS container.
+
+<!-- ---------------------------------------------------------------------- -->
 ## 5.5.0
 
 **Status:** June 2026

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -2229,7 +2229,7 @@ static bool store_dds_uncompressed_image(
 		for (unsigned int z = 1; z < dim_z; z++)
 		{
 			row_pointers8[z] = row_pointers8[0] + dim_y * z;
-			row_pointers8[z][0] = row_pointers8[0][0] + dim_y * dim_z * image_components * z;
+			row_pointers8[z][0] = row_pointers8[0][0] + dim_y * dim_x * image_components * z;
 		}
 
 		for (unsigned int z = 0; z < dim_z; z++)

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1550,7 +1550,7 @@ static bool store_ktx_uncompressed_image(
 		for (unsigned int z = 1; z < dim_z; z++)
 		{
 			row_pointers8[z] = row_pointers8[0] + dim_y * z;
-			row_pointers8[z][0] = row_pointers8[0][0] + dim_y * dim_x * image_components * z;
+			row_pointers8[z][0] = row_pointers8[0][0] + dim_x * dim_y * image_components * z;
 		}
 
 		for (unsigned int z = 0; z < dim_z; z++)
@@ -1615,7 +1615,7 @@ static bool store_ktx_uncompressed_image(
 		for (unsigned int z = 1; z < dim_z; z++)
 		{
 			row_pointers16[z] = row_pointers16[0] + dim_y * z;
-			row_pointers16[z][0] = row_pointers16[0][0] + dim_y * dim_x * image_components * z;
+			row_pointers16[z][0] = row_pointers16[0][0] + dim_x * dim_y * image_components * z;
 		}
 
 		for (unsigned int z = 0; z < dim_z; z++)
@@ -2229,7 +2229,7 @@ static bool store_dds_uncompressed_image(
 		for (unsigned int z = 1; z < dim_z; z++)
 		{
 			row_pointers8[z] = row_pointers8[0] + dim_y * z;
-			row_pointers8[z][0] = row_pointers8[0][0] + dim_y * dim_x * image_components * z;
+			row_pointers8[z][0] = row_pointers8[0][0] + dim_x * dim_y * image_components * z;
 		}
 
 		for (unsigned int z = 0; z < dim_z; z++)
@@ -2295,7 +2295,7 @@ static bool store_dds_uncompressed_image(
 		for (unsigned int z = 1; z < dim_z; z++)
 		{
 			row_pointers16[z] = row_pointers16[0] + dim_y * z;
-			row_pointers16[z][0] = row_pointers16[0][0] + dim_y * dim_x * image_components * z;
+			row_pointers16[z][0] = row_pointers16[0][0] + dim_x * dim_y * image_components * z;
 		}
 
 		for (unsigned int z = 0; z < dim_z; z++)


### PR DESCRIPTION
While checking the uncompressed DDS writer against the KTX one I noticed the LDR plane pointer in store_dds_uncompressed_image is advanced by dim_y * dim_z * image_components per slice, where a plane is actually dim_x * dim_y * image_components. The 16-bit branch in the same function, and both branches of the KTX writer, use dim_x, so this is a stray dim_z. For any 3D image whose depth is larger than its width the per-slice base pointer lands past the end of the pixel_data8 buffer and the scanline copy then writes over the heap. It is reachable when decoding a 3D LDR .astc straight to .dds, or when saving a 3D image array as .dds.

AddressSanitizer reports a heap write one byte past the pixel buffer on a 4x4x8 LDR image, traced back to this slice loop; with the stray dim_z swapped back to dim_x every plane pointer sits inside the buffer and the writer round-trips cleanly. The bound belongs in the writer because the buffer being indexed is the one this function allocates from the same dimensions, so a caller has no way to correct a stride computed internally.