### PR TITLE
zero reserved2 field before writing dds header

### DIFF
--- a/Docs/ChangeLog-5x.md
+++ b/Docs/ChangeLog-5x.md
@@ -14,6 +14,9 @@ clocked at 4.2 GHz, running `astcenc` using AVX2 and 6 threads.
 The 5.6.0 release is a minor maintenance release.
 
 * **Command line tool updates:**
+  * **Bug fix:** Zero the trailing reserved field of the DDS header before
+    writing it, so uncompressed `.dds` output no longer contains uninitialized
+    stack bytes.
   * **Bug fix:** Fixed incorrect plane stride when writing an uncompressed 3D
     LDR image to a DDS container.
   * **Bug fix:** Fixed potential integer overflow when storing very large

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -2249,6 +2249,7 @@ static bool store_dds_uncompressed_image(
 	hdr.caps2 = (dim_z > 1) ? 0x200000 : 0;
 	hdr.caps3 = 0;
 	hdr.caps4 = 0;
+	hdr.reserved2 = 0;
 
 	// Pixel-format data
 	if (bitness == 8)


### PR DESCRIPTION
store_dds_uncompressed_image sets every field of the on-stack dds_header individually, but the trailing reserved2 word is never assigned. Since the whole struct is then serialised with file.write(&hdr, sizeof(dds_header)), those four bytes come straight from uninitialised stack memory. I spotted it while auditing the header writers after the recent DDS/KTX store fixes: caps3, caps4 and the reserved1 array are all explicitly zeroed, but reserved2 sits just past caps4 and was missed. A build with -ftrivial-auto-var-init=pattern makes it obvious, the field lands in the output file as 0xAAAAAAAA.

Every uncompressed .dds we write therefore leaks four bytes of encoder stack at file offset 124, and the container is non-conformant because the spec requires that word to be zero. The fix assigns hdr.reserved2 = 0 next to the existing caps3/caps4 zeroing, keeping the field-by-field style of the function. After the change a round-tripped .dds carries a zero reserved2 and the unit tests stay green.