### PR TITLE
Improve test reference rebuilds

### DIFF
--- a/Test/astc_test_image.py
+++ b/Test/astc_test_image.py
@@ -344,6 +344,8 @@ def parse_command_line():
 
     # All reference encoders
     reference_encoders = [
+        'rebuild',
+
         'ref-5.0-neon',
         'ref-5.0-sse2', 'ref-5.0-sse4.1', 'ref-5.0-avx2',
 
@@ -403,7 +405,7 @@ def parse_command_line():
     quality_choices = list(TEST_QUALITIES)
     quality_choices.append('all')
     quality_choices.append('all+')
-    parser.add_argument('--test-quality', dest='test_qual', default='thorough',
+    parser.add_argument('--test-quality', dest='test_qual', action='append',
                         choices=quality_choices, help='test quality')
 
     parser.add_argument('--repeats', dest='repeats', default=1,
@@ -425,14 +427,13 @@ def parse_command_line():
     else:
         args.encoders = [args.encoders]
 
-    if args.test_qual == 'all+':
+    if (args.test_qual is not None) and ('all+' in args.test_qual):
         args.test_qual = TEST_QUALITIES
-    elif args.test_qual == 'all':
+
+    elif (args.test_qual is None) or ('all' in args.test_qual):
         args.test_qual = TEST_QUALITIES
         args.test_qual.remove('verythorough')
         args.test_qual.remove('exhaustive')
-    else:
-        args.test_qual = [args.test_qual]
 
     if not args.block_sizes or ('all' in args.block_sizes):
         args.block_sizes = TEST_BLOCK_SIZES
@@ -451,6 +452,9 @@ def parse_command_line():
         args.formats = format_choices[:-1]
     else:
         args.formats = [args.formats]
+
+    if args.reference == 'rebuild':
+        args.reference = None
 
     return args
 

--- a/Test/astc_update_ref.sh
+++ b/Test/astc_update_ref.sh
@@ -8,7 +8,7 @@ fi
 echo "Generating new ref-$1 results"
 
 if [ "$1" = "main" ]; then
-    echo "Using binary from ./bin/${1}/"
+    echo "Using binary from ./bin/"
 else
     echo "Using binary from ./Binaries/${1}/"
 fi
@@ -17,7 +17,7 @@ echo ""
 
 TARGET_ROOT=${1}
 
-python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --encoder ref-$1-avx2
-#python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --encoder ref-$1-sse4.1
-#python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --encoder ref-$1-sse2
-#python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --encoder ref-$1-neon -j3
+python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --reference rebuild --encoder ref-$1-avx2
+#python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --reference rebuild --encoder ref-$1-sse4.1
+#python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --reference rebuild --encoder ref-$1-sse2
+#python3 ./Test/astc_test_image.py --test-set all --block-size all --test-quality all --repeats 6 --reference rebuild --encoder ref-$1-neon -j3


### PR DESCRIPTION
Make reference rebuilds an explicit test run target, rather than inferred. 
Make test quality an option list rather than a single option.