### PR TITLE
Add ASAN and UBSAN to Actions runs

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -81,6 +81,98 @@ jobs:
         run: ctest -E "test-unit-sve_128|test-unit-sve_256" --rerun-failed --output-on-failure
         working-directory: build_rel
 
+  build-ubuntu-arm64-clang-asan:
+    name: Ubuntu arm64 Clang (ASAN)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=clang++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_SVE_256=ON -DASTCENC_ISA_NONE=ON -DASTCENC_PACKAGE=arm64 -DASTCENC_ASAN=ON ..
+          make install package -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        # Disable SVE for now
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+
+      - name: Run unit tests
+        # Disable SVE for now
+        run: ctest -E "test-unit-sve_128|test-unit-sve_256" --rerun-failed --output-on-failure
+        working-directory: build_rel
+
+  build-ubuntu-arm64-clang-ubasn:
+    name: Ubuntu arm64 Clang (UBSAN)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=clang++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_SVE_256=ON -DASTCENC_ISA_NONE=ON -DASTCENC_PACKAGE=arm64 -DASTCENC_UBSAN=ON ..
+          make install package -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        # Disable SVE for now
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+
+      - name: Run unit tests
+        # Disable SVE for now
+        run: ctest -E "test-unit-sve_128|test-unit-sve_256" --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-ubuntu-arm64-gcc:
     name: Ubuntu arm64 GCC
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -239,6 +239,104 @@ jobs:
         run: ctest -E "test-unit-sve_128|test-unit-sve_256" --rerun-failed --output-on-failure
         working-directory: build_rel
 
+  build-ubuntu-arm64-gcc-asan:
+    name: Ubuntu arm64 GCC (ASAN)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Install GCC 14
+        run: sudo apt-get install -y gcc-14
+
+      - name: Build release
+        run: |
+          export CXX=g++-14
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_NONE=ON -DASTCENC_ASAN=ON ..
+          make install -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        # Disable SVE for now
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+
+      - name: Run unit tests
+        # Disable SVE for now
+        run: ctest -E "test-unit-sve_128|test-unit-sve_256" --rerun-failed --output-on-failure
+        working-directory: build_rel
+
+  build-ubuntu-arm64-gcc-ubsan:
+    name: Ubuntu arm64 GCC (UBSAN)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Install GCC 14
+        run: sudo apt-get install -y gcc-14
+
+      - name: Build release
+        run: |
+          export CXX=g++-14
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_NEON=ON -DASTCENC_ISA_SVE_128=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UBSAN=ON ..
+          make install -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        # Disable SVE for now
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder neon
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder neon --test-set Small
+
+      - name: Run unit tests
+        # Disable SVE for now
+        run: ctest -E "test-unit-sve_128|test-unit-sve_256" --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-ubuntu-x64-clang:
     name: Ubuntu x64 Clang
     runs-on: ubuntu-24.04
@@ -310,6 +408,98 @@ jobs:
         run: ctest --rerun-failed --output-on-failure
         working-directory: build_rel
 
+  build-ubuntu-x64-clang-asan:
+    name: Ubuntu x64 Clang (ASAN)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=clang++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_ASAN=ON -DASTCENC_PACKAGE=x64 ..
+          make install package -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder sse2
+          python ./Test/astc_test_functional.py --encoder sse4.1
+          python ./Test/astc_test_functional.py --encoder avx2
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
+
+      - name: Run unit tests
+        run: ctest --rerun-failed --output-on-failure
+        working-directory: build_rel
+
+  build-ubuntu-x64-clang-ubsan:
+    name: Ubuntu x64 Clang (UBSAN)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=clang++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_UBSAN=ON -DASTCENC_PACKAGE=x64 ..
+          make install package -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder sse2
+          python ./Test/astc_test_functional.py --encoder sse4.1
+          python ./Test/astc_test_functional.py --encoder avx2
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
+
+      - name: Run unit tests
+        run: ctest --rerun-failed --output-on-failure
+        working-directory: build_rel
+
   build-ubuntu-x64-gcc:
     name: Ubuntu x64 GCC
     runs-on: ubuntu-24.04
@@ -349,6 +539,98 @@ jobs:
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DASTCENC_VERSION=refs/pull/${{ github.event.number }}/head ..
           make -j4
         working-directory: Utils/Example
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder sse2
+          python ./Test/astc_test_functional.py --encoder sse4.1
+          python ./Test/astc_test_functional.py --encoder avx2
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
+
+      - name: Run unit tests
+        run: ctest --rerun-failed --output-on-failure
+        working-directory: build_rel
+
+  build-ubuntu-x64-gcc-asan:
+    name: Ubuntu x64 GCC (ASAN)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=g++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_ASAN=ON -DASTCENC_PACKAGE=x64 ..
+          make install package -j4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Get Python modules
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Pillow
+
+      - name: Run system tests
+        run: |
+          python ./Test/astc_test_functional.py --encoder none
+          python ./Test/astc_test_functional.py --encoder sse2
+          python ./Test/astc_test_functional.py --encoder sse4.1
+          python ./Test/astc_test_functional.py --encoder avx2
+          python ./Test/astc_test_image.py --encoder none --test-set Small
+          python ./Test/astc_test_image.py --encoder all-x86 --test-set Small
+
+      - name: Run unit tests
+        run: ctest --rerun-failed --output-on-failure
+        working-directory: build_rel
+
+  build-ubuntu-x64-gcc-ubsan:
+    name: Ubuntu x64 GCC (UBSAN)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Update apt packages
+        run: sudo apt-get update
+
+      - name: Install ImageMagick
+        run: sudo apt-get install imagemagick
+
+      - name: Build release
+        run: |
+          export CXX=g++
+          mkdir build_rel
+          cd build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../ -DASTCENC_UNITTEST=ON -DASTCENC_ISA_AVX2=ON -DASTCENC_ISA_SSE41=ON -DASTCENC_ISA_SSE2=ON -DASTCENC_ISA_NONE=ON -DASTCENC_UNITTEST=ON -DASTCENC_UBSAN=ON -DASTCENC_PACKAGE=x64 ..
+          make install package -j4
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
This change adds ASAN and UBSAN test runs to GitHub Actions precommit runs, for the matrix of `[Arm64, x86-64]` x `[Clang, GCC]`. Not added to RISC-V because those tests rely on QEMU which is already too slow to be comfortable.