### PR TITLE
clamp angular weight span before narrowing to int

### DIFF
--- a/Source/astcenc_weight_align.cpp
+++ b/Source/astcenc_weight_align.cpp
@@ -225,8 +225,13 @@ static void compute_lowest_and_highest_weight(
 			cut_high_weight_err = select(cut_high_weight_err, accum, mask);
 		}
 
-		// Write out min weight and weight span; clamp span to a usable range
-		vint span = float_to_int(maxidx - minidx + vfloat(1));
+		// Write out min weight and weight span; clamp span to a usable range.
+		// The span is derived from the ideal weights, which are non-finite when
+		// the input texels are non-finite, so clamp into the representable result
+		// range before narrowing to avoid an out-of-range float to int conversion
+		vfloat spanf = clamp(0.0f, static_cast<float>(max_quant_steps + 3),
+		                     maxidx - minidx + vfloat(1));
+		vint span = float_to_int(spanf);
 		span = min(span, vint(max_quant_steps + 3));
 		span = max(span, vint(2));
 		storea(minidx, lowest_weight + sp);


### PR DESCRIPTION
compute_lowest_and_highest_weight() in the angular weight search narrows the per-step span with float_to_int(maxidx - minidx + 1). The span is derived from the block's ideal decimated weights, which in turn come from the input texels, so an HDR source carrying +/-inf or NaN (both legal in fp16/fp32 and routinely present in EXR content) makes the span non-finite and the conversion runs outside the representable int range. UBSan reports "inf is outside the range of representable values of type int" at the vecmathlib float_to_int, reached directly from astcenc_compress_image on a normal HDR compress; the value is silently garbage on the platforms where it does not trap.

The span is already clamped into [2, max_quant_steps + 3] on the next two lines, so I clamp the float into that same range before the conversion rather than altering the shared float_to_int primitive. That keeps the change at the one spot that can observe non-finite input and stays bit-identical for every finite in-range value, leaving the existing integer min/max untouched.
