### PR TITLE
reject undersized payload in load_ktx_compressed_image

### DIFF
--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1361,6 +1361,29 @@ bool load_ktx_compressed_image(
 		data_len = reverse_bytes_u32(data_len);
 	}
 
+	// The imageSize and pixel dimensions are independent header fields, so
+	// reject a payload that is too small for the block grid the dimensions
+	// describe (load_cimage derives the size from the dimensions instead).
+	size_t block_x = fmt->x;
+	size_t block_y = fmt->y;
+	size_t block_z = fmt->z == 0 ? 1 : fmt->z;
+
+	size_t dim_z = hdr.pixel_depth == 0 ? 1 : hdr.pixel_depth;
+	size_t blocks_x = (static_cast<size_t>(hdr.pixel_width) + block_x - 1) / block_x;
+	size_t blocks_y = (static_cast<size_t>(hdr.pixel_height) + block_y - 1) / block_y;
+	size_t blocks_z = (dim_z + block_z - 1) / block_z;
+
+	bool overflow { false };
+	size_t size_needed = astc::mul_safe(blocks_x, blocks_y, overflow);
+	size_needed = astc::mul_safe(size_needed, blocks_z, overflow);
+	size_needed = astc::mul_safe(size_needed, 16, overflow);
+
+	if (overflow || data_len < size_needed)
+	{
+		print_error("ERROR: Image header corrupt '%s'\n", filename);
+		return true;
+	}
+
 	// Read the data
 	img.data.resize(data_len);
 	file.read(reinterpret_cast<char*>(img.data.data()), data_len);

--- a/Source/astcenccli_image_load_store.cpp
+++ b/Source/astcenccli_image_load_store.cpp
@@ -1361,17 +1361,16 @@ bool load_ktx_compressed_image(
 		data_len = reverse_bytes_u32(data_len);
 	}
 
-	// The imageSize and pixel dimensions are independent header fields, so
-	// reject a payload that is too small for the block grid the dimensions
-	// describe (load_cimage derives the size from the dimensions instead).
+	// The data size and pixel dimensions are independent header fields, so
+	// reject a data size that is too small for the given image dimensions
 	size_t block_x = fmt->x;
 	size_t block_y = fmt->y;
 	size_t block_z = fmt->z == 0 ? 1 : fmt->z;
 
 	size_t dim_z = hdr.pixel_depth == 0 ? 1 : hdr.pixel_depth;
-	size_t blocks_x = (static_cast<size_t>(hdr.pixel_width) + block_x - 1) / block_x;
-	size_t blocks_y = (static_cast<size_t>(hdr.pixel_height) + block_y - 1) / block_y;
-	size_t blocks_z = (dim_z + block_z - 1) / block_z;
+	size_t blocks_x =  astc::get_block_count_safe(hdr.pixel_width, block_x);
+	size_t blocks_y = astc::get_block_count_safe(hdr.pixel_height, block_y);
+	size_t blocks_z = astc::get_block_count_safe(dim_z, block_z);
 
 	bool overflow { false };
 	size_t size_needed = astc::mul_safe(blocks_x, blocks_y, overflow);
@@ -1495,8 +1494,8 @@ static bool store_ktx_uncompressed_image(
 	// Size of image data padded to a multiple of 4 bytes
 	size_t image_write_bytes = (image_bytes + 3) & ~3;
 
-	// The KTX imageSize field is a fixed 32-bit value, so check that the size_t
-	/// value can be safely narrowed, and does not wrap when padded
+	// The KTX data size field is a fixed 32-bit value, so check that the
+	// size_t value can be safely narrowed and does not wrap when padded
 	uint32_t image_bytes_field = static_cast<uint32_t>(image_bytes);
 	if ((image_bytes_field != image_bytes) || (image_write_bytes < image_bytes))
 	{


### PR DESCRIPTION
`load_ktx_compressed_image` reads the KTX `imageSize` field as the compressed payload length and reads the pixel dimensions from separate header fields, but never checks the two agree. A crafted `.ktx` can declare dimensions spanning many blocks while carrying a payload sized for far fewer, so the loader hands back an `astc_compressed_image` whose `data` buffer is smaller than its own dimensions imply. I noticed this comparing the KTX path with `load_cimage`, which sizes the payload from the dimensions and so cannot store an inconsistent pair.

The change derives the block count from the dimensions and the format block footprint with `astc::mul_safe` and rejects the file when `imageSize` cannot cover it, matching how `load_cimage` sizes its own payload. `astcenc_decompress_image` already re-checks the length before its block loop, so a plain `-dl` decode was refused either way, but `print_diagnostic_image` walks `block_cols * block_rows` blocks straight out of the payload with no length check of its own; validating in the loader keeps every consumer working from a consistent object instead of re-deriving the bound.
