### PR TITLE
use size_t for pixel count in wuffs png loader

### DIFF
--- a/Source/astcenccli_image_external.cpp
+++ b/Source/astcenccli_image_external.cpp
@@ -127,7 +127,7 @@ astcenc_image_ptr load_png_with_wuffs(
 
 	uint32_t dim_x = wuffs_base__pixel_config__width(&ic.pixcfg);
 	uint32_t dim_y = wuffs_base__pixel_config__height(&ic.pixcfg);
-	size_t num_pixels = dim_x * dim_y;
+	size_t num_pixels = static_cast<size_t>(dim_x) * dim_y;
 	if (num_pixels > (SIZE_MAX / 4))
 	{
 		return nullptr;


### PR DESCRIPTION
1. dim_x and dim_y come from the PNG image config as uint32_t, so `num_pixels = dim_x * dim_y` is evaluated in 32-bit and wraps once the pixel count reaches 2^32 (65536x65536 truncates to 0, 65536x65537 to 65536).
2. the wrapped count then slips past the `num_pixels > SIZE_MAX / 4` guard on the next line and sizes the pixbuf allocation, so the oversize rejection never fires and the buffer is under-sized for the real dimensions.

Widened the first multiply to size_t so the count and the guard are computed at full width, matching the sizing in alloc_image and the KTX/DDS/ASTC loaders. Wuffs' own slice-length check still rejects the mismatch today, so this keeps the guard correct rather than fixing a live overflow.
