### PR TITLE
avoid unaligned aliasing load in neon vint4 byte constructor

### DIFF
--- a/Source/astcenc_vecmathlib_avx2_8.h
+++ b/Source/astcenc_vecmathlib_avx2_8.h
@@ -142,12 +142,13 @@ struct vint8
 	 */
 	ASTCENC_SIMD_INLINE explicit vint8(const uint8_t *p)
 	{
-		// _mm_loadu_si64 would be nicer syntax, but missing on older GCC and
-		// generates broken code on GCC 11.x before 11.3, so use this to
-		// generate alignment-safe and aliasing-safe alternative
+		// Copy through a uint32_t to avoid load through a reinterpreted
+		// pointer, which is both unaligned and an aliasing violation.
 		uint64_t tmp;
 		std::memcpy(&tmp, p, sizeof(tmp));
 
+		// _mm_loadu_si64 would be nicer syntax, but missing on older GCC and
+		// generates broken code on GCC 11.x before 11.3.
 		m = _mm256_cvtepu8_epi32(_mm_cvtsi64_si128(tmp));
 	}
 

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -195,8 +195,12 @@ struct vint4
 	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
 	{
 #if ASTCENC_SVE == 0
-	// Cast is safe - NEON loads are allowed to be unaligned
-	uint32x2_t t8 = vld1_dup_u32(reinterpret_cast<const uint32_t*>(p));
+	// Copy through a uint32_t to avoid a load through a reinterpreted pointer,
+	// which is both unaligned (p has no four byte alignment guarantee) and an
+	// aliasing violation. Matches the SSE and AVX2 backends.
+	uint32_t tmp;
+	std::memcpy(&tmp, p, sizeof(tmp));
+	uint32x2_t t8 = vdup_n_u32(tmp);
 	uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
 	m = vreinterpretq_s32_u32(vmovl_u16(t16));
 #else

--- a/Source/astcenc_vecmathlib_neon_4.h
+++ b/Source/astcenc_vecmathlib_neon_4.h
@@ -195,17 +195,17 @@ struct vint4
 	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
 	{
 #if ASTCENC_SVE == 0
-	// Copy through a uint32_t to avoid a load through a reinterpreted pointer,
-	// which is both unaligned (p has no four byte alignment guarantee) and an
-	// aliasing violation. Matches the SSE and AVX2 backends.
-	uint32_t tmp;
-	std::memcpy(&tmp, p, sizeof(tmp));
-	uint32x2_t t8 = vdup_n_u32(tmp);
-	uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
-	m = vreinterpretq_s32_u32(vmovl_u16(t16));
+		// Copy through a uint32_t to avoid load through a reinterpreted
+		// pointer, which is both unaligned and an aliasing violation.
+		uint32_t tmp;
+		std::memcpy(&tmp, p, sizeof(tmp));
+
+		uint32x2_t t8 = vdup_n_u32(tmp);
+		uint16x4_t t16 = vget_low_u16(vmovl_u8(vreinterpret_u8_u32(t8)));
+		m = vreinterpretq_s32_u32(vmovl_u16(t16));
 #else
-	svint32_t data = svld1ub_s32(svptrue_pat_b32(SV_VL4), p);
-	m = svget_neonq(data);
+		svint32_t data = svld1ub_s32(svptrue_pat_b32(SV_VL4), p);
+		m = svget_neonq(data);
 #endif
 	}
 

--- a/Source/astcenc_vecmathlib_sse_4.h
+++ b/Source/astcenc_vecmathlib_sse_4.h
@@ -207,12 +207,13 @@ struct vint4
 	 */
 	ASTCENC_SIMD_INLINE explicit vint4(const uint8_t *p)
 	{
-		// _mm_loadu_si32 would be nicer syntax, but missing on older GCC and
-		// generates broken code on GCC 11.x before 11.3, so use this to
-		// generate alignment-safe and aliasing-safe alternative
+		// Copy through a uint32_t to avoid load through a reinterpreted
+		// pointer, which is both unaligned and an aliasing violation.
 		int32_t tmp;
 		std::memcpy(&tmp, p, sizeof(tmp));
 
+		// _mm_loadu_si32 would be nicer syntax, but missing on older GCC and
+		// generates broken code on GCC 11.x before 11.3.
 		__m128i t = _mm_cvtsi32_si128(tmp);
 
 #if ASTCENC_SSE >= 41


### PR DESCRIPTION
The NEON vint4(const uint8_t*) constructor reads its four bytes with vld1_dup_u32(reinterpret_cast<const uint32_t*>(p)). p is a plain byte pointer with no four-byte alignment guarantee, so the cast both performs a potentially unaligned load and reads the uint8_t storage through a uint32_t lvalue, which breaks strict aliasing. SuiteVint4.UnalignedLoad8 already constructs from u8_data + 1 (an odd address), and the same constructor runs for every texel during encode via load_texel_u8, so the path is well exercised.

This is the defect #650 removed from the SSE and AVX2 backends by copying through a scalar with memcpy before broadcasting; NEON was left on the old reinterpret-cast path, and an x86 UBSAN run does not flag it because the load sits inside an intrinsic. I have applied the same memcpy form the load() helper in this header already uses, so the bytes are read alignment- and aliasing-safely before the existing vmovl widening. Results are bit-identical for aligned data and the full NEON unit suite stays green; keeping the load in the library helper avoids asking callers to pre-align.