### PR TITLE
write ktx imageSize field as uint32 not size_t

### DIFF
--- a/Source/astcenccli_image.cpp
+++ b/Source/astcenccli_image.cpp
@@ -78,8 +78,9 @@ astcenc_image_ptr alloc_image(
 }
 
 /* See header for documentation. */
-void astcenc_image_deleter::operator()(astcenc_image* img) const
-{
+void astcenc_image_deleter::operator()(
+	astcenc_image* img
+) const {
 	if (img == nullptr)
 	{
 		return;
@@ -111,8 +112,9 @@ void astcenc_image_deleter::operator()(astcenc_image* img) const
 }
 
 /* See header for documentation. */
-int determine_image_components(const astcenc_image * img)
-{
+unsigned int determine_image_components(
+	const astcenc_image * img
+) {
 	unsigned int dim_x = img->dim_x;
 	unsigned int dim_y = img->dim_y;
 	unsigned int dim_z = img->dim_z;
@@ -188,8 +190,7 @@ int determine_image_components(const astcenc_image * img)
 		}
 	}
 
-	int image_components = 1 + (is_luma == 0 ? 2 : 0) + (has_alpha ? 1 : 0);
-	return image_components;
+	return 1 + (is_luma == 0 ? 2 : 0) + (has_alpha ? 1 : 0);
 }
 
 /* See header for documentation. */

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1499,7 +1499,15 @@ static bool store_ktx_uncompressed_image(
 	unsigned int image_components = determine_image_components(img);
 
 	// Size of the image data in bytes
-	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
+	bool overflow { false };
+	size_t image_bytes = astc::mul_safe(dim_x, dim_y, overflow);
+	image_bytes = astc::mul_safe(image_bytes, dim_z, overflow);
+	image_bytes = astc::mul_safe(image_bytes, image_components, overflow);
+	image_bytes = astc::mul_safe(image_bytes, bitness / 8, overflow);
+	if (overflow)
+	{
+		return false;
+	}
 
 	// Size of image data padded to a multiple of 4 bytes
 	size_t image_write_bytes = (image_bytes + 3) & ~3;
@@ -2181,14 +2189,24 @@ static bool store_dds_uncompressed_image(
 	unsigned int bitness = img->data_type == ASTCENC_TYPE_U8 ? 8 : 16;
 	unsigned int image_components = (bitness == 16) ? 4 : determine_image_components(img);
 
-	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
+	// Size of the image data in bytes
+	bool overflow { false };
+	size_t image_bytes = astc::mul_safe(dim_x, dim_y, overflow);
+	image_bytes = astc::mul_safe(image_bytes, dim_z, overflow);
+	image_bytes = astc::mul_safe(image_bytes, image_components, overflow);
+	image_bytes = astc::mul_safe(image_bytes, bitness / 8, overflow);
+	if (overflow)
+	{
+		return false;
+	}
+
+	// Must be smaller than image_bytes, so no need to check overflow here
+	size_t pitch_bytes = dim_x * image_components * (bitness / 8);
 
 	// The pitch_or_linear_size field is a fixed 32-bit value, so the size_t used
 	// for buffer sizing must be narrowed before it is serialized into the file.
-	// The check here is conservative and checks whole image rather than just row
-	// pitch, to ensure consistency with KTX output files.
-	uint32_t image_bytes_field = static_cast<uint32_t>(image_bytes);
-	if (image_bytes_field != image_bytes)
+	uint32_t pitch_bytes_field = static_cast<uint32_t>(pitch_bytes);
+	if (pitch_bytes_field != pitch_bytes)
 	{
 		return false;
 	}
@@ -2220,7 +2238,7 @@ static bool store_dds_uncompressed_image(
 	hdr.flags = 0x100F | (dim_z > 1 ? 0x800000 : 0);
 	hdr.height = static_cast<uint32_t>(dim_y);
 	hdr.width = static_cast<uint32_t>(dim_x);
-	hdr.pitch_or_linear_size = static_cast<uint32_t>(image_components * (bitness / 8) * dim_x);
+	hdr.pitch_or_linear_size = pitch_bytes_field;
 	hdr.depth = static_cast<uint32_t>(dim_z);
 	hdr.mipmapcount = 1;
 	for (unsigned int i = 0; i < 11; i++)

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1495,8 +1495,22 @@ static bool store_ktx_uncompressed_image(
 	size_t dim_y = img->dim_y;
 	size_t dim_z = img->dim_z;
 
-	int bitness = img->data_type == ASTCENC_TYPE_U8 ? 8 : 16;
-	int image_components = determine_image_components(img);
+	unsigned int bitness = img->data_type == ASTCENC_TYPE_U8 ? 8 : 16;
+	unsigned int image_components = determine_image_components(img);
+
+	// Size of the image data in bytes
+	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
+
+	// Size of image data padded to a multiple of 4 bytes
+	size_t image_write_bytes = (image_bytes + 3) & ~3;
+
+	// The KTX imageSize field is a fixed 32-bit value, so check that the size_t
+	/// value can be safely narrowed, and does not wrap when padded
+	uint32_t image_bytes_field = static_cast<uint32_t>(image_bytes);
+	if ((image_bytes_field != image_bytes) || (image_write_bytes < image_bytes))
+	{
+		return false;
+	}
 
 	ktx_header hdr;
 
@@ -1549,6 +1563,7 @@ static bool store_ktx_uncompressed_image(
 	{
 		row_pointers8.resize(dim_z);
 		row_data8.resize(dim_y * dim_z);
+		// + 3 to ensure this can be padded to be word aligned when written
 		pixel_data8.resize(dim_x * dim_y * dim_z * image_components + 3);
 
 		row_pointers8[0] = row_data8.data();
@@ -1614,6 +1629,7 @@ static bool store_ktx_uncompressed_image(
 	{
 		row_pointers16.resize(dim_z);
 		row_data16.resize(dim_y * dim_z);
+		// + 1 to ensure this can be padded to be word aligned when written
 		pixel_data16.resize(dim_x * dim_y * dim_z * image_components + 1);
 
 		row_pointers16[0] = row_data16.data();
@@ -1677,13 +1693,6 @@ static bool store_ktx_uncompressed_image(
 	}
 
 	bool retval { true };
-	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
-	size_t image_write_bytes = (image_bytes + 3) & ~3;
-
-	// The KTX imageSize field is a fixed 32-bit value, so the size_t used for
-	// buffer sizing must be narrowed before it is serialized into the file.
-	uint32_t image_bytes_field = static_cast<uint32_t>(image_bytes);
-
 	std::ofstream file(filename, std::ios::out | std::ios::binary);
 	if (file)
 	{
@@ -2169,8 +2178,20 @@ static bool store_dds_uncompressed_image(
 	size_t dim_y = img->dim_y;
 	size_t dim_z = img->dim_z;
 
-	int bitness = img->data_type == ASTCENC_TYPE_U8 ? 8 : 16;
-	int image_components = (bitness == 16) ? 4 : determine_image_components(img);
+	unsigned int bitness = img->data_type == ASTCENC_TYPE_U8 ? 8 : 16;
+	unsigned int image_components = (bitness == 16) ? 4 : determine_image_components(img);
+
+	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
+
+	// The pitch_or_linear_size field is a fixed 32-bit value, so the size_t used
+	// for buffer sizing must be narrowed before it is serialized into the file.
+	// The check here is conservative and checks whole image rather than just row
+	// pitch, to ensure consistency with KTX output files.
+	uint32_t image_bytes_field = static_cast<uint32_t>(image_bytes);
+	if (image_bytes_field != image_bytes)
+	{
+		return false;
+	}
 
 	// DDS-pixel-format structures to use when storing LDR image with 1,2,3 or 4 components.
 	static const dds_pixelformat format_of_image_components[4] =
@@ -2372,7 +2393,6 @@ static bool store_dds_uncompressed_image(
 	}
 
 	bool retval { true };
-	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
 
 	uint32_t dds_magic = DDS_MAGIC;
 

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1680,6 +1680,10 @@ static bool store_ktx_uncompressed_image(
 	size_t image_bytes = dim_x * dim_y * dim_z * image_components * (bitness / 8);
 	size_t image_write_bytes = (image_bytes + 3) & ~3;
 
+	// The KTX imageSize field is a fixed 32-bit value, so the size_t used for
+	// buffer sizing must be narrowed before it is serialized into the file.
+	uint32_t image_bytes_field = static_cast<uint32_t>(image_bytes);
+
 	std::ofstream file(filename, std::ios::out | std::ios::binary);
 	if (file)
 	{
@@ -1688,7 +1692,7 @@ static bool store_ktx_uncompressed_image(
 			reinterpret_cast<void*>(row_pointers8[0][0]);
 
 		file.write(reinterpret_cast<const char*>(&hdr), sizeof(ktx_header));
-		file.write(reinterpret_cast<const char*>(&image_bytes), sizeof(image_bytes));
+		file.write(reinterpret_cast<const char*>(&image_bytes_field), sizeof(image_bytes_field));
 		file.write(reinterpret_cast<const char*>(dataptr), image_write_bytes);
 		if (file.fail())
 		{

--- a/Source/astcenccli_internal.h
+++ b/Source/astcenccli_internal.h
@@ -218,7 +218,7 @@ astcenc_image_ptr alloc_image(
  *
  * @return The number of active components in the image.
  */
-int determine_image_components(
+unsigned int determine_image_components(
 	const astcenc_image* img);
 
 /**


### PR DESCRIPTION
Noticed the .ktx files written by a -dl decode came out four bytes longer than the header plus surface should account for, which is what led me here.

1. the per-level imageSize is written with file.write(&image_bytes, sizeof(image_bytes)), and image_bytes is now a size_t since the write-buffer sizing was widened, so eight bytes are emitted.
2. the KTX1 container defines that field as a fixed 32-bit unsigned value, and load_ktx_uncompressed_image reads it straight back as a uint32_t, so the writer disagrees with both the format and our own loader.

The four stray bytes land in front of the surface, so a re-load picks the pixels up from the wrong offset and quietly corrupts the round trip rather than failing cleanly. Narrowed the value to a uint32_t for the serialised field and left the size_t sizing maths alone.